### PR TITLE
fix: run CI on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [main]
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
## what changed
- added `push: branches: [main]` trigger back to CI workflow

## why
- seeds rust/go/bun caches for future PRs
- catches merge-combination bugs
- standard practice for open source projects

## test plan
- [ ] CI runs on merge to main
- [ ] rust-cache saves after successful run