### PR TITLE
feat: load .env.local for phase 0 dev creds

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -642,6 +642,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2488,6 +2494,7 @@ name = "prismoid"
 version = "0.0.1"
 dependencies = [
  "chrono",
+ "dotenvy",
  "serde",
  "serde_json",
  "tauri",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -14,6 +14,7 @@ tauri-build = { version = "2.5", features = [] }
 tauri = { version = "2.10", features = [] }
 tauri-plugin-shell = "2.3"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
+dotenvy = "0.15"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["time"] }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -16,11 +16,17 @@ fn get_platform() -> &'static str {
 }
 
 pub fn run() {
-    // Phase 0 dev convenience: load `.env.local` from cwd or any parent before
-    // anything reads PRISMOID_TWITCH_*. Production builds with no .env.local
-    // present silently no-op (the Err is dropped). Real secret storage uses
-    // OS keychain via OAuth, see docs/platform-apis.md §Twitch.
-    let _ = dotenvy::from_filename(".env.local");
+    // Phase 0 dev convenience: in debug builds only, load `.env.local` from
+    // cwd or any parent before anything reads PRISMOID_TWITCH_*. Release
+    // builds skip this entirely so a stray file in the install dir cannot
+    // change runtime behavior. Real secret storage uses OS keychain via
+    // OAuth, see docs/platform-apis.md §Twitch.
+    #[cfg(debug_assertions)]
+    match dotenvy::from_filename(".env.local") {
+        Ok(_) => {}
+        Err(dotenvy::Error::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => eprintln!("failed to load .env.local: {err}"),
+    }
 
     tracing_subscriber::fmt()
         .with_env_filter(

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -16,6 +16,12 @@ fn get_platform() -> &'static str {
 }
 
 pub fn run() {
+    // Phase 0 dev convenience: load `.env.local` from cwd or any parent before
+    // anything reads PRISMOID_TWITCH_*. Production builds with no .env.local
+    // present silently no-op (the Err is dropped). Real secret storage uses
+    // OS keychain via OAuth, see docs/platform-apis.md §Twitch.
+    let _ = dotenvy::from_filename(".env.local");
+
     tracing_subscriber::fmt()
         .with_env_filter(
             EnvFilter::from_default_env().add_directive("prismoid=debug".parse().unwrap()),


### PR DESCRIPTION
Implements [PRI-9](https://linear.app/frostcrypt/issue/PRI-9). Phase 0 dev convenience: auto-load `.env.local` so `cargo tauri dev` picks up the four `PRISMOID_TWITCH_*` vars without manual `export`.

## what

- Add `dotenvy = "0.15"` to `apps/desktop/src-tauri/Cargo.toml`
- Call `dotenvy::from_filename(".env.local")` at the very top of `lib::run()`, before tracing init and before host::setup reads the env. The `Result` is dropped via `let _ =` so a missing `.env.local` is silently a no-op
- `.env.local` is already covered by `~/.gitignore_global` (the existing `.env.local` and `.env*.local` patterns under "Environment"), so committing it is impossible without `git add -f`

## why

Phase 0 reads creds from env vars per PRI-6. Without this PR, every `cargo tauri dev` needs `export PRISMOID_TWITCH_*` first. With this PR you create one file once, then the dev loop is just `cargo tauri dev`.

## not in this pr

- OAuth + OS keychain — that's the **production** secret path per `docs/platform-apis.md` §Twitch ("Token storage: OS keychain (never plaintext)"). Filed as a Phase 1 effort.
- Client Secret handling — desktop apps use Authorization Code + PKCE, no client secret ever shipped.

## verification

`cargo build` / `cargo test --lib` / `cargo clippy --lib -- -D warnings` / `cargo fmt -- --check` all clean. 28/28 tests pass.

Closes PRI-9.