### PR TITLE
feat: twitch eventsub websocket client

### DIFF
--- a/apps/desktop/src-sidecar/cmd/sidecar/main.go
+++ b/apps/desktop/src-sidecar/cmd/sidecar/main.go
@@ -13,6 +13,8 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/ImpulseB23/Prismoid/sidecar/internal/control"
+	"github.com/ImpulseB23/Prismoid/sidecar/internal/ringbuf"
+	"github.com/ImpulseB23/Prismoid/sidecar/internal/twitch"
 )
 
 func main() {
@@ -42,6 +44,13 @@ func main() {
 	defer heartbeat.Stop()
 
 	encoder := json.NewEncoder(os.Stdout)
+	clients := make(map[string]context.CancelFunc)
+
+	notify := func(msgType string, payload any) {
+		if err := encoder.Encode(control.Message{Type: msgType, Payload: payload}); err != nil {
+			log.Error().Err(err).Str("type", msgType).Msg("failed to notify host")
+		}
+	}
 
 	for {
 		select {
@@ -54,7 +63,70 @@ func main() {
 				return
 			}
 		case cmd := <-cmdCh:
-			log.Info().Str("cmd", cmd.Cmd).Str("channel", cmd.Channel).Msg("received command")
+			switch cmd.Cmd {
+			case "twitch_connect":
+				handleTwitchConnect(ctx, cmd, clients, notify)
+			case "twitch_disconnect":
+				handleTwitchDisconnect(cmd, clients)
+			default:
+				log.Info().Str("cmd", cmd.Cmd).Str("channel", cmd.Channel).Msg("received command")
+			}
 		}
 	}
+}
+
+func handleTwitchConnect(ctx context.Context, cmd control.Command, clients map[string]context.CancelFunc, notify twitch.Notify) {
+	if _, exists := clients[cmd.BroadcasterID]; exists {
+		log.Warn().Str("broadcaster", cmd.BroadcasterID).Msg("already connected, ignoring")
+		return
+	}
+
+	mem, cleanup, err := ringbuf.OpenShared(cmd.ShmName, cmd.ShmSize)
+	if err != nil {
+		log.Error().Err(err).Str("shm", cmd.ShmName).Msg("failed to open shared memory")
+		return
+	}
+
+	writer, err := ringbuf.Open(mem)
+	if err != nil {
+		cleanup()
+		log.Error().Err(err).Msg("failed to open ring buffer writer")
+		return
+	}
+
+	clientCtx, clientCancel := context.WithCancel(ctx)
+
+	client := &twitch.Client{
+		BroadcasterID: cmd.BroadcasterID,
+		UserID:        cmd.UserID,
+		AccessToken:   cmd.Token,
+		ClientID:      cmd.ClientID,
+		Writer:        writer,
+		Log:           log.With().Str("broadcaster", cmd.BroadcasterID).Logger(),
+		Notify:        notify,
+	}
+
+	clients[cmd.BroadcasterID] = func() {
+		clientCancel()
+		cleanup()
+	}
+
+	go func() {
+		if err := client.Run(clientCtx); err != nil && ctx.Err() == nil {
+			log.Error().Err(err).Str("broadcaster", cmd.BroadcasterID).Msg("twitch client exited")
+		}
+	}()
+
+	log.Info().Str("broadcaster", cmd.BroadcasterID).Msg("twitch client started")
+}
+
+func handleTwitchDisconnect(cmd control.Command, clients map[string]context.CancelFunc) {
+	cancelFn, exists := clients[cmd.BroadcasterID]
+	if !exists {
+		log.Warn().Str("broadcaster", cmd.BroadcasterID).Msg("no active connection to disconnect")
+		return
+	}
+	cancelFn()
+	delete(clients, cmd.BroadcasterID)
+	log.Info().Str("broadcaster", cmd.BroadcasterID).Msg("twitch client disconnected")
 }

--- a/apps/desktop/src-sidecar/go.mod
+++ b/apps/desktop/src-sidecar/go.mod
@@ -5,6 +5,7 @@ go 1.26
 require github.com/rs/zerolog v1.35.0
 
 require (
+	github.com/coder/websocket v1.8.14 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	golang.org/x/sys v0.29.0 // indirect

--- a/apps/desktop/src-sidecar/go.sum
+++ b/apps/desktop/src-sidecar/go.sum
@@ -1,3 +1,5 @@
+github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
+github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/apps/desktop/src-sidecar/internal/backoff/backoff.go
+++ b/apps/desktop/src-sidecar/internal/backoff/backoff.go
@@ -1,0 +1,33 @@
+package backoff
+
+import (
+	"math"
+	"math/rand/v2"
+	"time"
+)
+
+// Backoff implements exponential backoff with full jitter.
+// See https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+type Backoff struct {
+	base    time.Duration
+	max     time.Duration
+	attempt int
+}
+
+func New(base, max time.Duration) *Backoff {
+	return &Backoff{base: base, max: max}
+}
+
+// Next returns a jittered duration in [0, min(max, base * 2^attempt)] and increments the attempt.
+func (b *Backoff) Next() time.Duration {
+	ceiling := float64(b.base) * math.Pow(2, float64(b.attempt))
+	if ceiling > float64(b.max) {
+		ceiling = float64(b.max)
+	}
+	b.attempt++
+	return time.Duration(rand.Int64N(int64(ceiling) + 1))
+}
+
+func (b *Backoff) Reset() {
+	b.attempt = 0
+}

--- a/apps/desktop/src-sidecar/internal/backoff/backoff_test.go
+++ b/apps/desktop/src-sidecar/internal/backoff/backoff_test.go
@@ -1,0 +1,63 @@
+package backoff
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNextStaysWithinBounds(t *testing.T) {
+	b := New(1*time.Second, 30*time.Second)
+	for i := range 20 {
+		d := b.Next()
+		if d < 0 {
+			t.Fatalf("attempt %d: got negative duration %v", i, d)
+		}
+		if d > 30*time.Second {
+			t.Fatalf("attempt %d: %v exceeds max 30s", i, d)
+		}
+	}
+}
+
+func TestCeilingGrows(t *testing.T) {
+	b := New(1*time.Second, 1*time.Hour)
+
+	var maxSeen time.Duration
+	for range 100 {
+		d := b.Next()
+		if d > maxSeen {
+			maxSeen = d
+		}
+	}
+
+	// with 100 attempts and a 1h cap, we should see values well above 1s
+	if maxSeen < 10*time.Second {
+		t.Fatalf("expected to see values above 10s across 100 attempts, max was %v", maxSeen)
+	}
+}
+
+func TestReset(t *testing.T) {
+	b := New(1*time.Second, 30*time.Second)
+	for range 10 {
+		b.Next()
+	}
+	b.Reset()
+
+	// after reset, ceiling should be back to base (1s), so values must be <= 1s
+	for range 50 {
+		d := b.Next()
+		if d > 1*time.Second {
+			t.Fatalf("after reset, first attempt exceeded base: %v", d)
+		}
+		b.Reset()
+	}
+}
+
+func TestCapRespected(t *testing.T) {
+	b := New(100*time.Millisecond, 500*time.Millisecond)
+	for range 50 {
+		d := b.Next()
+		if d > 500*time.Millisecond {
+			t.Fatalf("exceeded cap: %v", d)
+		}
+	}
+}

--- a/apps/desktop/src-sidecar/internal/control/control.go
+++ b/apps/desktop/src-sidecar/internal/control/control.go
@@ -1,9 +1,14 @@
 package control
 
 type Command struct {
-	Cmd     string `json:"cmd"`
-	Channel string `json:"channel,omitempty"`
-	Token   string `json:"token,omitempty"`
+	Cmd           string `json:"cmd"`
+	Channel       string `json:"channel,omitempty"`
+	Token         string `json:"token,omitempty"`
+	ClientID      string `json:"client_id,omitempty"`
+	BroadcasterID string `json:"broadcaster_id,omitempty"`
+	UserID        string `json:"user_id,omitempty"`
+	ShmName       string `json:"shm_name,omitempty"`
+	ShmSize       int    `json:"shm_size,omitempty"`
 }
 
 type Message struct {

--- a/apps/desktop/src-sidecar/internal/twitch/eventsub.go
+++ b/apps/desktop/src-sidecar/internal/twitch/eventsub.go
@@ -1,0 +1,197 @@
+package twitch
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/rs/zerolog"
+
+	"github.com/ImpulseB23/Prismoid/sidecar/internal/backoff"
+	"github.com/ImpulseB23/Prismoid/sidecar/internal/ringbuf"
+)
+
+const defaultWSURL = "wss://eventsub.wss.twitch.tv/ws"
+
+// Notify is called on control-plane events (auth errors, revocations) that
+// the Rust host should know about. The caller wires this to stdout JSON.
+type Notify func(msgType string, payload any)
+
+type Client struct {
+	BroadcasterID string
+	UserID        string
+	AccessToken   string
+	ClientID      string
+	HelixBase     string // override for testing; "" uses default
+	WSURL         string // override for testing; "" uses default
+
+	Writer *ringbuf.Writer
+	Log    zerolog.Logger
+	Notify Notify
+}
+
+// Run connects to EventSub and reads messages until ctx is cancelled.
+// It reconnects automatically on errors with exponential backoff.
+func (c *Client) Run(ctx context.Context) error {
+	bo := backoff.New(1*time.Second, 30*time.Second)
+	wsURL := c.WSURL
+	if wsURL == "" {
+		wsURL = defaultWSURL
+	}
+
+	for {
+		err := c.connectAndListen(ctx, wsURL)
+		if err == nil || errors.Is(err, context.Canceled) {
+			return err
+		}
+
+		// reconnect messages provide a URL; on normal errors use the default
+		var re *reconnectError
+		if errors.As(err, &re) {
+			wsURL = re.url
+			bo.Reset()
+			continue
+		}
+
+		wsURL = c.wsURL()
+		c.Log.Warn().Err(err).Msg("eventsub disconnected, reconnecting")
+
+		delay := bo.Next()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+}
+
+func (c *Client) wsURL() string {
+	if c.WSURL != "" {
+		return c.WSURL
+	}
+	return defaultWSURL
+}
+
+func (c *Client) connectAndListen(ctx context.Context, url string) error {
+	conn, _, err := websocket.Dial(ctx, url, nil)
+	if err != nil {
+		return fmt.Errorf("dial %s: %w", url, err)
+	}
+	defer func() { _ = conn.CloseNow() }()
+
+	sessionID, keepalive, err := c.readWelcome(ctx, conn)
+	if err != nil {
+		return err
+	}
+
+	c.Log.Info().Str("session", sessionID).Int("keepalive_s", keepalive).Msg("connected to eventsub")
+
+	if err := Subscribe(ctx, c.HelixBase, sessionID, c.BroadcasterID, c.UserID, c.AccessToken, c.ClientID); err != nil {
+		var authErr *AuthError
+		if errors.As(err, &authErr) {
+			if c.Notify != nil {
+				c.Notify("auth_error", authErr.Error())
+			}
+			return err
+		}
+		return fmt.Errorf("subscribe: %w", err)
+	}
+
+	c.Log.Info().Msg("subscribed to channel.chat.message")
+
+	return c.listenLoop(ctx, conn, keepalive)
+}
+
+func (c *Client) readWelcome(ctx context.Context, conn *websocket.Conn) (string, int, error) {
+	// twitch expects subscription within keepalive_timeout_seconds (default 10s)
+	readCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	_, data, err := conn.Read(readCtx)
+	if err != nil {
+		return "", 0, fmt.Errorf("read welcome: %w", err)
+	}
+
+	var env Envelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return "", 0, fmt.Errorf("unmarshal welcome: %w", err)
+	}
+
+	if env.Metadata.MessageType != "session_welcome" {
+		return "", 0, fmt.Errorf("expected session_welcome, got %s", env.Metadata.MessageType)
+	}
+
+	var payload WelcomePayload
+	if err := json.Unmarshal(env.Payload, &payload); err != nil {
+		return "", 0, fmt.Errorf("unmarshal welcome payload: %w", err)
+	}
+
+	return payload.Session.ID, payload.Session.KeepaliveTimeoutSeconds, nil
+}
+
+func (c *Client) listenLoop(ctx context.Context, conn *websocket.Conn, keepaliveSec int) error {
+	timeout := time.Duration(keepaliveSec)*time.Second + time.Second
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	for {
+		readCtx, cancel := context.WithTimeout(ctx, timeout)
+		_, data, err := conn.Read(readCtx)
+		cancel()
+		if err != nil {
+			if errors.Is(err, context.Canceled) && ctx.Err() != nil {
+				_ = conn.Close(websocket.StatusNormalClosure, "shutting down")
+				return ctx.Err()
+			}
+			return fmt.Errorf("read: %w", err)
+		}
+
+		timer.Reset(timeout)
+
+		var env Envelope
+		if err := json.Unmarshal(data, &env); err != nil {
+			c.Log.Error().Err(err).Msg("unmarshal envelope failed")
+			continue
+		}
+
+		switch env.Metadata.MessageType {
+		case "notification":
+			if !c.Writer.Write(data) {
+				c.Log.Warn().Msg("ring buffer full, dropping message")
+			}
+
+		case "session_keepalive":
+			// timer already reset above
+
+		case "session_reconnect":
+			var payload ReconnectPayload
+			if err := json.Unmarshal(env.Payload, &payload); err != nil {
+				c.Log.Error().Err(err).Msg("unmarshal reconnect payload")
+				continue
+			}
+			c.Log.Info().Str("url", payload.Session.ReconnectURL).Msg("reconnect requested")
+			return &reconnectError{url: payload.Session.ReconnectURL}
+
+		case "revocation":
+			c.Log.Warn().RawJSON("payload", env.Payload).Msg("subscription revoked")
+			if c.Notify != nil {
+				c.Notify("revocation", json.RawMessage(env.Payload))
+			}
+			return fmt.Errorf("subscription revoked")
+
+		default:
+			c.Log.Debug().Str("type", env.Metadata.MessageType).Msg("unhandled message type")
+		}
+	}
+}
+
+type reconnectError struct {
+	url string
+}
+
+func (e *reconnectError) Error() string {
+	return "reconnect to " + e.url
+}

--- a/apps/desktop/src-sidecar/internal/twitch/eventsub_test.go
+++ b/apps/desktop/src-sidecar/internal/twitch/eventsub_test.go
@@ -1,0 +1,401 @@
+package twitch
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/coder/websocket"
+	"github.com/rs/zerolog"
+
+	"github.com/ImpulseB23/Prismoid/sidecar/internal/ringbuf"
+)
+
+const (
+	testCacheLine  = 64
+	testHeaderSize = testCacheLine * 3
+)
+
+func makeTestBuf(capacity int) ([]byte, *ringbuf.Writer) {
+	mem := make([]byte, testHeaderSize+capacity)
+	*(*uint64)(unsafe.Pointer(&mem[testCacheLine*2])) = uint64(capacity)
+	w, err := ringbuf.Open(mem)
+	if err != nil {
+		panic(err)
+	}
+	return mem, w
+}
+
+func readFromBuf(mem []byte) [][]byte {
+	writePos := atomic.LoadUint64((*uint64)(unsafe.Pointer(&mem[0])))
+	readPos := atomic.LoadUint64((*uint64)(unsafe.Pointer(&mem[testCacheLine])))
+
+	data := mem[testHeaderSize:]
+	cap := *(*uint64)(unsafe.Pointer(&mem[testCacheLine*2]))
+
+	var msgs [][]byte
+	for readPos+4 <= writePos {
+		offset := readPos % cap
+		msgLen := uint64(binary.BigEndian.Uint32(data[offset : offset+4]))
+		readPos += 4
+		offset = readPos % cap
+		msg := make([]byte, msgLen)
+		copy(msg, data[offset:offset+msgLen])
+		msgs = append(msgs, msg)
+		readPos += msgLen
+	}
+	return msgs
+}
+
+func welcomeMsg(sessionID string, keepaliveSec int) []byte {
+	msg := fmt.Sprintf(`{
+		"metadata":{"message_id":"1","message_type":"session_welcome","message_timestamp":"2025-01-01T00:00:00Z"},
+		"payload":{"session":{"id":"%s","keepalive_timeout_seconds":%d}}
+	}`, sessionID, keepaliveSec)
+	return []byte(msg)
+}
+
+func notificationMsg(id, text string) []byte {
+	msg := fmt.Sprintf(`{
+		"metadata":{"message_id":"%s","message_type":"notification","message_timestamp":"2025-01-01T00:00:01Z"},
+		"payload":{"subscription":{"type":"channel.chat.message"},"event":{"message":{"text":"%s"}}}
+	}`, id, text)
+	return []byte(msg)
+}
+
+func keepaliveMsg() []byte {
+	return []byte(`{"metadata":{"message_id":"ka-1","message_type":"session_keepalive","message_timestamp":"2025-01-01T00:00:02Z"},"payload":{}}`)
+}
+
+func newTestClient(wsURL, helixURL string, writer *ringbuf.Writer) *Client {
+	return &Client{
+		BroadcasterID: "broadcaster-1",
+		UserID:        "user-1",
+		AccessToken:   "test-token",
+		ClientID:      "test-client",
+		HelixBase:     helixURL,
+		WSURL:         wsURL,
+		Writer:        writer,
+		Log:           zerolog.Nop(),
+		Notify:        func(string, any) {},
+	}
+}
+
+func TestClientReceivesNotifications(t *testing.T) {
+	helixSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer helixSrv.Close()
+
+	wsSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept: %v", err)
+			return
+		}
+		defer func() { _ = conn.CloseNow() }()
+
+		ctx := context.Background()
+		_ = conn.Write(ctx, websocket.MessageText, welcomeMsg("sess-1", 30))
+		_ = conn.Write(ctx, websocket.MessageText, notificationMsg("n-1", "hello chat"))
+		_ = conn.Write(ctx, websocket.MessageText, notificationMsg("n-2", "second msg"))
+
+		time.Sleep(100 * time.Millisecond)
+		_ = conn.Close(websocket.StatusNormalClosure, "done")
+	}))
+	defer wsSrv.Close()
+
+	mem, writer := makeTestBuf(4096)
+	client := newTestClient(
+		"ws"+strings.TrimPrefix(wsSrv.URL, "http"),
+		helixSrv.URL,
+		writer,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_ = client.Run(ctx)
+
+	msgs := readFromBuf(mem)
+	if len(msgs) < 2 {
+		t.Fatalf("expected at least 2 messages in ring buffer, got %d", len(msgs))
+	}
+
+	var env Envelope
+	if err := json.Unmarshal(msgs[0], &env); err != nil {
+		t.Fatalf("unmarshal first message: %v", err)
+	}
+	if env.Metadata.MessageType != "notification" {
+		t.Fatalf("expected notification, got %s", env.Metadata.MessageType)
+	}
+}
+
+func TestClientHandlesKeepalive(t *testing.T) {
+	helixSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer helixSrv.Close()
+
+	wsSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.CloseNow() }()
+
+		ctx := context.Background()
+		_ = conn.Write(ctx, websocket.MessageText, welcomeMsg("sess-2", 30))
+		_ = conn.Write(ctx, websocket.MessageText, keepaliveMsg())
+		_ = conn.Write(ctx, websocket.MessageText, notificationMsg("n-1", "after keepalive"))
+
+		time.Sleep(100 * time.Millisecond)
+		_ = conn.Close(websocket.StatusNormalClosure, "done")
+	}))
+	defer wsSrv.Close()
+
+	mem, writer := makeTestBuf(4096)
+	client := newTestClient(
+		"ws"+strings.TrimPrefix(wsSrv.URL, "http"),
+		helixSrv.URL,
+		writer,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_ = client.Run(ctx)
+
+	msgs := readFromBuf(mem)
+	if len(msgs) < 1 {
+		t.Fatal("expected at least 1 notification after keepalive")
+	}
+}
+
+func TestClientAuthError(t *testing.T) {
+	helixSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"Unauthorized"}`))
+	}))
+	defer helixSrv.Close()
+
+	wsSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.CloseNow() }()
+
+		ctx := context.Background()
+		_ = conn.Write(ctx, websocket.MessageText, welcomeMsg("sess-3", 30))
+
+		time.Sleep(2 * time.Second)
+	}))
+	defer wsSrv.Close()
+
+	_, writer := makeTestBuf(4096)
+
+	var notified atomic.Bool
+	client := newTestClient(
+		"ws"+strings.TrimPrefix(wsSrv.URL, "http"),
+		helixSrv.URL,
+		writer,
+	)
+	client.Notify = func(msgType string, _ any) {
+		if msgType == "auth_error" {
+			notified.Store(true)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := client.Run(ctx)
+	if err == nil {
+		t.Fatal("expected error on auth failure")
+	}
+	if !notified.Load() {
+		t.Fatal("expected auth_error notification")
+	}
+}
+
+func TestClientReconnect(t *testing.T) {
+	helixSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer helixSrv.Close()
+
+	var secondConnected atomic.Bool
+
+	// second server (reconnect target)
+	secondSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.CloseNow() }()
+		secondConnected.Store(true)
+
+		ctx := context.Background()
+		_ = conn.Write(ctx, websocket.MessageText, welcomeMsg("sess-new", 30))
+		_ = conn.Write(ctx, websocket.MessageText, notificationMsg("n-after-reconnect", "reconnected"))
+
+		time.Sleep(100 * time.Millisecond)
+		_ = conn.Close(websocket.StatusNormalClosure, "done")
+	}))
+	defer secondSrv.Close()
+
+	reconnectURL := "ws" + strings.TrimPrefix(secondSrv.URL, "http")
+
+	// first server sends reconnect
+	firstSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.CloseNow() }()
+
+		ctx := context.Background()
+		_ = conn.Write(ctx, websocket.MessageText, welcomeMsg("sess-old", 30))
+
+		reconnectMsg := fmt.Sprintf(`{
+			"metadata":{"message_id":"r-1","message_type":"session_reconnect","message_timestamp":"2025-01-01T00:00:03Z"},
+			"payload":{"session":{"id":"sess-old","reconnect_url":"%s"}}
+		}`, reconnectURL)
+		_ = conn.Write(ctx, websocket.MessageText, []byte(reconnectMsg))
+
+		time.Sleep(2 * time.Second)
+	}))
+	defer firstSrv.Close()
+
+	mem, writer := makeTestBuf(4096)
+	client := newTestClient(
+		"ws"+strings.TrimPrefix(firstSrv.URL, "http"),
+		helixSrv.URL,
+		writer,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_ = client.Run(ctx)
+
+	if !secondConnected.Load() {
+		t.Fatal("expected client to connect to reconnect URL")
+	}
+
+	msgs := readFromBuf(mem)
+	if len(msgs) < 1 {
+		t.Fatal("expected at least 1 message after reconnect")
+	}
+}
+
+func TestClientRevocation(t *testing.T) {
+	helixSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer helixSrv.Close()
+
+	wsSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.CloseNow() }()
+
+		ctx := context.Background()
+		_ = conn.Write(ctx, websocket.MessageText, welcomeMsg("sess-rev", 30))
+		_ = conn.Write(ctx, websocket.MessageText, []byte(`{
+			"metadata":{"message_id":"rev-1","message_type":"revocation","message_timestamp":"2025-01-01T00:00:04Z"},
+			"payload":{"subscription":{"type":"channel.chat.message","status":"user_removed"}}
+		}`))
+
+		time.Sleep(2 * time.Second)
+	}))
+	defer wsSrv.Close()
+
+	_, writer := makeTestBuf(4096)
+
+	var notifyType atomic.Value
+	client := newTestClient(
+		"ws"+strings.TrimPrefix(wsSrv.URL, "http"),
+		helixSrv.URL,
+		writer,
+	)
+	client.Notify = func(msgType string, _ any) {
+		notifyType.Store(msgType)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := client.Run(ctx)
+	if err == nil {
+		t.Fatal("expected error on revocation")
+	}
+
+	v := notifyType.Load()
+	if v == nil || v.(string) != "revocation" {
+		t.Fatalf("expected revocation notification, got %v", v)
+	}
+}
+
+func TestClientBufferFull(t *testing.T) {
+	helixSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer helixSrv.Close()
+
+	wsSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.CloseNow() }()
+
+		ctx := context.Background()
+		_ = conn.Write(ctx, websocket.MessageText, welcomeMsg("sess-full", 30))
+
+		// send many large notifications to fill the tiny buffer
+		for i := range 20 {
+			_ = conn.Write(ctx, websocket.MessageText, notificationMsg(
+				fmt.Sprintf("n-%d", i),
+				"this is a message that will eventually overflow the ring buffer",
+			))
+		}
+
+		time.Sleep(100 * time.Millisecond)
+		_ = conn.Close(websocket.StatusNormalClosure, "done")
+	}))
+	defer wsSrv.Close()
+
+	// tiny buffer that can only hold a few messages
+	_, writer := makeTestBuf(256)
+	client := newTestClient(
+		"ws"+strings.TrimPrefix(wsSrv.URL, "http"),
+		helixSrv.URL,
+		writer,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// should not panic, just drop messages
+	_ = client.Run(ctx)
+}
+
+func TestReconnectErrorMessage(t *testing.T) {
+	e := &reconnectError{url: "wss://example.com/new"}
+	got := e.Error()
+	if got != "reconnect to wss://example.com/new" {
+		t.Fatalf("unexpected error message: %s", got)
+	}
+}

--- a/apps/desktop/src-sidecar/internal/twitch/helix.go
+++ b/apps/desktop/src-sidecar/internal/twitch/helix.go
@@ -1,0 +1,70 @@
+package twitch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const defaultHelixBase = "https://api.twitch.tv/helix"
+
+// Subscribe creates an EventSub subscription for channel.chat.message via the Helix API.
+// helixBase can be overridden for testing; pass "" to use the default.
+func Subscribe(ctx context.Context, helixBase, sessionID, broadcasterID, userID, accessToken, clientID string) error {
+	if helixBase == "" {
+		helixBase = defaultHelixBase
+	}
+
+	body, err := json.Marshal(SubscriptionRequest{
+		Type:    "channel.chat.message",
+		Version: "1",
+		Condition: map[string]string{
+			"broadcaster_user_id": broadcasterID,
+			"user_id":             userID,
+		},
+		Transport: Transport{
+			Method:    "websocket",
+			SessionID: sessionID,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("marshal subscription request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, helixBase+"/eventsub/subscriptions", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Client-Id", clientID)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("helix request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return &AuthError{Status: resp.StatusCode, Body: string(respBody)}
+	}
+	if resp.StatusCode != http.StatusAccepted {
+		return fmt.Errorf("helix returned %d: %s", resp.StatusCode, respBody)
+	}
+
+	return nil
+}
+
+type AuthError struct {
+	Status int
+	Body   string
+}
+
+func (e *AuthError) Error() string {
+	return fmt.Sprintf("twitch auth error (%d): %s", e.Status, e.Body)
+}

--- a/apps/desktop/src-sidecar/internal/twitch/helix_test.go
+++ b/apps/desktop/src-sidecar/internal/twitch/helix_test.go
@@ -1,0 +1,85 @@
+package twitch
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSubscribeSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/eventsub/subscriptions" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Fatalf("bad auth header: %s", r.Header.Get("Authorization"))
+		}
+		if r.Header.Get("Client-Id") != "test-client" {
+			t.Fatalf("bad client-id: %s", r.Header.Get("Client-Id"))
+		}
+
+		var req SubscriptionRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if req.Type != "channel.chat.message" {
+			t.Fatalf("unexpected type: %s", req.Type)
+		}
+		if req.Transport.SessionID != "sess-123" {
+			t.Fatalf("unexpected session_id: %s", req.Transport.SessionID)
+		}
+
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	err := Subscribe(context.Background(), srv.URL, "sess-123", "broadcaster-1", "user-1", "test-token", "test-client")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestSubscribeAuthError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"Unauthorized"}`))
+	}))
+	defer srv.Close()
+
+	err := Subscribe(context.Background(), srv.URL, "sess-123", "b", "u", "bad-token", "client")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	var authErr *AuthError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected AuthError, got %T: %v", err, err)
+	}
+	if authErr.Status != 401 {
+		t.Fatalf("expected status 401, got %d", authErr.Status)
+	}
+}
+
+func TestSubscribeServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"Internal Server Error"}`))
+	}))
+	defer srv.Close()
+
+	err := Subscribe(context.Background(), srv.URL, "sess-123", "b", "u", "token", "client")
+	if err == nil {
+		t.Fatal("expected error for 500")
+	}
+
+	var authErr *AuthError
+	if errors.As(err, &authErr) {
+		t.Fatal("500 should not be an AuthError")
+	}
+}

--- a/apps/desktop/src-sidecar/internal/twitch/types.go
+++ b/apps/desktop/src-sidecar/internal/twitch/types.go
@@ -1,0 +1,54 @@
+package twitch
+
+import "encoding/json"
+
+// Envelope is the top-level EventSub WebSocket message.
+type Envelope struct {
+	Metadata Metadata        `json:"metadata"`
+	Payload  json.RawMessage `json:"payload"`
+}
+
+type Metadata struct {
+	MessageID   string `json:"message_id"`
+	MessageType string `json:"message_type"`
+	Timestamp   string `json:"message_timestamp"`
+}
+
+type WelcomePayload struct {
+	Session WelcomeSession `json:"session"`
+}
+
+type WelcomeSession struct {
+	ID                      string `json:"id"`
+	KeepaliveTimeoutSeconds int    `json:"keepalive_timeout_seconds"`
+}
+
+type ReconnectPayload struct {
+	Session ReconnectSession `json:"session"`
+}
+
+type ReconnectSession struct {
+	ID           string `json:"id"`
+	ReconnectURL string `json:"reconnect_url"`
+}
+
+type SubscriptionRequest struct {
+	Type      string            `json:"type"`
+	Version   string            `json:"version"`
+	Condition map[string]string `json:"condition"`
+	Transport Transport         `json:"transport"`
+}
+
+type Transport struct {
+	Method    string `json:"method"`
+	SessionID string `json:"session_id"`
+}
+
+type SubscriptionResponse struct {
+	Data []SubscriptionData `json:"data"`
+}
+
+type SubscriptionData struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+}


### PR DESCRIPTION
## what changed
- EventSub WebSocket client in Go (`internal/twitch/`)
  - Connects to `wss://eventsub.wss.twitch.tv/ws`
  - Reads welcome, subscribes to `channel.chat.message` via Helix
  - Writes raw notification envelopes to the shared memory ring buffer
  - Handles keepalive, reconnect, and revocation messages
  - Reconnects with exponential backoff + full jitter
- Reusable backoff package (`internal/backoff/`)
- Helix subscription helper with typed auth errors (`internal/twitch/helix.go`)
- Sidecar wired up: `twitch_connect` / `twitch_disconnect` commands in main.go
- Auth via command fields (Phase 0, env var on Rust side)

## tests
- backoff: bounds, cap, reset (4 tests)
- helix: success, 401 auth error, 500 server error (3 tests)
- eventsub: notifications, keepalive, auth error, reconnect, revocation, buffer full, error message (7 tests)

Closes #16

## test plan
- [ ] `go test ./...` passes
- [ ] `golangci-lint run` clean
- [ ] CI green