### PR TITLE
fix: release-please config to stay pre-1.0

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,5 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@c3fc4de07084f75a2b61a5b933069bda6edf3d5c # v4
         with:
-          release-type: node
           manifest-file: .release-please-manifest.json
           config-file: release-please-config.json

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "packages": {
     ".": {
       "release-type": "node",
+      "initial-version": "0.0.1",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "changelog-sections": [


### PR DESCRIPTION
## what changed
- removed `release-type` from workflow (conflicts with manifest mode)
- added `initial-version: "0.0.1"` to config (prevents defaulting to 1.0.0)

## why
release-please was creating a 1.0.0 release PR instead of 0.0.2. the action-level `release-type` caused it to use the wrong code path, bypassing the manifest version.

## test plan
- [ ] next merge to main creates a release PR for 0.0.2, not 1.0.0