### PR TITLE
feat: chatstore ring buffer with per-frame viewport signal

### DIFF
--- a/apps/desktop/src/components/ChatFeed.tsx
+++ b/apps/desktop/src/components/ChatFeed.tsx
@@ -1,6 +1,18 @@
-import { Component, For, createEffect, onMount, onCleanup } from "solid-js";
-import { messages, addMessages, type ChatMessage } from "../stores/chatStore";
+import {
+  Component,
+  For,
+  createEffect,
+  createMemo,
+  onCleanup,
+  onMount,
+} from "solid-js";
 import { listen } from "@tauri-apps/api/event";
+import {
+  addMessages,
+  getMessage,
+  viewport,
+  type ChatMessage,
+} from "../stores/chatStore";
 
 const ChatFeed: Component = () => {
   let containerRef: HTMLDivElement | undefined;
@@ -18,8 +30,23 @@ const ChatFeed: Component = () => {
     userScrolledUp = scrollHeight - scrollTop - clientHeight > 40;
   };
 
+  // Derive the visible message slice from the viewport signal. The ring
+  // buffer stores stable references, so `<For>` reuses DOM nodes for messages
+  // that remain in the visible window across frames. The per-frame array
+  // allocation is bounded by maxMessages and matches ADR 21's "one viewport
+  // update per frame" contract.
+  const visibleMessages = createMemo<ChatMessage[]>(() => {
+    const v = viewport();
+    const out: ChatMessage[] = [];
+    for (let i = 0; i < v.count; i++) {
+      const msg = getMessage(v.start + i);
+      if (msg) out.push(msg);
+    }
+    return out;
+  });
+
   createEffect(() => {
-    messages();
+    visibleMessages();
     scrollToBottom();
   });
 
@@ -44,7 +71,7 @@ const ChatFeed: Component = () => {
         "will-change": "transform",
       }}
     >
