### PR TITLE
fix: remove build job from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -174,75 +172,3 @@ jobs:
         with:
           files: coverage/lcov.info
           flags: typescript
-
-  build:
-    name: Build
-    needs: [changes, rust, go, typescript]
-    if: |
-      github.event_name == 'push' &&
-      always() &&
-      (needs.rust.result == 'success' || needs.rust.result == 'skipped') &&
-      (needs.go.result == 'success' || needs.go.result == 'skipped') &&
-      (needs.typescript.result == 'success' || needs.typescript.result == 'skipped') &&
-      (needs.changes.outputs.rust == 'true' || needs.changes.outputs.go == 'true' || needs.changes.outputs.typescript == 'true')
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: windows-latest
-            args: ""
-            sidecar_target: x86_64-pc-windows-msvc
-            sidecar_ext: .exe
-          - platform: macos-latest
-            args: "--target aarch64-apple-darwin"
-            sidecar_target: aarch64-apple-darwin
-            sidecar_ext: ""
-          - platform: macos-latest
-            args: "--target x86_64-apple-darwin"
-            sidecar_target: x86_64-apple-darwin
-            sidecar_ext: ""
-          - platform: ubuntu-latest
-            args: ""
-            sidecar_target: x86_64-unknown-linux-gnu
-            sidecar_ext: ""
-    runs-on: ${{ matrix.platform }}
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-
-      - uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
-        with:
-          workspaces: "./src-tauri -> target"
-          cache-on-failure: true
-
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: src-sidecar/go.sum
-
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: "1.3.11"
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Install Tauri system dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
-
-      - name: Build Go sidecar
-        working-directory: src-sidecar
-        run: go build -o "../src-tauri/binaries/sidecar-${{ matrix.sidecar_target }}${{ matrix.sidecar_ext }}" ./cmd/sidecar
-
-      - uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0.6.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: ${{ matrix.args }}


### PR DESCRIPTION
## what changed
- removed cross-platform build job from CI workflow
- removed push-to-main trigger from CI (only runs on PRs now)

## why
CI should lint and test, not build. Builds belong in the release workflow (triggered by version tags). Every merge to main was triggering 4 platform builds unnecessarily, wasting CI minutes and failing on macOS x86 cross-compile.

## test plan
- [ ] CI only runs lint/test jobs on PRs
- [ ] no build job appears in CI
- [ ] release workflow still has the build matrix