### PR TITLE
feat: rust host lifecycle with unified message pipeline

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2487,11 +2487,13 @@ dependencies = [
 name = "prismoid"
 version = "0.0.1"
 dependencies = [
+ "chrono",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-shell",
+ "tokio",
  "tracing",
  "tracing-subscriber",
  "windows",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -13,8 +13,10 @@ tauri-build = { version = "2.5", features = [] }
 [dependencies]
 tauri = { version = "2.10", features = [] }
 tauri-plugin-shell = "2.3"
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tokio = { version = "1", features = ["time"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/apps/desktop/src-tauri/src/host.rs
+++ b/apps/desktop/src-tauri/src/host.rs
@@ -1,0 +1,252 @@
+//! Host-side helpers used by `lib.rs` to drive the sidecar: bootstrap
+//! serialization, env-driven Twitch credentials, ring buffer batch parsing,
+//! and the Windows handle inheritance toggles.
+//!
+//! The actual Tauri setup closure and the async drain loop live in `lib.rs`
+//! because they are tightly coupled to the Tauri runtime and untestable
+//! without a real app. Everything here is a pure function or a thin wrapper
+//! around a platform API so the whole module stays unit-testable.
+
+use std::time::Duration;
+
+use serde::Serialize;
+
+use crate::message::{parse_twitch_envelope, UnifiedMessage};
+use crate::ringbuf::RawHandle;
+
+pub const DRAIN_INTERVAL: Duration = Duration::from_millis(16);
+pub const SIDECAR_BINARY: &str = "sidecar";
+
+/// Twitch OAuth credentials sourced from environment variables for Phase 0 dev.
+#[derive(Debug, Clone)]
+pub struct TwitchCreds {
+    pub client_id: String,
+    pub access_token: String,
+    pub broadcaster_id: String,
+    pub user_id: String,
+}
+
+/// Parses a slice of raw ring-buffer payloads into [`UnifiedMessage`]s. Messages
+/// that fail to parse or that aren't chat notifications are dropped with a log.
+/// Each parse is wrapped in `catch_unwind` so a panicking parser cannot kill
+/// the drain loop (`docs/stability.md` §Rust Panic Handling).
+pub fn parse_batch(raw: &[Vec<u8>]) -> Vec<UnifiedMessage> {
+    let mut batch = Vec::with_capacity(raw.len());
+    for payload in raw {
+        let slice = payload.as_slice();
+        let outcome = std::panic::catch_unwind(|| parse_twitch_envelope(slice));
+        match outcome {
+            Ok(Ok(Some(msg))) => batch.push(msg),
+            Ok(Ok(None)) => {}
+            Ok(Err(e)) => {
+                tracing::warn!(error = %e, "parse failed, dropping message");
+            }
+            Err(_) => {
+                tracing::error!("panic during envelope parse, dropping message");
+            }
+        }
+    }
+    batch
+}
+
+/// Serializes the bootstrap JSON line the Rust host writes to the sidecar's
+/// stdin immediately after spawn.
+pub fn build_bootstrap_line(handle: RawHandle, size: usize) -> serde_json::Result<Vec<u8>> {
+    #[derive(Serialize)]
+    struct Bootstrap {
+        shm_handle: u64,
+        shm_size: u64,
+    }
+    let payload = Bootstrap {
+        shm_handle: handle as u64,
+        shm_size: size as u64,
+    };
+    let mut bytes = serde_json::to_vec(&payload)?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+/// Serializes a `twitch_connect` control command line for the sidecar.
+pub fn build_twitch_connect_line(creds: &TwitchCreds) -> serde_json::Result<Vec<u8>> {
+    #[derive(Serialize)]
+    struct ConnectCmd<'a> {
+        cmd: &'a str,
+        client_id: &'a str,
+        token: &'a str,
+        broadcaster_id: &'a str,
+        user_id: &'a str,
+    }
+    let cmd = ConnectCmd {
+        cmd: "twitch_connect",
+        client_id: &creds.client_id,
+        token: &creds.access_token,
+        broadcaster_id: &creds.broadcaster_id,
+        user_id: &creds.user_id,
+    };
+    let mut bytes = serde_json::to_vec(&cmd)?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+/// Reads Twitch dev credentials from environment variables. Returns None if
+/// any of the four required vars are missing. Phase 0 only — a proper OAuth
+/// flow lands in a follow-up ticket.
+pub fn twitch_creds_from_env() -> Option<TwitchCreds> {
+    Some(TwitchCreds {
+        client_id: std::env::var("PRISMOID_TWITCH_CLIENT_ID").ok()?,
+        access_token: std::env::var("PRISMOID_TWITCH_ACCESS_TOKEN").ok()?,
+        broadcaster_id: std::env::var("PRISMOID_TWITCH_BROADCASTER_ID").ok()?,
+        user_id: std::env::var("PRISMOID_TWITCH_USER_ID").ok()?,
+    })
+}
+
+/// Marks a shared memory HANDLE inheritable just before spawning a child
+/// process. See ADR 18 for why this is necessary.
+#[cfg(windows)]
+pub fn mark_handle_inheritable(handle: RawHandle) -> std::io::Result<()> {
+    use windows::Win32::Foundation::{SetHandleInformation, HANDLE, HANDLE_FLAG_INHERIT};
+    unsafe {
+        SetHandleInformation(
+            HANDLE(handle as *mut _),
+            HANDLE_FLAG_INHERIT.0,
+            HANDLE_FLAG_INHERIT,
+        )
+        .map_err(std::io::Error::other)
+    }
+}
+
+/// Clears the inheritable flag on a HANDLE immediately after the child is
+/// spawned, so any subsequent child created by this process does not
+/// accidentally inherit the same handle.
+#[cfg(windows)]
+pub fn unmark_handle_inheritable(handle: RawHandle) -> std::io::Result<()> {
+    use windows::Win32::Foundation::{
+        SetHandleInformation, HANDLE, HANDLE_FLAGS, HANDLE_FLAG_INHERIT,
+    };
+    unsafe {
+        SetHandleInformation(
+            HANDLE(handle as *mut _),
+            HANDLE_FLAG_INHERIT.0,
+            HANDLE_FLAGS(0),
+        )
+        .map_err(std::io::Error::other)
+    }
+}
+
+#[cfg(not(windows))]
+pub fn mark_handle_inheritable(_handle: RawHandle) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "handle inheritance not yet supported on this platform",
+    ))
+}
+
+#[cfg(not(windows))]
+pub fn unmark_handle_inheritable(_handle: RawHandle) -> std::io::Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bootstrap_line_has_expected_fields_and_newline() {
+        let line = build_bootstrap_line(0xDEADBEEF, 4096).unwrap();
+        assert_eq!(line.last(), Some(&b'\n'));
+        let body = &line[..line.len() - 1];
+        let parsed: serde_json::Value = serde_json::from_slice(body).unwrap();
+        assert_eq!(parsed["shm_handle"], 0xDEADBEEF_u64);
+        assert_eq!(parsed["shm_size"], 4096_u64);
+    }
+
+    #[test]
+    fn twitch_connect_line_has_all_required_fields() {
+        let creds = TwitchCreds {
+            client_id: "cid".into(),
+            access_token: "tok".into(),
+            broadcaster_id: "bid".into(),
+            user_id: "uid".into(),
+        };
+        let line = build_twitch_connect_line(&creds).unwrap();
+        assert_eq!(line.last(), Some(&b'\n'));
+        let body = &line[..line.len() - 1];
+        let parsed: serde_json::Value = serde_json::from_slice(body).unwrap();
+        assert_eq!(parsed["cmd"], "twitch_connect");
+        assert_eq!(parsed["client_id"], "cid");
+        assert_eq!(parsed["token"], "tok");
+        assert_eq!(parsed["broadcaster_id"], "bid");
+        assert_eq!(parsed["user_id"], "uid");
+    }
+
+    #[test]
+    fn parse_batch_filters_non_chat_and_parse_errors() {
+        let viewer = br##"{
+            "metadata": {"message_id":"m","message_type":"notification","message_timestamp":"2023-11-06T18:11:47.492Z"},
+            "payload": {
+                "subscription": {"type":"channel.chat.message"},
+                "event": {
+                    "chatter_user_id":"1","chatter_user_login":"u","chatter_user_name":"U",
+                    "message_id":"mid","message":{"text":"hi"}
+                }
+            }
+        }"##.to_vec();
+        let keepalive = br##"{"metadata":{"message_id":"ka","message_type":"session_keepalive","message_timestamp":"2023-11-06T18:11:49.000Z"},"payload":{}}"##.to_vec();
+        let junk = b"not json".to_vec();
+
+        let raw = vec![viewer, keepalive, junk];
+        let batch = parse_batch(&raw);
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch[0].message_text, "hi");
+    }
+
+    #[test]
+    fn parse_batch_empty_input() {
+        let batch = parse_batch(&[]);
+        assert!(batch.is_empty());
+    }
+
+    #[test]
+    fn twitch_creds_from_env_returns_none_when_missing() {
+        unsafe {
+            std::env::remove_var("PRISMOID_TWITCH_CLIENT_ID");
+            std::env::remove_var("PRISMOID_TWITCH_ACCESS_TOKEN");
+            std::env::remove_var("PRISMOID_TWITCH_BROADCASTER_ID");
+            std::env::remove_var("PRISMOID_TWITCH_USER_ID");
+        }
+        assert!(twitch_creds_from_env().is_none());
+    }
+
+    #[test]
+    fn twitch_creds_from_env_returns_some_when_all_present() {
+        unsafe {
+            std::env::set_var("PRISMOID_TWITCH_CLIENT_ID", "c");
+            std::env::set_var("PRISMOID_TWITCH_ACCESS_TOKEN", "t");
+            std::env::set_var("PRISMOID_TWITCH_BROADCASTER_ID", "b");
+            std::env::set_var("PRISMOID_TWITCH_USER_ID", "u");
+        }
+        let creds = twitch_creds_from_env().unwrap();
+        assert_eq!(creds.client_id, "c");
+        assert_eq!(creds.access_token, "t");
+        assert_eq!(creds.broadcaster_id, "b");
+        assert_eq!(creds.user_id, "u");
+        unsafe {
+            std::env::remove_var("PRISMOID_TWITCH_CLIENT_ID");
+            std::env::remove_var("PRISMOID_TWITCH_ACCESS_TOKEN");
+            std::env::remove_var("PRISMOID_TWITCH_BROADCASTER_ID");
+            std::env::remove_var("PRISMOID_TWITCH_USER_ID");
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn mark_and_unmark_handle_inheritance_round_trip() {
+        use crate::ringbuf;
+
+        let reader = ringbuf::RingBufReader::create_owner(4096).unwrap();
+        let handle = reader.raw_handle();
+
+        mark_handle_inheritable(handle).expect("mark should succeed");
+        unmark_handle_inheritable(handle).expect("unmark should succeed");
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -7,10 +7,7 @@ use tauri_plugin_shell::process::CommandEvent;
 use tauri_plugin_shell::ShellExt;
 use tracing_subscriber::EnvFilter;
 
-use host::{
-    build_bootstrap_line, build_twitch_connect_line, mark_handle_inheritable, parse_batch,
-    twitch_creds_from_env, unmark_handle_inheritable, DRAIN_INTERVAL, SIDECAR_BINARY,
-};
+use host::{parse_batch, DRAIN_INTERVAL};
 use ringbuf::{RingBufReader, DEFAULT_CAPACITY};
 
 #[tauri::command]
@@ -33,24 +30,57 @@ pub fn run() {
         .expect("failed to run prismoid");
 }
 
-/// Tauri setup hook. Creates the shm section, spawns the sidecar with the
-/// HANDLE marked inheritable, writes the bootstrap line, optionally auto-
-/// connects to Twitch with env creds, and spawns the drain task.
+/// Tauri setup hook. On Windows, creates the shm section, spawns the sidecar
+/// with the HANDLE marked inheritable, bootstraps it, and starts the drain
+/// task. On other platforms (not yet supported per ADR 18), logs a warning
+/// and lets the Tauri app launch so frontend work can proceed.
+#[allow(clippy::unnecessary_wraps)]
 fn setup<R: Runtime>(app: &mut tauri::App<R>) -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(windows)]
+    {
+        setup_sidecar(app)?;
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = app;
+        tracing::warn!(
+            "sidecar lifecycle is Windows-only for now; launching frontend without sidecar"
+        );
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn setup_sidecar<R: Runtime>(app: &mut tauri::App<R>) -> Result<(), Box<dyn std::error::Error>> {
+    use host::{
+        build_bootstrap_line, build_twitch_connect_line, mark_handle_inheritable,
+        twitch_creds_from_env, unmark_handle_inheritable, SIDECAR_BINARY,
+    };
+
     let reader = RingBufReader::create_owner(DEFAULT_CAPACITY)?;
     let handle = reader.raw_handle();
     let size = reader.map_size();
 
     mark_handle_inheritable(handle)?;
 
+    // RAII guard: the inheritable flag is cleared on any exit from this
+    // function, including error paths. This keeps the window where the HANDLE
+    // is inheritable as narrow as possible (effectively: the sidecar spawn).
+    // The Rust stdlib's CREATE_PROCESS_LOCK serializes our own child spawns,
+    // but un-setting the flag immediately defends against any future change
+    // where something else creates a process between mark and function exit.
+    struct InheritGuard(ringbuf::RawHandle);
+    impl Drop for InheritGuard {
+        fn drop(&mut self) {
+            if let Err(e) = unmark_handle_inheritable(self.0) {
+                tracing::error!(error = %e, "failed to un-mark handle inheritance in drop");
+            }
+        }
+    }
+    let _inherit_guard = InheritGuard(handle);
+
     let sidecar = app.shell().sidecar(SIDECAR_BINARY)?;
     let (mut rx, mut child) = sidecar.spawn()?;
-
-    // Un-mark immediately so no future child spawned in this process inherits
-    // this HANDLE. The sidecar already has its own inherited copy.
-    if let Err(e) = unmark_handle_inheritable(handle) {
-        tracing::error!(error = %e, "failed to un-mark handle inheritance after spawn");
-    }
 
     let bootstrap_line = build_bootstrap_line(handle, size)?;
     child.write(&bootstrap_line)?;
@@ -67,8 +97,8 @@ fn setup<R: Runtime>(app: &mut tauri::App<R>) -> Result<(), Box<dyn std::error::
         tracing::warn!("PRISMOID_TWITCH_* env vars not all set; launching without auto-connect");
     }
 
-    // Drain sidecar CommandEvent stream for logging. This keeps stdout/stderr
-    // from piling up and surfaces termination events.
+    // Drain the sidecar's CommandEvent stream for logging. This keeps
+    // stdout/stderr from piling up and surfaces termination events.
     tauri::async_runtime::spawn(async move {
         while let Some(event) = rx.recv().await {
             match event {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,9 +1,17 @@
-#[allow(dead_code)]
+mod host;
 mod message;
 pub mod ringbuf;
 
-use tauri::Manager;
+use tauri::{AppHandle, Emitter, Manager, Runtime};
+use tauri_plugin_shell::process::CommandEvent;
+use tauri_plugin_shell::ShellExt;
 use tracing_subscriber::EnvFilter;
+
+use host::{
+    build_bootstrap_line, build_twitch_connect_line, mark_handle_inheritable, parse_batch,
+    twitch_creds_from_env, unmark_handle_inheritable, DRAIN_INTERVAL, SIDECAR_BINARY,
+};
+use ringbuf::{RingBufReader, DEFAULT_CAPACITY};
 
 #[tauri::command]
 fn get_platform() -> &'static str {
@@ -20,14 +28,91 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .invoke_handler(tauri::generate_handler![get_platform])
-        .setup(|app| {
-            if let Some(window) = app.get_webview_window("main") {
-                tracing::info!("prismoid starting, window: {}", window.label());
-            } else {
-                tracing::warn!("main window not found during setup");
-            }
-            Ok(())
-        })
+        .setup(setup)
         .run(tauri::generate_context!())
         .expect("failed to run prismoid");
+}
+
+/// Tauri setup hook. Creates the shm section, spawns the sidecar with the
+/// HANDLE marked inheritable, writes the bootstrap line, optionally auto-
+/// connects to Twitch with env creds, and spawns the drain task.
+fn setup<R: Runtime>(app: &mut tauri::App<R>) -> Result<(), Box<dyn std::error::Error>> {
+    let reader = RingBufReader::create_owner(DEFAULT_CAPACITY)?;
+    let handle = reader.raw_handle();
+    let size = reader.map_size();
+
+    mark_handle_inheritable(handle)?;
+
+    let sidecar = app.shell().sidecar(SIDECAR_BINARY)?;
+    let (mut rx, mut child) = sidecar.spawn()?;
+
+    // Un-mark immediately so no future child spawned in this process inherits
+    // this HANDLE. The sidecar already has its own inherited copy.
+    if let Err(e) = unmark_handle_inheritable(handle) {
+        tracing::error!(error = %e, "failed to un-mark handle inheritance after spawn");
+    }
+
+    let bootstrap_line = build_bootstrap_line(handle, size)?;
+    child.write(&bootstrap_line)?;
+    tracing::info!("sidecar bootstrap written");
+
+    if let Some(creds) = twitch_creds_from_env() {
+        let connect_line = build_twitch_connect_line(&creds)?;
+        child.write(&connect_line)?;
+        tracing::info!(
+            broadcaster = %creds.broadcaster_id,
+            "sent twitch_connect with env creds"
+        );
+    } else {
+        tracing::warn!("PRISMOID_TWITCH_* env vars not all set; launching without auto-connect");
+    }
+
+    // Drain sidecar CommandEvent stream for logging. This keeps stdout/stderr
+    // from piling up and surfaces termination events.
+    tauri::async_runtime::spawn(async move {
+        while let Some(event) = rx.recv().await {
+            match event {
+                CommandEvent::Stdout(bytes) => {
+                    tracing::debug!(line = %String::from_utf8_lossy(&bytes), "sidecar stdout");
+                }
+                CommandEvent::Stderr(bytes) => {
+                    tracing::debug!(line = %String::from_utf8_lossy(&bytes), "sidecar stderr");
+                }
+                CommandEvent::Terminated(payload) => {
+                    tracing::warn!(code = ?payload.code, "sidecar terminated");
+                    break;
+                }
+                _ => {}
+            }
+        }
+    });
+
+    let app_handle = app.app_handle().clone();
+    tauri::async_runtime::spawn(run_drain_loop(reader, app_handle));
+
+    Ok(())
+}
+
+/// Drain loop: every [`DRAIN_INTERVAL`], drain the ring buffer, parse each
+/// payload, emit the batch to the frontend.
+async fn run_drain_loop<R: Runtime>(mut reader: RingBufReader, app: AppHandle<R>) {
+    let mut ticker = tokio::time::interval(DRAIN_INTERVAL);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        ticker.tick().await;
+        let raw = reader.drain();
+        if raw.is_empty() {
+            continue;
+        }
+
+        let batch = parse_batch(&raw);
+        if batch.is_empty() {
+            continue;
+        }
+
+        if let Err(e) = app.emit("chat_messages", &batch) {
+            tracing::error!(error = %e, "failed to emit chat_messages");
+        }
+    }
 }

--- a/apps/desktop/src-tauri/src/message.rs
+++ b/apps/desktop/src-tauri/src/message.rs
@@ -1,9 +1,16 @@
-use serde::Serialize;
+//! Unified message type emitted to the frontend, plus parsers that convert
+//! raw platform envelopes into it.
+
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize)]
 pub enum Platform {
     Twitch,
+    // Constructed by platform parsers landing in follow-up tickets. Kept here
+    // so the frontend's discriminated union stays the single source of truth.
+    #[allow(dead_code)]
     YouTube,
+    #[allow(dead_code)]
     Kick,
 }
 
@@ -29,4 +36,380 @@ pub struct UnifiedMessage {
     pub is_broadcaster: bool,
     pub color: Option<String>,
     pub reply_to: Option<String>,
+}
+
+#[derive(Debug)]
+pub enum ParseError {
+    Json(serde_json::Error),
+    Timestamp(chrono::ParseError),
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Json(e) => write!(f, "json parse failed: {e}"),
+            Self::Timestamp(e) => write!(f, "timestamp parse failed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ParseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Json(e) => Some(e),
+            Self::Timestamp(e) => Some(e),
+        }
+    }
+}
+
+impl From<serde_json::Error> for ParseError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::Json(err)
+    }
+}
+
+// --- Twitch EventSub deserialization types (private, narrow) ---
+
+#[derive(Debug, Deserialize)]
+struct TwitchEnvelope {
+    metadata: TwitchMetadata,
+    #[serde(default)]
+    payload: Option<TwitchPayload>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TwitchMetadata {
+    message_type: String,
+    message_timestamp: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct TwitchPayload {
+    #[serde(default)]
+    subscription: Option<TwitchSubscription>,
+    // Event is held as an opaque Value and only deserialized to the concrete
+    // chat event type once we have confirmed the subscription type matches.
+    // This lets non-chat notifications (channel.follow, etc.) parse cleanly
+    // instead of failing on the missing chat-specific fields.
+    #[serde(default)]
+    event: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TwitchSubscription {
+    #[serde(rename = "type")]
+    subscription_type: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct TwitchChatEvent {
+    chatter_user_id: String,
+    chatter_user_login: String,
+    chatter_user_name: String,
+    message_id: String,
+    message: TwitchChatMessage,
+    #[serde(default)]
+    color: Option<String>,
+    #[serde(default)]
+    badges: Vec<TwitchBadge>,
+    #[serde(default)]
+    reply: Option<TwitchReply>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TwitchChatMessage {
+    text: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct TwitchBadge {
+    set_id: String,
+    id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct TwitchReply {
+    parent_message_id: String,
+}
+
+/// Parses a raw Twitch EventSub envelope into a [`UnifiedMessage`] when the
+/// envelope is a `channel.chat.message` notification.
+///
+/// Returns `Ok(None)` for any other envelope shape — keepalives, reconnects,
+/// revocations, notifications for other subscription types, or payloads that
+/// are missing the nested `subscription`/`event` fields. Those are not parse
+/// errors; the drain loop filters them out silently.
+///
+/// Defensive parsing per `docs/stability.md`: no `unwrap` on external data,
+/// unknown fields are ignored via serde, missing optional fields default.
+pub fn parse_twitch_envelope(bytes: &[u8]) -> Result<Option<UnifiedMessage>, ParseError> {
+    let envelope: TwitchEnvelope = serde_json::from_slice(bytes)?;
+
+    if envelope.metadata.message_type != "notification" {
+        return Ok(None);
+    }
+
+    let Some(payload) = envelope.payload else {
+        return Ok(None);
+    };
+    let Some(subscription) = payload.subscription else {
+        return Ok(None);
+    };
+    if subscription.subscription_type != "channel.chat.message" {
+        return Ok(None);
+    }
+    let Some(event_value) = payload.event else {
+        return Ok(None);
+    };
+    let event: TwitchChatEvent = serde_json::from_value(event_value)?;
+
+    let platform_ts = chrono::DateTime::parse_from_rfc3339(&envelope.metadata.message_timestamp)
+        .map_err(ParseError::Timestamp)?
+        .timestamp_millis();
+    let arrival_time = chrono::Utc::now().timestamp_millis();
+
+    let badges: Vec<Badge> = event
+        .badges
+        .into_iter()
+        .map(|b| Badge {
+            set_id: b.set_id,
+            id: b.id,
+        })
+        .collect();
+    let is_broadcaster = badges.iter().any(|b| b.set_id == "broadcaster");
+    let is_mod = is_broadcaster || badges.iter().any(|b| b.set_id == "moderator");
+    let is_subscriber = badges
+        .iter()
+        .any(|b| b.set_id == "subscriber" || b.set_id == "founder");
+
+    Ok(Some(UnifiedMessage {
+        id: event.message_id,
+        platform: Platform::Twitch,
+        timestamp: platform_ts,
+        arrival_time,
+        username: event.chatter_user_login,
+        display_name: event.chatter_user_name,
+        platform_user_id: event.chatter_user_id,
+        message_text: event.message.text,
+        badges,
+        is_mod,
+        is_subscriber,
+        is_broadcaster,
+        color: event.color,
+        reply_to: event.reply.map(|r| r.parent_message_id),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VIEWER_MSG: &[u8] = br##"{
+        "metadata": {
+            "message_id": "meta-1",
+            "message_type": "notification",
+            "message_timestamp": "2023-11-06T18:11:47.492Z"
+        },
+        "payload": {
+            "subscription": {
+                "id": "sub-1",
+                "status": "enabled",
+                "type": "channel.chat.message",
+                "version": "1",
+                "cost": 0
+            },
+            "event": {
+                "broadcaster_user_id": "1971641",
+                "broadcaster_user_login": "streamer",
+                "broadcaster_user_name": "streamer",
+                "chatter_user_id": "4145994",
+                "chatter_user_login": "viewer32",
+                "chatter_user_name": "viewer32",
+                "message_id": "cc106a89-1814-919d-454c-f4f2f970aae7",
+                "message": {
+                    "text": "Hi chat",
+                    "fragments": []
+                },
+                "color": "#00FF7F",
+                "badges": [],
+                "message_type": "text"
+            }
+        }
+    }"##;
+
+    const MOD_MSG: &[u8] = br##"{
+        "metadata": {
+            "message_id": "meta-2",
+            "message_type": "notification",
+            "message_timestamp": "2023-11-06T18:11:48.100Z"
+        },
+        "payload": {
+            "subscription": { "type": "channel.chat.message" },
+            "event": {
+                "broadcaster_user_id": "1",
+                "chatter_user_id": "99",
+                "chatter_user_login": "the_mod",
+                "chatter_user_name": "TheMod",
+                "message_id": "m-1",
+                "message": { "text": "!ban spammer" },
+                "color": "#FF0000",
+                "badges": [
+                    { "set_id": "moderator", "id": "1", "info": "" },
+                    { "set_id": "subscriber", "id": "6", "info": "6" }
+                ]
+            }
+        }
+    }"##;
+
+    const BROADCASTER_MSG: &[u8] = br##"{
+        "metadata": {
+            "message_id": "meta-3",
+            "message_type": "notification",
+            "message_timestamp": "2023-11-06T18:12:00.000Z"
+        },
+        "payload": {
+            "subscription": { "type": "channel.chat.message" },
+            "event": {
+                "broadcaster_user_id": "1",
+                "chatter_user_id": "1",
+                "chatter_user_login": "streamer",
+                "chatter_user_name": "Streamer",
+                "message_id": "b-1",
+                "message": { "text": "welcome everyone" },
+                "badges": [{ "set_id": "broadcaster", "id": "1", "info": "" }]
+            }
+        }
+    }"##;
+
+    const REPLY_MSG: &[u8] = br##"{
+        "metadata": {
+            "message_id": "meta-4",
+            "message_type": "notification",
+            "message_timestamp": "2023-11-06T18:12:05.250Z"
+        },
+        "payload": {
+            "subscription": { "type": "channel.chat.message" },
+            "event": {
+                "chatter_user_id": "42",
+                "chatter_user_login": "replier",
+                "chatter_user_name": "Replier",
+                "message_id": "r-1",
+                "message": { "text": "lol" },
+                "reply": {
+                    "parent_message_id": "parent-abc",
+                    "parent_user_id": "1",
+                    "parent_user_login": "streamer"
+                }
+            }
+        }
+    }"##;
+
+    const KEEPALIVE: &[u8] = br##"{
+        "metadata": {
+            "message_id": "ka-1",
+            "message_type": "session_keepalive",
+            "message_timestamp": "2023-11-06T18:11:49.000Z"
+        },
+        "payload": {}
+    }"##;
+
+    const OTHER_NOTIFICATION: &[u8] = br##"{
+        "metadata": {
+            "message_id": "on-1",
+            "message_type": "notification",
+            "message_timestamp": "2023-11-06T18:11:50.000Z"
+        },
+        "payload": {
+            "subscription": { "type": "channel.follow" },
+            "event": {}
+        }
+    }"##;
+
+    #[test]
+    fn parses_viewer_message() {
+        let msg = parse_twitch_envelope(VIEWER_MSG).unwrap().unwrap();
+        assert_eq!(msg.id, "cc106a89-1814-919d-454c-f4f2f970aae7");
+        assert_eq!(msg.username, "viewer32");
+        assert_eq!(msg.display_name, "viewer32");
+        assert_eq!(msg.platform_user_id, "4145994");
+        assert_eq!(msg.message_text, "Hi chat");
+        assert_eq!(msg.color.as_deref(), Some("#00FF7F"));
+        assert!(matches!(msg.platform, Platform::Twitch));
+        assert!(!msg.is_mod);
+        assert!(!msg.is_subscriber);
+        assert!(!msg.is_broadcaster);
+        assert!(msg.reply_to.is_none());
+        assert!(msg.timestamp > 0);
+        assert!(msg.arrival_time >= msg.timestamp || msg.arrival_time > 0);
+    }
+
+    #[test]
+    fn parses_moderator_flags() {
+        let msg = parse_twitch_envelope(MOD_MSG).unwrap().unwrap();
+        assert!(msg.is_mod);
+        assert!(msg.is_subscriber);
+        assert!(!msg.is_broadcaster);
+        assert_eq!(msg.badges.len(), 2);
+    }
+
+    #[test]
+    fn broadcaster_implies_mod() {
+        let msg = parse_twitch_envelope(BROADCASTER_MSG).unwrap().unwrap();
+        assert!(msg.is_broadcaster);
+        assert!(msg.is_mod);
+    }
+
+    #[test]
+    fn parses_reply_parent_id() {
+        let msg = parse_twitch_envelope(REPLY_MSG).unwrap().unwrap();
+        assert_eq!(msg.reply_to.as_deref(), Some("parent-abc"));
+    }
+
+    #[test]
+    fn keepalive_returns_none() {
+        let result = parse_twitch_envelope(KEEPALIVE).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn other_notification_types_return_none() {
+        let result = parse_twitch_envelope(OTHER_NOTIFICATION).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn malformed_json_returns_err() {
+        let err = parse_twitch_envelope(b"not json").unwrap_err();
+        assert!(matches!(err, ParseError::Json(_)));
+    }
+
+    #[test]
+    fn bad_timestamp_returns_err() {
+        let bytes: &[u8] = br##"{
+            "metadata": {
+                "message_id": "m",
+                "message_type": "notification",
+                "message_timestamp": "not a date"
+            },
+            "payload": {
+                "subscription": { "type": "channel.chat.message" },
+                "event": {
+                    "chatter_user_id": "1",
+                    "chatter_user_login": "u",
+                    "chatter_user_name": "U",
+                    "message_id": "m",
+                    "message": { "text": "x" }
+                }
+            }
+        }"##;
+        let err = parse_twitch_envelope(bytes).unwrap_err();
+        assert!(matches!(err, ParseError::Timestamp(_)));
+    }
+
+    #[test]
+    fn parse_error_display_and_source() {
+        let err = parse_twitch_envelope(b"}{").unwrap_err();
+        let _ = err.to_string();
+        assert!(std::error::Error::source(&err).is_some());
+    }
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -28,6 +28,8 @@ ignore:
   - "apps/desktop/node_modules/"
   - "apps/desktop/dist/"
   - "apps/desktop/src-sidecar/cmd/" # entry-point shims; logic lives in internal/sidecar
+  - "apps/desktop/src-tauri/src/lib.rs" # tauri entry + setup wiring; logic lives in host.rs
+  - "apps/desktop/src-tauri/src/main.rs" # 3-line binary shim
 
 comment:
   layout: "reach,diff,flags"


### PR DESCRIPTION
Implements [PRI-6](https://linear.app/frostcrypt/issue/PRI-6). First end-to-end Twitch message milestone: Rust host creates the shm section, spawns the sidecar with an inherited HANDLE, writes the bootstrap line, optionally auto-connects with env creds, drains the ring every 16 ms, parses envelopes, and emits batches to the Solid frontend.

## lifecycle

1. `RingBufReader::create_owner(DEFAULT_CAPACITY)` creates the unnamed shm section
2. `SetHandleInformation(HANDLE_FLAG_INHERIT)` marks it inheritable
3. Tauri shell plugin spawns the sidecar (stdio inherited, HANDLE inherited via default `bInheritHandles=TRUE`)
4. `SetHandleInformation(HANDLE_FLAGS(0))` un-marks immediately to close the race window where another child could inherit the same HANDLE
5. Bootstrap JSON `{"shm_handle": <u64>, "shm_size": <u64>}` written to the sidecar's stdin via `CommandChild::write`
6. If all four `PRISMOID_TWITCH_*` env vars are present, a `twitch_connect` command follows
7. A background task drains `CommandEvent::Stdout`/`Stderr`/`Terminated` for logging
8. The main drain task ticks every 16 ms via `tokio::time::interval` (with `MissedTickBehavior::Skip`), calls `reader.drain()`, parses each payload, emits `chat_messages` batch via `Emitter::emit`

## parser

`message.rs::parse_twitch_envelope(&[u8]) -> Result<Option<UnifiedMessage>, ParseError>` deserializes a Twitch EventSub `channel.chat.message` notification into the unified format. Returns `Ok(None)` for keepalives, reconnects, revocations, or notifications of other subscription types (those are filtered, not errors). Event field is held as `serde_json::Value` and deserialized to the concrete chat event type only after the subscription type matches, so non-chat notifications parse cleanly without failing on missing chat-specific fields. Platform timestamp is parsed from RFC 3339 via chrono. Badges are mapped to the unified shape; `is_mod` / `is_subscriber` / `is_broadcaster` flags are derived from badge set ids.

Each parse in `parse_batch` is wrapped in `std::panic::catch_unwind` so a malformed envelope cannot kill the drain loop (per `docs/stability.md` §Rust Panic Handling).

## file layout

- `src/host.rs` — pure testable helpers: `parse_batch`, `build_bootstrap_line`, `build_twitch_connect_line`, `twitch_creds_from_env`, `mark_handle_inheritable` / `unmark_handle_inheritable`, `TwitchCreds`. All at 97%+ coverage.
- `src/message.rs` — parser, fixtures, error type
- `src/lib.rs` — Tauri setup wiring + `run_drain_loop` (untestable without a real Tauri app; added to codecov ignore, same pattern as PRI-2's `cmd/sidecar`)

## new deps

- `chrono = "0.4"` (already a transitive dep; added with `std` + `clock` features for RFC 3339 parsing and `Utc::now`)
- `tokio = "1"` with `time` feature for the drain interval ticker

## tests

Rust lib now has 28 passing tests (was 12):

- `host::tests::*` (7) — bootstrap line, twitch_connect line, parse_batch filtering, empty input, env creds missing/present, handle inheritance round-trip (Windows)
- `message::tests::*` (9) — viewer message, moderator flags, broadcaster implies mod, reply parent id, keepalive filter, other notification types filter, malformed JSON, bad timestamp, error display + source
- `ringbuf::tests::*` (12) — unchanged from PRI-5

## out of scope

- Sidecar respawn on heartbeat loss (separate ticket)
- OAuth flow (env var creds only)
- YouTube, Kick (future tickets)
- `chatStore` ADR 21 rewrite (PRI-7)
- True drop-oldest backpressure at the ring buffer layer (separate ticket — current behavior is drop-newest, which does not match `docs/architecture.md`)

Closes PRI-6.