### PR TITLE
fix: golangci-lint v2 module path, add codecov token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: src-tauri/coverage-rust.lcov
           flags: rust
 
@@ -126,7 +127,7 @@ jobs:
         run: go vet ./...
 
       - name: Lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v2.1.6 && golangci-lint run
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 && golangci-lint run
 
       - name: Vulnerability check
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4 && govulncheck ./...
@@ -137,6 +138,7 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: src-sidecar/coverage.txt
           flags: go
 
@@ -170,5 +172,6 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/lcov.info
           flags: typescript


### PR DESCRIPTION
## what changed
- fixed golangci-lint install path from `cmd/golangci-lint` to `v2/cmd/golangci-lint`
- added CODECOV_TOKEN to all codecov upload steps

## why
- golangci-lint v2 moved its module path, CI was failing with "unknown revision"
- codecov needs a token for coverage uploads

## test plan
- [ ] Go CI lint step passes
- [ ] codecov receives coverage data