-      <For each={messages()}>
+      <For each={visibleMessages()}>
         {(msg) => (
           <div style={{ padding: "2px 0", "line-height": "1.4" }}>
             <span

--- a/apps/desktop/src/stores/chatStore.test.ts
+++ b/apps/desktop/src/stores/chatStore.test.ts
@@ -1,28 +1,152 @@
-import { describe, it, expect } from "vitest";
-import { messages, addMessages } from "./chatStore";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createChatStore, type ChatMessage } from "./chatStore";
+
+function makeMsg(id: string, text = `msg ${id}`): ChatMessage {
+  return {
+    id,
+    platform: "Twitch",
+    timestamp: 0,
+    arrival_time: 0,
+    username: "u",
+    display_name: "U",
+    platform_user_id: "1",
+    message_text: text,
+    badges: [],
+    is_mod: false,
+    is_subscriber: false,
+    is_broadcaster: false,
+    color: null,
+    reply_to: null,
+  };
+}
 
 describe("chatStore", () => {
-  it("adds messages to the buffer", () => {
-    addMessages([
-      {
-        id: "1",
-        platform: "Twitch",
-        timestamp: Date.now(),
-        arrival_time: Date.now(),
-        username: "testuser",
-        display_name: "TestUser",
-        platform_user_id: "123",
-        message_text: "hello world",
-        badges: [],
-        is_mod: false,
-        is_subscriber: false,
-        is_broadcaster: false,
-        color: "#ff0000",
-        reply_to: null,
-      },
-    ]);
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
 
-    expect(messages().length).toBe(1);
-    expect(messages()[0].message_text).toBe("hello world");
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts with empty viewport", () => {
+    const store = createChatStore(10);
+    expect(store.viewport()).toEqual({ start: 0, count: 0 });
+  });
+
+  it("rejects non-positive maxMessages", () => {
+    expect(() => createChatStore(0)).toThrow();
+    expect(() => createChatStore(-5)).toThrow();
+  });
+
+  it("addMessages writes synchronously but defers viewport update to RAF", () => {
+    const store = createChatStore(10);
+    store.addMessages([makeMsg("1"), makeMsg("2")]);
+
+    // Viewport is still stale before RAF fires.
+    expect(store.viewport()).toEqual({ start: 0, count: 0 });
+    // getMessage reflects writes immediately.
+    expect(store.getMessage(0)?.id).toBe("1");
+    expect(store.getMessage(1)?.id).toBe("2");
+
+    vi.runAllTimers();
+
+    expect(store.viewport()).toEqual({ start: 0, count: 2 });
+  });
+
+  it("coalesces multiple batches in the same frame into one viewport update", () => {
+    const store = createChatStore(10);
+    const calls: number[] = [];
+    // Spy on the signal by polling its value after each flush.
+    store.addMessages([makeMsg("1")]);
+    store.addMessages([makeMsg("2")]);
+    store.addMessages([makeMsg("3")]);
+
+    expect(store.viewport().count).toBe(0);
+    vi.runAllTimers();
+    expect(store.viewport().count).toBe(3);
+
+    // A second tick with nothing new should not change the viewport.
+    calls.push(store.viewport().count);
+    vi.runAllTimers();
+    expect(store.viewport().count).toBe(3);
+  });
+
+  it("empty batches are no-ops and do not schedule a frame", () => {
+    const store = createChatStore(10);
+    const rafSpy = vi.spyOn(globalThis, "requestAnimationFrame");
+    store.addMessages([]);
+    expect(rafSpy).not.toHaveBeenCalled();
+    rafSpy.mockRestore();
+  });
+
+  it("wraps around and evicts the oldest messages", () => {
+    const store = createChatStore(3);
+    store.addMessages([makeMsg("1"), makeMsg("2"), makeMsg("3"), makeMsg("4")]);
+    vi.runAllTimers();
+
+    expect(store.viewport()).toEqual({ start: 1, count: 3 });
+    // Evicted: index 0 should be undefined.
+    expect(store.getMessage(0)).toBeUndefined();
+    // Still present: 1, 2, 3.
+    expect(store.getMessage(1)?.id).toBe("2");
+    expect(store.getMessage(2)?.id).toBe("3");
+    expect(store.getMessage(3)?.id).toBe("4");
+  });
+
+  it("getMessage returns undefined for out-of-range indices", () => {
+    const store = createChatStore(5);
+    store.addMessages([makeMsg("1"), makeMsg("2")]);
+    vi.runAllTimers();
+
+    expect(store.getMessage(-1)).toBeUndefined();
+    expect(store.getMessage(2)).toBeUndefined();
+    expect(store.getMessage(100)).toBeUndefined();
+  });
+
+  it("isolates state between stores", () => {
+    const a = createChatStore(10);
+    const b = createChatStore(10);
+    a.addMessages([makeMsg("a1")]);
+    b.addMessages([makeMsg("b1"), makeMsg("b2")]);
+    vi.runAllTimers();
+
+    expect(a.viewport().count).toBe(1);
+    expect(b.viewport().count).toBe(2);
+    expect(a.getMessage(0)?.id).toBe("a1");
+    expect(b.getMessage(0)?.id).toBe("b1");
+  });
+
+  it("viewport.start advances monotonically with wraparound", () => {
+    const store = createChatStore(3);
+    store.addMessages([makeMsg("1"), makeMsg("2"), makeMsg("3")]);
+    vi.runAllTimers();
+    expect(store.viewport()).toEqual({ start: 0, count: 3 });
+
+    store.addMessages([makeMsg("4")]);
+    vi.runAllTimers();
+    expect(store.viewport()).toEqual({ start: 1, count: 3 });
+
+    store.addMessages([makeMsg("5"), makeMsg("6")]);
+    vi.runAllTimers();
+    expect(store.viewport()).toEqual({ start: 3, count: 3 });
+  });
+
+  it("only issues one requestAnimationFrame call per frame", () => {
+    const store = createChatStore(10);
+    const rafSpy = vi.spyOn(globalThis, "requestAnimationFrame");
+
+    store.addMessages([makeMsg("1")]);
+    store.addMessages([makeMsg("2")]);
+    store.addMessages([makeMsg("3")]);
+    expect(rafSpy).toHaveBeenCalledTimes(1);
+
+    vi.runAllTimers();
+
+    // After the flush, a new batch schedules a fresh frame.
+    store.addMessages([makeMsg("4")]);
+    expect(rafSpy).toHaveBeenCalledTimes(2);
+
+    rafSpy.mockRestore();
   });
 });

--- a/apps/desktop/src/stores/chatStore.test.ts
+++ b/apps/desktop/src/stores/chatStore.test.ts
@@ -56,8 +56,6 @@ describe("chatStore", () => {
 
   it("coalesces multiple batches in the same frame into one viewport update", () => {
     const store = createChatStore(10);
-    const calls: number[] = [];
-    // Spy on the signal by polling its value after each flush.
     store.addMessages([makeMsg("1")]);
     store.addMessages([makeMsg("2")]);
     store.addMessages([makeMsg("3")]);
@@ -67,7 +65,6 @@ describe("chatStore", () => {
     expect(store.viewport().count).toBe(3);
 
     // A second tick with nothing new should not change the viewport.
-    calls.push(store.viewport().count);
     vi.runAllTimers();
     expect(store.viewport().count).toBe(3);
   });

--- a/apps/desktop/src/stores/chatStore.ts
+++ b/apps/desktop/src/stores/chatStore.ts
@@ -1,3 +1,7 @@
+// ADR 21 + docs/frontend.md: plain TS ring buffer outside Solid reactivity,
+// one viewport signal per frame. The virtual scroller reads messages from
+// the ring by monotonic index.
+
 import { createSignal } from "solid-js";
 
 export interface ChatMessage {
@@ -17,16 +21,79 @@ export interface ChatMessage {
   reply_to: string | null;
 }
 
-const MAX_MESSAGES = 5000;
-const buffer: ChatMessage[] = [];
-const [messages, setMessages] = createSignal<ChatMessage[]>([]);
-
-export function addMessages(batch: ChatMessage[]) {
-  buffer.push(...batch);
-  if (buffer.length > MAX_MESSAGES) {
-    buffer.splice(0, buffer.length - MAX_MESSAGES);
-  }
-  setMessages([...buffer]);
+export interface Viewport {
+  /** Monotonic index of the oldest message currently in the ring. */
+  start: number;
+  /** Number of valid messages in the ring (≤ maxMessages). */
+  count: number;
 }
 
-export { messages };
+export interface ChatStore {
+  viewport: () => Viewport;
+  addMessages: (batch: ChatMessage[]) => void;
+  getMessage: (monoIndex: number) => ChatMessage | undefined;
+}
+
+export const DEFAULT_MAX_MESSAGES = 5000;
+
+/**
+ * Creates a chat store backed by a plain pre-allocated ring buffer. Writes
+ * happen synchronously; the single viewport signal is batched into one
+ * `requestAnimationFrame` tick so multiple batches arriving within the same
+ * frame coalesce into exactly one reactive update.
+ */
+export function createChatStore(maxMessages = DEFAULT_MAX_MESSAGES): ChatStore {
+  if (maxMessages <= 0) {
+    throw new Error(`maxMessages must be positive, got ${maxMessages}`);
+  }
+
+  // Pre-allocated ring. Undefined slots only exist before writeIndex reaches
+  // maxMessages for the first time; getMessage guards against reading them.
+  const ring: (ChatMessage | undefined)[] = new Array<ChatMessage | undefined>(
+    maxMessages,
+  );
+  let writeIndex = 0;
+  let rafPending = false;
+
+  const [viewport, setViewport] = createSignal<Viewport>({
+    start: 0,
+    count: 0,
+  });
+
+  function addMessages(batch: ChatMessage[]): void {
+    if (batch.length === 0) return;
+    for (const msg of batch) {
+      ring[writeIndex % maxMessages] = msg;
+      writeIndex++;
+    }
+    scheduleViewportUpdate();
+  }
+
+  function scheduleViewportUpdate(): void {
+    if (rafPending) return;
+    rafPending = true;
+    requestAnimationFrame(() => {
+      rafPending = false;
+      setViewport({
+        start: Math.max(0, writeIndex - maxMessages),
+        count: Math.min(writeIndex, maxMessages),
+      });
+    });
+  }
+
+  function getMessage(monoIndex: number): ChatMessage | undefined {
+    if (monoIndex < 0 || monoIndex >= writeIndex) return undefined;
+    // evicted by wraparound
+    if (monoIndex < writeIndex - maxMessages) return undefined;
+    return ring[monoIndex % maxMessages];
+  }
+
+  return { viewport, addMessages, getMessage };
+}
+
+// Default singleton used by the production app.
+const defaultStore = createChatStore();
+
+export const viewport = defaultStore.viewport;
+export const addMessages = defaultStore.addMessages;
+export const getMessage = defaultStore.getMessage;


### PR DESCRIPTION
Implements [PRI-7](https://linear.app/frostcrypt/issue/PRI-7). Rewrites the chat store to match ADR 21 and `docs/frontend.md` §State Management: plain pre-allocated ring buffer outside Solid reactivity, single viewport signal coalesced to one update per frame via `requestAnimationFrame`.

## what changes

### `src/stores/chatStore.ts`

- Factory function `createChatStore(maxMessages)` returns `{ viewport, addMessages, getMessage }`
- Plain `Array<ChatMessage | undefined>` of length `maxMessages` as the ring, monotonic `writeIndex` counter
- `addMessages(batch)` writes synchronously into the ring at `writeIndex % maxMessages` slots; schedules exactly one RAF callback to fire `setViewport` regardless of how many batches arrive in the same frame
- `viewport()` returns `{ start, count }` where `start` is the monotonic index of the oldest retained message and `count = min(writeIndex, maxMessages)`
- `getMessage(monoIndex)` returns the message at that monotonic index, or `undefined` if it has been evicted by wraparound
- Default singleton exported for production use; tests instantiate their own isolated stores via the factory

### `src/components/ChatFeed.tsx`

- Rendered messages are derived from `viewport()` via `createMemo` + a tight loop over `getMessage(start + i)`
- `<For>` over the derived array — ring slots hold stable references, so `<For>`'s keyed reconciliation reuses DOM nodes for messages that persist across frames
- Scroll-to-bottom logic unchanged

### `src/stores/chatStore.test.ts`

Rewritten to use `vi.useFakeTimers()` so `requestAnimationFrame` is deterministic. 10 tests covering:

1. initial empty viewport
2. rejects non-positive `maxMessages`
3. `addMessages` writes sync, viewport deferred to RAF
4. multiple batches within a frame coalesce into one viewport update
5. empty batches do not schedule a frame
6. wraparound evicts oldest messages
7. `getMessage` returns undefined out-of-range
8. independent stores isolate state
9. `viewport.start` advances monotonically with wraparound
10. exactly one `requestAnimationFrame` call per frame regardless of batch count

## out of scope

- Pretext integration, height pre-computation, true DOM virtualization — separate tickets per `docs/frontend.md` §Virtual Scrolling
- `<For>` currently renders all `count` messages; bounded by `DEFAULT_MAX_MESSAGES = 5000`. Sufficient until a virtualization ticket lands.

Closes PRI-7.