### PR TITLE
refactor: ring buffer uses direct windows crate + handle passing

### DIFF
--- a/apps/desktop/src-sidecar/internal/ringbuf/shm_linux.go
+++ b/apps/desktop/src-sidecar/internal/ringbuf/shm_linux.go
@@ -2,31 +2,10 @@
 
 package ringbuf
 
-import (
-	"fmt"
-	"os"
-	"syscall"
-)
+import "fmt"
 
-// OpenShared opens a named shared memory region created by the Rust host.
-func OpenShared(name string, size int) ([]byte, func(), error) {
-	path := "/dev/shm/" + name
-
-	f, err := os.OpenFile(path, os.O_RDWR, 0)
-	if err != nil {
-		return nil, nil, fmt.Errorf("open shm %s: %w", path, err)
-	}
-
-	mem, err := syscall.Mmap(int(f.Fd()), 0, size, syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_SHARED)
-	if err != nil {
-		f.Close()
-		return nil, nil, fmt.Errorf("mmap: %w", err)
-	}
-
-	cleanup := func() {
-		syscall.Munmap(mem)
-		f.Close()
-	}
-
-	return mem, cleanup, nil
+// Attach is not yet implemented on Linux. See ADR 18 (revised 2026-04-11):
+// Linux will use memfd_create + fd passing via a subsequent ticket.
+func Attach(_ uintptr, _ int) ([]byte, func(), error) {
+	return nil, nil, fmt.Errorf("ring buffer attach not yet supported on linux")
 }

--- a/apps/desktop/src-sidecar/internal/ringbuf/shm_windows.go
+++ b/apps/desktop/src-sidecar/internal/ringbuf/shm_windows.go
@@ -4,7 +4,6 @@ package ringbuf
 
 import (
 	"fmt"
-	"syscall"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -12,31 +11,27 @@ import (
 
 const fileMapAllAccess = 0xF001F
 
-var (
-	kernel32            = syscall.NewLazyDLL("kernel32.dll")
-	procOpenFileMapping = kernel32.NewProc("OpenFileMappingW")
-)
-
-// OpenShared opens a named shared memory region created by the Rust host.
-func OpenShared(name string, size int) ([]byte, func(), error) {
-	namePtr, err := windows.UTF16PtrFromString(name)
-	if err != nil {
-		return nil, nil, fmt.Errorf("invalid shm name: %w", err)
+// Attach maps a shared memory section that was created by the parent Rust host
+// and inherited into this process via CreateProcess handle inheritance. The
+// parent passes the raw handle value via the stdio bootstrap; this function
+// takes ownership of that handle and closes it in the returned cleanup.
+//
+// The returned slice is backed by the mapped section. Writes are visible to
+// any other process that has mapped the same section. The caller must call
+// the returned cleanup exactly once when the section is no longer needed.
+func Attach(handle uintptr, size int) ([]byte, func(), error) {
+	if size <= 0 {
+		return nil, nil, fmt.Errorf("invalid size %d", size)
+	}
+	if handle == 0 {
+		return nil, nil, fmt.Errorf("invalid handle 0")
 	}
 
-	r1, _, e1 := procOpenFileMapping.Call(
-		uintptr(fileMapAllAccess),
-		0, // bInheritHandle = false
-		uintptr(unsafe.Pointer(namePtr)),
-	)
-	if r1 == 0 {
-		return nil, nil, fmt.Errorf("OpenFileMappingW(%s): %w", name, e1)
-	}
-	handle := windows.Handle(r1)
+	h := windows.Handle(handle)
 
-	addr, err := windows.MapViewOfFile(handle, fileMapAllAccess, 0, 0, uintptr(size))
+	addr, err := windows.MapViewOfFile(h, fileMapAllAccess, 0, 0, uintptr(size))
 	if err != nil {
-		_ = windows.CloseHandle(handle)
+		_ = windows.CloseHandle(h)
 		return nil, nil, fmt.Errorf("MapViewOfFile: %w", err)
 	}
 
@@ -44,7 +39,7 @@ func OpenShared(name string, size int) ([]byte, func(), error) {
 
 	cleanup := func() {
 		_ = windows.UnmapViewOfFile(addr)
-		_ = windows.CloseHandle(handle)
+		_ = windows.CloseHandle(h)
 	}
 
 	return mem, cleanup, nil

--- a/apps/desktop/src-sidecar/internal/ringbuf/shm_windows_test.go
+++ b/apps/desktop/src-sidecar/internal/ringbuf/shm_windows_test.go
@@ -28,23 +28,33 @@ func createTestMapping(t *testing.T, name string, size uint32) windows.Handle {
 	return handle
 }
 
-func TestOpenSharedNonexistent(t *testing.T) {
-	_, _, err := OpenShared("nonexistent_prismoid_test_shm", 4096)
+func TestAttachRejectsZeroHandle(t *testing.T) {
+	_, _, err := Attach(0, 4096)
 	if err == nil {
-		t.Fatal("expected error for nonexistent shared memory")
+		t.Fatal("expected error for zero handle")
 	}
 }
 
-func TestOpenSharedRoundTrip(t *testing.T) {
-	name := "prismoid_test_shm_roundtrip"
-	size := 4096
-
-	handle := createTestMapping(t, name, uint32(size))
+func TestAttachRejectsZeroSize(t *testing.T) {
+	handle := createTestMapping(t, "prismoid_test_attach_zero_size", 4096)
 	defer func() { _ = windows.CloseHandle(handle) }()
 
-	mem, cleanup, err := OpenShared(name, size)
+	_, _, err := Attach(uintptr(handle), 0)
+	if err == nil {
+		t.Fatal("expected error for zero size")
+	}
+}
+
+func TestAttachRoundTrip(t *testing.T) {
+	const size = 4096
+
+	// Attach takes ownership of the handle; do NOT also defer CloseHandle here.
+	handle := createTestMapping(t, "prismoid_test_attach_roundtrip", size)
+
+	mem, cleanup, err := Attach(uintptr(handle), size)
 	if err != nil {
-		t.Fatalf("OpenShared: %v", err)
+		_ = windows.CloseHandle(handle)
+		t.Fatalf("Attach: %v", err)
 	}
 	defer cleanup()
 

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -754,7 +754,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
- "memoffset 0.9.1",
+ "memoffset",
  "rustc_version",
 ]
 
@@ -1858,15 +1858,6 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -1957,19 +1948,6 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
-name = "nix"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
-dependencies = [
- "bitflags 1.3.2",
- "cc",
- "cfg-if",
- "libc",
- "memoffset 0.6.5",
-]
 
 [[package]]
 name = "nodrop"
@@ -2511,12 +2489,12 @@ version = "0.0.1"
 dependencies = [
  "serde",
  "serde_json",
- "shared_memory",
  "tauri",
  "tauri-build",
  "tauri-plugin-shell",
  "tracing",
  "tracing-subscriber",
+ "windows",
 ]
 
 [[package]]
@@ -3140,19 +3118,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shared_memory"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba8593196da75d9dc4f69349682bd4c2099f8cde114257d1ef7ef1b33d1aba54"
-dependencies = [
- "cfg-if",
- "libc",
- "nix",
- "rand 0.8.5",
- "win-sys",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3436,7 +3401,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows 0.61.3",
+ "windows",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -3507,7 +3472,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows 0.61.3",
+ "windows",
 ]
 
 [[package]]
@@ -3633,7 +3598,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows 0.61.3",
+ "windows",
 ]
 
 [[package]]
@@ -3658,7 +3623,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows 0.61.3",
+ "windows",
  "wry",
 ]
 
@@ -4471,7 +4436,7 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows 0.61.3",
+ "windows",
  "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
@@ -4495,17 +4460,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows 0.61.3",
+ "windows",
  "windows-core 0.61.2",
-]
-
-[[package]]
-name = "win-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b7b128a98c1cfa201b09eb49ba285887deb3cbe7466a98850eb1adabb452be5"
-dependencies = [
- "windows 0.34.0",
 ]
 
 [[package]]
@@ -4552,19 +4508,6 @@ dependencies = [
  "raw-window-handle",
  "windows-sys 0.59.0",
  "windows-version",
-]
-
-[[package]]
-name = "windows"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45296b64204227616fdbf2614cefa4c236b98ee64dfaaaa435207ed99fe7829f"
-dependencies = [
- "windows_aarch64_msvc 0.34.0",
- "windows_i686_gnu 0.34.0",
- "windows_i686_msvc 0.34.0",
- "windows_x86_64_gnu 0.34.0",
- "windows_x86_64_msvc 0.34.0",
 ]
 
 [[package]]
@@ -4828,12 +4771,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
@@ -4849,12 +4786,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4888,12 +4819,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
@@ -4909,12 +4834,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4951,12 +4870,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5142,7 +5055,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows 0.61.3",
+ "windows",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -15,6 +15,12 @@ tauri = { version = "2.10", features = [] }
 tauri-plugin-shell = "2.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-shared_memory = "0.12"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_System_Memory",
+    "Win32_Security",
+] }

--- a/apps/desktop/src-tauri/src/ringbuf.rs
+++ b/apps/desktop/src-tauri/src/ringbuf.rs
@@ -1,10 +1,22 @@
+//! SPSC shared memory ring buffer for the Go sidecar → Rust host hot path.
+//!
+//! The Rust host creates an unnamed shared memory section and hands the raw
+//! HANDLE to the Go sidecar at spawn time via handle inheritance + stdio
+//! bootstrap. See ADR 18 (revised 2026-04-11). Windows is the primary target;
+//! Linux and macOS return `ErrorKind::Unsupported` until their own tickets land.
+
+use std::io;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 const CACHE_LINE: usize = 64;
 const HEADER_SIZE: usize = CACHE_LINE * 3;
 
-pub const DEFAULT_CAPACITY: usize = 4 * 1024 * 1024; // 4MB
-const SHM_NAME: &str = "prismoid_ringbuf";
+pub const DEFAULT_CAPACITY: usize = 4 * 1024 * 1024; // 4MB ring data
+
+/// Portable integer representation of a platform shared memory handle.
+/// On Windows this is a `HANDLE` cast through `usize`. On POSIX platforms this
+/// will be a file descriptor packed into the same width.
+pub type RawHandle = usize;
 
 #[repr(C, align(64))]
 struct WriteSlot {
@@ -24,66 +36,169 @@ struct MetaSlot {
     _pad: [u8; CACHE_LINE - 8],
 }
 
+#[derive(Debug)]
 pub struct RingBufReader {
-    shmem: shared_memory::Shmem,
+    base: *mut u8,
+    map_size: usize,
     data_offset: usize,
+    #[cfg(windows)]
+    mapping_handle: windows::Win32::Foundation::HANDLE,
+    owner: bool,
 }
 
-impl RingBufReader {
-    pub fn create(capacity: usize) -> Result<Self, shared_memory::ShmemError> {
-        Self::create_named(SHM_NAME, capacity)
-    }
+// The reader owns a view into shared memory and is the sole consumer. Atomics
+// in the header enforce cross-process ordering, and the struct only holds raw
+// pointers into memory that is valid for the reader's lifetime.
+unsafe impl Send for RingBufReader {}
 
-    pub fn create_named(name: &str, capacity: usize) -> Result<Self, shared_memory::ShmemError> {
-        assert!(
-            capacity >= 4,
-            "ring buffer capacity must be at least 4 bytes"
-        );
+#[cfg(windows)]
+impl RingBufReader {
+    pub fn create_owner(capacity: usize) -> io::Result<Self> {
+        use windows::core::PCWSTR;
+        use windows::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+        use windows::Win32::System::Memory::{
+            CreateFileMappingW, MapViewOfFile, FILE_MAP, FILE_MAP_READ, FILE_MAP_WRITE,
+            PAGE_READWRITE,
+        };
+
+        if capacity < 4 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "ring buffer capacity must be at least 4 bytes",
+            ));
+        }
+
         let total = HEADER_SIZE
             .checked_add(capacity)
-            .expect("ring buffer total size overflowed usize");
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "capacity overflow"))?;
+        let hi = ((total as u64 >> 32) & 0xFFFF_FFFF) as u32;
+        let lo = (total as u64 & 0xFFFF_FFFF) as u32;
 
-        let shmem = shared_memory::ShmemConf::new()
-            .os_id(name)
-            .size(total)
-            .create()?;
+        let handle = unsafe {
+            CreateFileMappingW(
+                INVALID_HANDLE_VALUE,
+                None,
+                PAGE_READWRITE,
+                hi,
+                lo,
+                PCWSTR::null(),
+            )
+        }
+        .map_err(windows_err)?;
 
-        let ptr = shmem.as_ptr();
+        let view = unsafe {
+            MapViewOfFile(
+                handle,
+                FILE_MAP(FILE_MAP_READ.0 | FILE_MAP_WRITE.0),
+                0,
+                0,
+                total,
+            )
+        };
+        if view.Value.is_null() {
+            unsafe {
+                let _ = CloseHandle(handle);
+            }
+            return Err(io::Error::other("MapViewOfFile returned null"));
+        }
+
+        let base = view.Value as *mut u8;
 
         unsafe {
-            std::ptr::write_bytes(ptr, 0, total);
-
-            let meta_slot = &mut *(ptr.add(CACHE_LINE * 2) as *mut MetaSlot);
-            meta_slot.capacity = capacity as u64;
-
-            let write_slot = &*(ptr as *const WriteSlot);
-            let read_slot = &*(ptr.add(CACHE_LINE) as *const ReadSlot);
-            write_slot.index.store(0, Ordering::Release);
-            read_slot.index.store(0, Ordering::Release);
+            std::ptr::write_bytes(base, 0, total);
+            let meta = &mut *(base.add(CACHE_LINE * 2) as *mut MetaSlot);
+            meta.capacity = capacity as u64;
         }
 
         Ok(Self {
-            shmem,
+            base,
+            map_size: total,
             data_offset: HEADER_SIZE,
+            mapping_handle: handle,
+            owner: true,
         })
     }
 
-    pub fn os_id(&self) -> &str {
-        self.shmem.get_os_id()
+    pub fn attach(handle: RawHandle, map_size: usize) -> io::Result<Self> {
+        use windows::Win32::Foundation::HANDLE;
+        use windows::Win32::System::Memory::{
+            MapViewOfFile, FILE_MAP, FILE_MAP_READ, FILE_MAP_WRITE,
+        };
+
+        if map_size < HEADER_SIZE + 4 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "map_size too small for ring buffer header + minimum data",
+            ));
+        }
+
+        let mapping_handle = HANDLE(handle as *mut _);
+        let view = unsafe {
+            MapViewOfFile(
+                mapping_handle,
+                FILE_MAP(FILE_MAP_READ.0 | FILE_MAP_WRITE.0),
+                0,
+                0,
+                map_size,
+            )
+        };
+        if view.Value.is_null() {
+            return Err(io::Error::last_os_error());
+        }
+
+        Ok(Self {
+            base: view.Value as *mut u8,
+            map_size,
+            data_offset: HEADER_SIZE,
+            mapping_handle,
+            owner: false,
+        })
+    }
+
+    /// Raw handle suitable for passing to a child process via stdio bootstrap.
+    /// Only meaningful for readers created via `create_owner`.
+    pub fn raw_handle(&self) -> RawHandle {
+        self.mapping_handle.0 as RawHandle
+    }
+}
+
+#[cfg(not(windows))]
+impl RingBufReader {
+    pub fn create_owner(_capacity: usize) -> io::Result<Self> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "ring buffer not yet supported on this platform",
+        ))
+    }
+
+    pub fn attach(_handle: RawHandle, _map_size: usize) -> io::Result<Self> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "ring buffer not yet supported on this platform",
+        ))
+    }
+
+    pub fn raw_handle(&self) -> RawHandle {
+        0
+    }
+}
+
+impl RingBufReader {
+    pub fn map_size(&self) -> usize {
+        self.map_size
     }
 
     fn header(&self) -> (*const WriteSlot, *const ReadSlot, u64) {
-        let ptr = self.shmem.as_ptr();
         unsafe {
-            let write_slot = &*(ptr as *const WriteSlot);
-            let read_slot = &*(ptr.add(CACHE_LINE) as *const ReadSlot);
-            let meta = &*(ptr.add(CACHE_LINE * 2) as *const MetaSlot);
+            let write_slot = self.base as *const WriteSlot;
+            let read_slot = self.base.add(CACHE_LINE) as *const ReadSlot;
+            let meta = &*(self.base.add(CACHE_LINE * 2) as *const MetaSlot);
             (write_slot, read_slot, meta.capacity)
         }
     }
 
     fn data_ptr(&self) -> *const u8 {
-        unsafe { self.shmem.as_ptr().add(self.data_offset) }
+        unsafe { self.base.add(self.data_offset) }
     }
 
     pub fn drain(&mut self) -> Vec<Vec<u8>> {
@@ -129,7 +244,9 @@ impl RingBufReader {
 
     unsafe fn read_u32_wrapped(&self, data: *const u8, pos: usize, cap: usize) -> u32 {
         let mut buf = [0u8; 4];
-        self.read_wrapped(data, pos, cap, &mut buf);
+        unsafe {
+            self.read_wrapped(data, pos, cap, &mut buf);
+        }
         u32::from_be_bytes(buf)
     }
 
@@ -137,27 +254,54 @@ impl RingBufReader {
         let offset = pos % cap;
         let first_chunk = cap - offset;
 
-        if first_chunk >= out.len() {
-            std::ptr::copy_nonoverlapping(data.add(offset), out.as_mut_ptr(), out.len());
-        } else {
-            std::ptr::copy_nonoverlapping(data.add(offset), out.as_mut_ptr(), first_chunk);
-            std::ptr::copy_nonoverlapping(
-                data,
-                out.as_mut_ptr().add(first_chunk),
-                out.len() - first_chunk,
-            );
+        unsafe {
+            if first_chunk >= out.len() {
+                std::ptr::copy_nonoverlapping(data.add(offset), out.as_mut_ptr(), out.len());
+            } else {
+                std::ptr::copy_nonoverlapping(data.add(offset), out.as_mut_ptr(), first_chunk);
+                std::ptr::copy_nonoverlapping(
+                    data,
+                    out.as_mut_ptr().add(first_chunk),
+                    out.len() - first_chunk,
+                );
+            }
         }
     }
 }
 
-#[cfg(test)]
+impl Drop for RingBufReader {
+    fn drop(&mut self) {
+        #[cfg(windows)]
+        unsafe {
+            use windows::Win32::Foundation::CloseHandle;
+            use windows::Win32::System::Memory::{UnmapViewOfFile, MEMORY_MAPPED_VIEW_ADDRESS};
+
+            if !self.base.is_null() {
+                let addr = MEMORY_MAPPED_VIEW_ADDRESS {
+                    Value: self.base as *mut _,
+                };
+                let _ = UnmapViewOfFile(addr);
+            }
+            if self.owner {
+                let _ = CloseHandle(self.mapping_handle);
+            }
+        }
+    }
+}
+
+#[cfg(windows)]
+fn windows_err(err: windows::core::Error) -> io::Error {
+    io::Error::from_raw_os_error(err.code().0)
+}
+
+#[cfg(all(test, windows))]
 mod tests {
     use super::*;
 
     fn write_to_buf(reader: &RingBufReader, payloads: &[&[u8]]) {
         let (write_slot, _, capacity) = reader.header();
         let cap = capacity as usize;
-        let data = reader.shmem.as_ptr() as usize + HEADER_SIZE;
+        let data = unsafe { reader.base.add(HEADER_SIZE) };
 
         unsafe {
             let mut write_pos = (*write_slot).index.load(Ordering::Relaxed) as usize;
@@ -166,44 +310,38 @@ mod tests {
                 let offset = write_pos % cap;
                 let first_chunk = cap - offset;
 
-                // write length (4 bytes), handling wrap
                 if first_chunk >= 4 {
-                    std::ptr::copy_nonoverlapping(
-                        len_bytes.as_ptr(),
-                        (data + offset) as *mut u8,
-                        4,
-                    );
+                    std::ptr::copy_nonoverlapping(len_bytes.as_ptr(), data.add(offset), 4);
                 } else {
                     std::ptr::copy_nonoverlapping(
                         len_bytes.as_ptr(),
-                        (data + offset) as *mut u8,
+                        data.add(offset),
                         first_chunk,
                     );
                     std::ptr::copy_nonoverlapping(
                         len_bytes.as_ptr().add(first_chunk),
-                        data as *mut u8,
+                        data,
                         4 - first_chunk,
                     );
                 }
 
-                // write payload, handling wrap
                 let pay_offset = (write_pos + 4) % cap;
                 let pay_first = cap - pay_offset;
                 if pay_first >= payload.len() {
                     std::ptr::copy_nonoverlapping(
                         payload.as_ptr(),
-                        (data + pay_offset) as *mut u8,
+                        data.add(pay_offset),
                         payload.len(),
                     );
                 } else {
                     std::ptr::copy_nonoverlapping(
                         payload.as_ptr(),
-                        (data + pay_offset) as *mut u8,
+                        data.add(pay_offset),
                         pay_first,
                     );
                     std::ptr::copy_nonoverlapping(
                         payload.as_ptr().add(pay_first),
-                        data as *mut u8,
+                        data,
                         payload.len() - pay_first,
                     );
                 }
@@ -217,21 +355,28 @@ mod tests {
     }
 
     #[test]
+    fn rejects_capacity_too_small() {
+        let err = RingBufReader::create_owner(2).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn create_default_capacity() {
+        let reader = RingBufReader::create_owner(DEFAULT_CAPACITY).unwrap();
+        assert!(reader.map_size() >= DEFAULT_CAPACITY + HEADER_SIZE);
+        assert!(reader.raw_handle() != 0);
+    }
+
+    #[test]
     fn create_and_drain_empty() {
-        let mut reader = RingBufReader::create_named("test_drain_empty_2", 4096).unwrap();
+        let mut reader = RingBufReader::create_owner(4096).unwrap();
         let messages = reader.drain();
         assert!(messages.is_empty());
     }
 
     #[test]
-    fn create_default_and_os_id() {
-        let reader = RingBufReader::create(4096).unwrap();
-        assert!(reader.os_id().contains(SHM_NAME));
-    }
-
-    #[test]
     fn write_and_read_single_message() {
-        let mut reader = RingBufReader::create_named("test_single_msg_2", 4096).unwrap();
+        let mut reader = RingBufReader::create_owner(4096).unwrap();
         write_to_buf(&reader, &[b"hello world"]);
 
         let messages = reader.drain();
@@ -241,7 +386,7 @@ mod tests {
 
     #[test]
     fn write_and_read_multiple_messages() {
-        let mut reader = RingBufReader::create_named("test_multi_msg_2", 4096).unwrap();
+        let mut reader = RingBufReader::create_owner(4096).unwrap();
         write_to_buf(&reader, &[b"msg1", b"msg two", b"third message"]);
 
         let messages = reader.drain();
@@ -253,15 +398,15 @@ mod tests {
 
     #[test]
     fn drain_stops_on_corrupt_length() {
-        let mut reader = RingBufReader::create_named("test_corrupt_len", 256).unwrap();
+        let mut reader = RingBufReader::create_owner(256).unwrap();
         let (write_slot, _, _) = reader.header();
-        let data = reader.shmem.as_ptr() as usize + HEADER_SIZE;
+        let data = unsafe { reader.base.add(HEADER_SIZE) };
 
         let bad_len: u32 = 257;
         let len_bytes = bad_len.to_be_bytes();
 
         unsafe {
-            std::ptr::copy_nonoverlapping(len_bytes.as_ptr(), data as *mut u8, 4);
+            std::ptr::copy_nonoverlapping(len_bytes.as_ptr(), data, 4);
             (*write_slot)
                 .index
                 .store(4 + bad_len as u64, Ordering::Release);
@@ -273,14 +418,14 @@ mod tests {
 
     #[test]
     fn drain_stops_on_partial_message() {
-        let mut reader = RingBufReader::create_named("test_partial_msg", 4096).unwrap();
+        let mut reader = RingBufReader::create_owner(4096).unwrap();
         let (write_slot, _, _) = reader.header();
-        let data = reader.shmem.as_ptr() as usize + HEADER_SIZE;
+        let data = unsafe { reader.base.add(HEADER_SIZE) };
 
-        let len_bytes = (100u32).to_be_bytes();
+        let len_bytes = 100u32.to_be_bytes();
 
         unsafe {
-            std::ptr::copy_nonoverlapping(len_bytes.as_ptr(), data as *mut u8, 4);
+            std::ptr::copy_nonoverlapping(len_bytes.as_ptr(), data, 4);
             (*write_slot).index.store(54, Ordering::Release);
         }
 
@@ -290,7 +435,7 @@ mod tests {
 
     #[test]
     fn read_wraps_around_boundary() {
-        let mut reader = RingBufReader::create_named("test_wrap_read", 32).unwrap();
+        let mut reader = RingBufReader::create_owner(32).unwrap();
         let (write_slot, read_slot, _) = reader.header();
 
         unsafe {
@@ -303,5 +448,24 @@ mod tests {
         let messages = reader.drain();
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0], b"ABCDEFGH");
+    }
+
+    #[test]
+    fn attach_reads_through_owner_handle() {
+        // In-process exercise of the cross-process handle contract: create an
+        // owner, then open a second view on the same section via attach using
+        // the raw handle. Messages written via the owner's view are visible
+        // through the attached reader's view. The kernel section stays alive
+        // as long as the owner holds its handle.
+        let owner = RingBufReader::create_owner(4096).unwrap();
+        let handle = owner.raw_handle();
+        let size = owner.map_size();
+
+        let mut attached = RingBufReader::attach(handle, size).unwrap();
+        write_to_buf(&owner, &[b"cross-view message"]);
+
+        let messages = attached.drain();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0], b"cross-view message");
     }
 }

--- a/apps/desktop/src-tauri/src/ringbuf.rs
+++ b/apps/desktop/src-tauri/src/ringbuf.rs
@@ -1,9 +1,19 @@
 //! SPSC shared memory ring buffer for the Go sidecar → Rust host hot path.
 //!
-//! The Rust host creates an unnamed shared memory section and hands the raw
-//! HANDLE to the Go sidecar at spawn time via handle inheritance + stdio
-//! bootstrap. See ADR 18 (revised 2026-04-11). Windows is the primary target;
-//! Linux and macOS return `ErrorKind::Unsupported` until their own tickets land.
+//! The Rust host creates an unnamed shared memory section via [`RingBufReader::create_owner`]
+//! and obtains the raw HANDLE via [`RingBufReader::raw_handle`]. See ADR 18
+//! (revised 2026-04-11).
+//!
+//! This primitive deliberately creates the handle as **non-inheritable**. The
+//! caller (the host lifecycle) is responsible for marking the handle inheritable
+//! via `SetHandleInformation(HANDLE_FLAG_INHERIT)` immediately before spawning
+//! the sidecar and un-marking it immediately after, to minimize the race window
+//! where any other child spawned in that interval would inherit the section.
+//! See the Rust stdlib comment in `library/std/src/sys/process/windows.rs`
+//! (around the `CREATE_PROCESS_LOCK` definition) for why this window matters.
+//!
+//! Windows is the primary target; Linux and macOS return `ErrorKind::Unsupported`
+//! until their own tickets land.
 
 use std::io;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -96,10 +106,11 @@ impl RingBufReader {
             )
         };
         if view.Value.is_null() {
+            let err = io::Error::last_os_error();
             unsafe {
                 let _ = CloseHandle(handle);
             }
-            return Err(io::Error::other("MapViewOfFile returned null"));
+            return Err(err);
         }
 
         let base = view.Value as *mut u8;
@@ -122,7 +133,8 @@ impl RingBufReader {
     pub fn attach(handle: RawHandle, map_size: usize) -> io::Result<Self> {
         use windows::Win32::Foundation::HANDLE;
         use windows::Win32::System::Memory::{
-            MapViewOfFile, FILE_MAP, FILE_MAP_READ, FILE_MAP_WRITE,
+            MapViewOfFile, UnmapViewOfFile, FILE_MAP, FILE_MAP_READ, FILE_MAP_WRITE,
+            MEMORY_MAPPED_VIEW_ADDRESS,
         };
 
         if map_size < HEADER_SIZE + 4 {
@@ -146,8 +158,28 @@ impl RingBufReader {
             return Err(io::Error::last_os_error());
         }
 
+        // Validate the creator-written header before drain() can trust it. An
+        // invalid capacity would cause a modulo-by-zero or an out-of-bounds
+        // read once messages start flowing.
+        let base = view.Value as *mut u8;
+        let capacity = unsafe {
+            let meta = &*(base.add(CACHE_LINE * 2) as *const MetaSlot);
+            meta.capacity as usize
+        };
+        if capacity < 4 || HEADER_SIZE.saturating_add(capacity) > map_size {
+            unsafe {
+                let _ = UnmapViewOfFile(MEMORY_MAPPED_VIEW_ADDRESS {
+                    Value: base as *mut _,
+                });
+            }
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "ring buffer header capacity is invalid or exceeds mapped size",
+            ));
+        }
+
         Ok(Self {
-            base: view.Value as *mut u8,
+            base,
             map_size,
             data_offset: HEADER_SIZE,
             mapping_handle,
@@ -291,7 +323,10 @@ impl Drop for RingBufReader {
 
 #[cfg(windows)]
 fn windows_err(err: windows::core::Error) -> io::Error {
-    io::Error::from_raw_os_error(err.code().0)
+    // Preserves the HRESULT message via the windows::core::Error's Display impl
+    // rather than reducing it to a bare errno, which `from_raw_os_error(err.code().0)`
+    // would do.
+    io::Error::other(err)
 }
 
 #[cfg(all(test, windows))]
@@ -467,5 +502,41 @@ mod tests {
         let messages = attached.drain();
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0], b"cross-view message");
+    }
+
+    #[test]
+    fn attach_rejects_zero_capacity_header() {
+        // Corrupt the owner's MetaSlot.capacity to 0, then try to attach via
+        // the raw handle. Attach must reject it instead of trusting the header,
+        // otherwise drain() would hit a modulo-by-zero.
+        let owner = RingBufReader::create_owner(4096).unwrap();
+        unsafe {
+            let meta = owner.base.add(CACHE_LINE * 2) as *mut MetaSlot;
+            (*meta).capacity = 0;
+        }
+        let err = RingBufReader::attach(owner.raw_handle(), owner.map_size()).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn attach_rejects_capacity_exceeding_map_size() {
+        let owner = RingBufReader::create_owner(4096).unwrap();
+        unsafe {
+            let meta = owner.base.add(CACHE_LINE * 2) as *mut MetaSlot;
+            (*meta).capacity = owner.map_size() as u64 + 1;
+        }
+        let err = RingBufReader::attach(owner.raw_handle(), owner.map_size()).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn attach_rejects_capacity_below_minimum() {
+        let owner = RingBufReader::create_owner(4096).unwrap();
+        unsafe {
+            let meta = owner.base.add(CACHE_LINE * 2) as *mut MetaSlot;
+            (*meta).capacity = 2;
+        }
+        let err = RingBufReader::attach(owner.raw_handle(), owner.map_size()).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 }


### PR DESCRIPTION
Implements [PRI-5](https://linear.app/frostcrypt/issue/PRI-5/ring-buffer-primitive-swap-shared-memory-crate-for-direct-platform). First code change for the revised ADR 18 (see #27).

## what

- Drops the `shared_memory = "0.12"` dependency from `apps/desktop/src-tauri`
- Adds `windows = "0.61"` with `Win32_Foundation`, `Win32_System_Memory`, `Win32_Security` features (target-gated to Windows)
- Rewrites `RingBufReader`:
  - `create_owner(capacity)` calls `CreateFileMappingW(INVALID_HANDLE_VALUE, None, PAGE_READWRITE, ...)` directly — unnamed kernel section, no disk backing, no temp file, no crash-recovery bug
  - `attach(handle, size)` maps a caller-provided handle via `MapViewOfFile` — the Go sidecar uses this after inheriting the handle via `CreateProcess` and receiving the raw value over stdio (wiring lands in PRI-2 / PRI-6)
  - `raw_handle()` exposes the owner's HANDLE for the host-side bootstrap
  - Drop unmaps the view and (for owners) closes the handle
  - Read/write/drain logic unchanged
- Rewrites `apps/desktop/src-sidecar/internal/ringbuf/shm_windows.go`:
  - `OpenShared(name, size)` → `Attach(handle, size)` — skips `OpenFileMappingW` entirely and goes straight to `MapViewOfFile` on the inherited handle
  - The returned cleanup takes ownership of the handle and closes it
- `shm_linux.go` stubs return `ErrorKind::Unsupported` until the `memfd_create` ticket lands

## tests

Rust (9 passing, was 7):

- existing coverage preserved: `create_and_drain_empty`, `write_and_read_single_message`, `write_and_read_multiple_messages`, `drain_stops_on_corrupt_length`, `drain_stops_on_partial_message`, `read_wraps_around_boundary`
- new: `rejects_capacity_too_small`, `create_default_capacity` (verifies `raw_handle()` is non-zero), `attach_reads_through_owner_handle` (in-process exercise of the cross-process handle contract — create owner, attach via raw handle, write via owner, read via attached)

Go (3 passing, was 2):

- `TestAttachRoundTrip` — create a mapping, pass the handle to `Attach`, read/write the mapped memory
- `TestAttachRejectsZeroHandle`, `TestAttachRejectsZeroSize` — input validation

## out of scope

- Sidecar bootstrap wiring (PRI-2)
- Rust host lifecycle (PRI-6)
- Linux `memfd_create` (separate ticket)
- macOS `shm_open` (separate ticket)

Closes PRI-5.