### PR TITLE
perf: kernel event signal for sidecar to host ring wakeups

### DIFF
--- a/apps/desktop/src-sidecar/internal/control/control.go
+++ b/apps/desktop/src-sidecar/internal/control/control.go
@@ -3,9 +3,15 @@ package control
 // Bootstrap is the first message the Rust host writes to the sidecar's stdin
 // at startup. It hands over the inherited shared memory section so the sidecar
 // can attach without having to know a name or open a kernel object by lookup.
+//
+// ShmEventHandle is an auto-reset Windows Event created by the host alongside
+// the mapping. The writer goroutine calls SetEvent on it after each successful
+// ring write so the host can wake from WaitForSingleObject immediately instead
+// of polling on a timer.
 type Bootstrap struct {
-	ShmHandle uintptr `json:"shm_handle"`
-	ShmSize   int     `json:"shm_size"`
+	ShmHandle      uintptr `json:"shm_handle"`
+	ShmEventHandle uintptr `json:"shm_event_handle"`
+	ShmSize        int     `json:"shm_size"`
 }
 
 // Command is a control-plane message from the Rust host received over stdin

--- a/apps/desktop/src-sidecar/internal/ringbuf/shm_darwin.go
+++ b/apps/desktop/src-sidecar/internal/ringbuf/shm_darwin.go
@@ -9,3 +9,14 @@ import "fmt"
 func Attach(_ uintptr, _ int) ([]byte, func(), error) {
 	return nil, nil, fmt.Errorf("ring buffer attach not yet supported on darwin")
 }
+
+// Notify is not yet implemented on macOS. The macOS port will use a Mach
+// semaphore or kqueue notification.
+func Notify(_ uintptr) error {
+	return fmt.Errorf("ring buffer notify not yet supported on darwin")
+}
+
+// CloseEventHandle is a no-op on macOS until the native implementation lands.
+func CloseEventHandle(_ uintptr) error {
+	return nil
+}

--- a/apps/desktop/src-sidecar/internal/ringbuf/shm_linux.go
+++ b/apps/desktop/src-sidecar/internal/ringbuf/shm_linux.go
@@ -9,3 +9,14 @@ import "fmt"
 func Attach(_ uintptr, _ int) ([]byte, func(), error) {
 	return nil, nil, fmt.Errorf("ring buffer attach not yet supported on linux")
 }
+
+// Notify is not yet implemented on Linux. The Linux port will use eventfd
+// instead of a Windows Event.
+func Notify(_ uintptr) error {
+	return fmt.Errorf("ring buffer notify not yet supported on linux")
+}
+
+// CloseEventHandle is a no-op on Linux until the eventfd implementation lands.
+func CloseEventHandle(_ uintptr) error {
+	return nil
+}

--- a/apps/desktop/src-sidecar/internal/ringbuf/shm_windows.go
+++ b/apps/desktop/src-sidecar/internal/ringbuf/shm_windows.go
@@ -44,3 +44,33 @@ func Attach(handle uintptr, size int) ([]byte, func(), error) {
 
 	return mem, cleanup, nil
 }
+
+// Notify signals the auto-reset Windows Event owned by the Rust host. Called
+// by the writer goroutine after each successful ring buffer write so the host
+// can wake from WaitForSingleObject immediately instead of polling on a timer.
+// The host's WaitForSingleObject acts as a full memory barrier on its side,
+// and the atomic.StoreUint64 of the write index inside `Writer.Write` already
+// acts as a release store on this side, so no extra fence is required here.
+func Notify(eventHandle uintptr) error {
+	if eventHandle == 0 {
+		return fmt.Errorf("invalid event handle 0")
+	}
+	if err := windows.SetEvent(windows.Handle(eventHandle)); err != nil {
+		return fmt.Errorf("SetEvent: %w", err)
+	}
+	return nil
+}
+
+// CloseEventHandle releases the inherited event HANDLE on shutdown. Called
+// from sidecar cleanup alongside the ring buffer cleanup. Separate from
+// Attach's cleanup because the event handle lifetime is independent of the
+// ring mapping.
+func CloseEventHandle(eventHandle uintptr) error {
+	if eventHandle == 0 {
+		return nil
+	}
+	if err := windows.CloseHandle(windows.Handle(eventHandle)); err != nil {
+		return fmt.Errorf("CloseHandle event: %w", err)
+	}
+	return nil
+}

--- a/apps/desktop/src-sidecar/internal/ringbuf/shm_windows_test.go
+++ b/apps/desktop/src-sidecar/internal/ringbuf/shm_windows_test.go
@@ -67,3 +67,75 @@ func TestAttachRoundTrip(t *testing.T) {
 		t.Fatal("shared memory read/write failed")
 	}
 }
+
+// createTestEvent creates an auto-reset unnamed Windows Event for Notify tests.
+// The caller is responsible for closing the returned handle.
+func createTestEvent(t *testing.T) windows.Handle {
+	t.Helper()
+	handle, err := windows.CreateEvent(nil, 0, 0, nil)
+	if err != nil {
+		t.Fatalf("CreateEvent: %v", err)
+	}
+	return handle
+}
+
+func TestNotifyRejectsZeroHandle(t *testing.T) {
+	if err := Notify(0); err == nil {
+		t.Fatal("expected error for zero event handle")
+	}
+}
+
+func TestNotifyRejectsInvalidHandle(t *testing.T) {
+	// An arbitrary non-zero value that is not a valid HANDLE. SetEvent returns
+	// ERROR_INVALID_HANDLE which our wrapper surfaces as a wrapped error.
+	if err := Notify(uintptr(0xDEADBEEF)); err == nil {
+		t.Fatal("expected error for invalid event handle")
+	}
+}
+
+func TestNotifySignalsEvent(t *testing.T) {
+	handle := createTestEvent(t)
+	defer func() { _ = windows.CloseHandle(handle) }()
+
+	if err := Notify(uintptr(handle)); err != nil {
+		t.Fatalf("Notify: %v", err)
+	}
+
+	// After Notify, a zero-timeout Wait should return WAIT_OBJECT_0 (auto-reset
+	// consumes the signal). A second Wait should return WAIT_TIMEOUT.
+	result, err := windows.WaitForSingleObject(handle, 0)
+	if err != nil {
+		t.Fatalf("WaitForSingleObject: %v", err)
+	}
+	if result != windows.WAIT_OBJECT_0 {
+		t.Fatalf("expected WAIT_OBJECT_0 after Notify, got %#x", result)
+	}
+
+	result, err = windows.WaitForSingleObject(handle, 0)
+	if err != nil {
+		t.Fatalf("WaitForSingleObject second: %v", err)
+	}
+	if result != uint32(windows.WAIT_TIMEOUT) {
+		t.Fatalf("expected WAIT_TIMEOUT after auto-reset, got %#x", result)
+	}
+}
+
+func TestCloseEventHandleZeroIsNoOp(t *testing.T) {
+	if err := CloseEventHandle(0); err != nil {
+		t.Fatalf("expected zero handle to be no-op, got %v", err)
+	}
+}
+
+func TestCloseEventHandleSuccess(t *testing.T) {
+	handle := createTestEvent(t)
+	if err := CloseEventHandle(uintptr(handle)); err != nil {
+		t.Fatalf("CloseEventHandle: %v", err)
+	}
+}
+
+func TestCloseEventHandleRejectsInvalid(t *testing.T) {
+	// Closing a bogus handle should surface the underlying CloseHandle error.
+	if err := CloseEventHandle(uintptr(0xDEADBEEF)); err == nil {
+		t.Fatal("expected error closing invalid handle")
+	}
+}

--- a/apps/desktop/src-sidecar/internal/sidecar/sidecar.go
+++ b/apps/desktop/src-sidecar/internal/sidecar/sidecar.go
@@ -96,15 +96,8 @@ func RunWithIO(
 	}
 
 	out := make(chan []byte, outChanCapacity)
-	eventHandle := boot.ShmEventHandle
-	go RunWriter(ctx, out, writer, func() {
-		if eventHandle == 0 {
-			return
-		}
-		if err := notify(eventHandle); err != nil {
-			logger.Warn().Err(err).Msg("failed to signal ring buffer event")
-		}
-	})
+	signal := MakeSignalFunc(boot.ShmEventHandle, notify, logger)
+	go RunWriter(ctx, out, writer, signal)
 
 	return RunCommandLoop(ctx, scanner, json.NewEncoder(stdout), out, logger)
 }
@@ -112,6 +105,30 @@ func RunWithIO(
 // NotifyFunc signals the host that new data has been written to the ring
 // buffer. The production impl is ringbuf.Notify; tests inject a fake.
 type NotifyFunc func(eventHandle uintptr) error
+
+// MakeSignalFunc builds the no-argument callback that [`RunWriter`] invokes
+// after each successful ring buffer write. The callback is a thin wrapper
+// around the provided NotifyFunc that:
+//
+//   - No-ops when eventHandle is 0 (bootstrap did not include an event, e.g.
+//     under a Rust host version that pre-dates PRI-12 or on non-Windows
+//     platforms that haven't wired eventfd/Mach semaphores yet).
+//   - Logs at Warn level if the NotifyFunc returns an error, so a transient
+//     SetEvent failure shows up in the host's stderr log drain without
+//     stalling or panicking the writer goroutine.
+//
+// Extracted from the inline closure in RunWithIO so the branching logic is
+// unit-testable.
+func MakeSignalFunc(eventHandle uintptr, notify NotifyFunc, logger zerolog.Logger) func() {
+	return func() {
+		if eventHandle == 0 {
+			return
+		}
+		if err := notify(eventHandle); err != nil {
+			logger.Warn().Err(err).Msg("failed to signal ring buffer event")
+		}
+	}
+}
 
 // ReadBootstrap consumes a single line from the scanner and decodes it as a
 // control.Bootstrap message. Returns an error on EOF or invalid JSON.

--- a/apps/desktop/src-sidecar/internal/sidecar/sidecar.go
+++ b/apps/desktop/src-sidecar/internal/sidecar/sidecar.go
@@ -45,7 +45,7 @@ func Run() error {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
-	return RunWithIO(ctx, os.Stdin, os.Stdout, log.Logger, ringbuf.Attach)
+	return RunWithIO(ctx, os.Stdin, os.Stdout, log.Logger, ringbuf.Attach, ringbuf.Notify)
 }
 
 // AttachFunc opens a shared memory section by handle. The production
@@ -55,7 +55,18 @@ type AttachFunc func(handle uintptr, size int) ([]byte, func(), error)
 // RunWithIO is the testable lifecycle entry: read the bootstrap, attach to
 // the shared memory section via the supplied AttachFunc, spawn the writer
 // goroutine, and run the command loop until ctx is cancelled or stdin closes.
-func RunWithIO(ctx context.Context, stdin io.Reader, stdout io.Writer, logger zerolog.Logger, attach AttachFunc) error {
+//
+// The `notify` callback is invoked by the writer goroutine after each
+// successful ring write. In production it wraps `ringbuf.Notify` (SetEvent on
+// Windows). Tests pass a no-op or a recorder.
+func RunWithIO(
+	ctx context.Context,
+	stdin io.Reader,
+	stdout io.Writer,
+	logger zerolog.Logger,
+	attach AttachFunc,
+	notify NotifyFunc,
+) error {
 	logger.Info().Msg("sidecar starting")
 
 	scanner := readerScanner(stdin)
@@ -65,7 +76,11 @@ func RunWithIO(ctx context.Context, stdin io.Reader, stdout io.Writer, logger ze
 		logger.Error().Err(err).Msg("failed to read bootstrap")
 		return err
 	}
-	logger.Info().Uint64("handle", uint64(boot.ShmHandle)).Int("size", boot.ShmSize).Msg("bootstrap received")
+	logger.Info().
+		Uint64("handle", uint64(boot.ShmHandle)).
+		Uint64("event_handle", uint64(boot.ShmEventHandle)).
+		Int("size", boot.ShmSize).
+		Msg("bootstrap received")
 
 	mem, cleanup, err := attach(boot.ShmHandle, boot.ShmSize)
 	if err != nil {
@@ -81,10 +96,22 @@ func RunWithIO(ctx context.Context, stdin io.Reader, stdout io.Writer, logger ze
 	}
 
 	out := make(chan []byte, outChanCapacity)
-	go RunWriter(ctx, out, writer)
+	eventHandle := boot.ShmEventHandle
+	go RunWriter(ctx, out, writer, func() {
+		if eventHandle == 0 {
+			return
+		}
+		if err := notify(eventHandle); err != nil {
+			logger.Warn().Err(err).Msg("failed to signal ring buffer event")
+		}
+	})
 
 	return RunCommandLoop(ctx, scanner, json.NewEncoder(stdout), out, logger)
 }
+
+// NotifyFunc signals the host that new data has been written to the ring
+// buffer. The production impl is ringbuf.Notify; tests inject a fake.
+type NotifyFunc func(eventHandle uintptr) error
 
 // ReadBootstrap consumes a single line from the scanner and decodes it as a
 // control.Bootstrap message. Returns an error on EOF or invalid JSON.
@@ -104,14 +131,21 @@ func ReadBootstrap(scanner *bufio.Scanner) (control.Bootstrap, error) {
 
 // RunWriter is the sole producer to the ring buffer. Multiple platform clients
 // send raw envelope bytes via `in`; this goroutine drains them serially into
-// the ring buffer.
+// the ring buffer, calling `signal` after each successful write so the host
+// can wake from WaitForSingleObject immediately.
 //
 // Backpressure: when the ring buffer is full, writer.Write returns false and
 // the current message is dropped (drop-newest). docs/architecture.md describes
 // drop-oldest semantics at the ring buffer layer; the current SPSC primitive
 // cannot evict already-written messages without reader-side cooperation that
 // has not been built yet. Tracked separately.
-func RunWriter(ctx context.Context, in <-chan []byte, writer *ringbuf.Writer) {
+//
+// Memory ordering: `writer.Write` ends with an atomic.StoreUint64 on the
+// write index (release store in Go's memory model). `signal` ultimately makes
+// a SetEvent syscall which acts as a full memory barrier, so by the time the
+// host's WaitForSingleObject returns and it loads the write index with
+// Acquire ordering, the payload bytes are guaranteed visible.
+func RunWriter(ctx context.Context, in <-chan []byte, writer *ringbuf.Writer, signal func()) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -119,7 +153,9 @@ func RunWriter(ctx context.Context, in <-chan []byte, writer *ringbuf.Writer) {
 		case data := <-in:
 			if !writer.Write(data) {
 				log.Warn().Msg("ring buffer full, dropping message")
+				continue
 			}
+			signal()
 		}
 	}
 }

--- a/apps/desktop/src-sidecar/internal/sidecar/sidecar.go
+++ b/apps/desktop/src-sidecar/internal/sidecar/sidecar.go
@@ -89,6 +89,16 @@ func RunWithIO(
 	}
 	defer cleanup()
 
+	// The host also inherited the event HANDLE separately; close our copy on
+	// shutdown so the handle count doesn't grow over the sidecar's lifetime.
+	// The host keeps its own reference and continues to own the underlying
+	// kernel object.
+	defer func() {
+		if err := ringbuf.CloseEventHandle(boot.ShmEventHandle); err != nil {
+			logger.Warn().Err(err).Msg("failed to close inherited event handle on shutdown")
+		}
+	}()
+
 	writer, err := ringbuf.Open(mem)
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to open ring buffer writer")

--- a/apps/desktop/src-sidecar/internal/sidecar/sidecar_test.go
+++ b/apps/desktop/src-sidecar/internal/sidecar/sidecar_test.go
@@ -395,6 +395,43 @@ func TestMakeNotify_SerializesConcurrentWrites(t *testing.T) {
 // about signaling. Returns nil without side effects.
 func nopNotify(_ uintptr) error { return nil }
 
+func TestMakeSignalFunc_NoopsOnZeroEventHandle(t *testing.T) {
+	var called atomic.Bool
+	notify := func(_ uintptr) error {
+		called.Store(true)
+		return nil
+	}
+	signal := MakeSignalFunc(0, notify, zerolog.Nop())
+	signal()
+	if called.Load() {
+		t.Fatal("notify should not be called when eventHandle is 0")
+	}
+}
+
+func TestMakeSignalFunc_CallsNotifyWithEventHandle(t *testing.T) {
+	var got atomic.Uintptr
+	notify := func(h uintptr) error {
+		got.Store(h)
+		return nil
+	}
+	signal := MakeSignalFunc(0x1234, notify, zerolog.Nop())
+	signal()
+	if got.Load() != 0x1234 {
+		t.Fatalf("expected notify called with 0x1234, got %#x", got.Load())
+	}
+}
+
+func TestMakeSignalFunc_SwallowsNotifyError(t *testing.T) {
+	// A notify that returns an error must not panic or block. The error is
+	// logged at Warn level and the writer goroutine continues.
+	notify := func(_ uintptr) error {
+		return errors.New("set event failed")
+	}
+	signal := MakeSignalFunc(0x42, notify, zerolog.Nop())
+	// Must not panic.
+	signal()
+}
+
 func TestRunWithIO_AttachError(t *testing.T) {
 	// Bootstrap is valid; the AttachFunc fails. RunWithIO must propagate.
 	stdin := strings.NewReader(`{"shm_handle": 1, "shm_event_handle": 2, "shm_size": 4096}` + "\n")

--- a/apps/desktop/src-sidecar/internal/sidecar/sidecar_test.go
+++ b/apps/desktop/src-sidecar/internal/sidecar/sidecar_test.go
@@ -86,10 +86,13 @@ func TestRunWriter_DrainsChannelToRing(t *testing.T) {
 	in <- []byte("hello")
 	in <- []byte("world")
 
+	var signalCount atomic.Int32
+	signal := func() { signalCount.Add(1) }
+
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() {
-		RunWriter(ctx, in, writer)
+		RunWriter(ctx, in, writer, signal)
 		close(done)
 	}()
 
@@ -104,6 +107,11 @@ func TestRunWriter_DrainsChannelToRing(t *testing.T) {
 	if writePos != 18 {
 		t.Errorf("expected write index 18, got %d", writePos)
 	}
+
+	// each successful write should have signaled exactly once
+	if got := signalCount.Load(); got != 2 {
+		t.Errorf("expected 2 signals, got %d", got)
+	}
 }
 
 func TestRunWriter_StopsOnContextCancel(t *testing.T) {
@@ -114,7 +122,7 @@ func TestRunWriter_StopsOnContextCancel(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		RunWriter(ctx, in, writer)
+		RunWriter(ctx, in, writer, func() {})
 		close(done)
 	}()
 
@@ -123,6 +131,35 @@ func TestRunWriter_StopsOnContextCancel(t *testing.T) {
 	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("RunWriter did not exit on context cancel")
+	}
+}
+
+func TestRunWriter_SkipsSignalOnFullRing(t *testing.T) {
+	// Tiny 32-byte data region; each message is 4 bytes framing + 20 bytes
+	// payload = 24 bytes. Second write should fail (capacity 32 < 48).
+	writer, _ := makeTestRingBuffer(t, 32)
+
+	in := make(chan []byte, 4)
+	in <- make([]byte, 20)
+	in <- make([]byte, 20)
+
+	var signalCount atomic.Int32
+	signal := func() { signalCount.Add(1) }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		RunWriter(ctx, in, writer, signal)
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	// Only the first write succeeded, so signal should have fired exactly once.
+	if got := signalCount.Load(); got != 1 {
+		t.Errorf("expected 1 signal (dropped writes must not signal), got %d", got)
 	}
 }
 
@@ -354,16 +391,20 @@ func TestMakeNotify_SerializesConcurrentWrites(t *testing.T) {
 	}
 }
 
+// nopNotify is a stub NotifyFunc used by RunWithIO tests that don't care
+// about signaling. Returns nil without side effects.
+func nopNotify(_ uintptr) error { return nil }
+
 func TestRunWithIO_AttachError(t *testing.T) {
 	// Bootstrap is valid; the AttachFunc fails. RunWithIO must propagate.
-	stdin := strings.NewReader(`{"shm_handle": 1, "shm_size": 4096}` + "\n")
+	stdin := strings.NewReader(`{"shm_handle": 1, "shm_event_handle": 2, "shm_size": 4096}` + "\n")
 	var stdout bytes.Buffer
 
 	fakeAttach := func(uintptr, int) ([]byte, func(), error) {
 		return nil, nil, errors.New("attach failed")
 	}
 
-	err := RunWithIO(context.Background(), stdin, &stdout, zerolog.Nop(), fakeAttach)
+	err := RunWithIO(context.Background(), stdin, &stdout, zerolog.Nop(), fakeAttach, nopNotify)
 	if err == nil || err.Error() != "attach failed" {
 		t.Fatalf("expected attach failed error, got: %v", err)
 	}
@@ -373,7 +414,7 @@ func TestRunWithIO_BootstrapError(t *testing.T) {
 	stdin := strings.NewReader("not json\n")
 	var stdout bytes.Buffer
 
-	err := RunWithIO(context.Background(), stdin, &stdout, zerolog.Nop(), nil)
+	err := RunWithIO(context.Background(), stdin, &stdout, zerolog.Nop(), nil, nopNotify)
 	if err == nil {
 		t.Fatal("expected bootstrap error")
 	}
@@ -385,14 +426,14 @@ func TestRunWithIO_BootstrapError(t *testing.T) {
 func TestRunWithIO_RingbufOpenError(t *testing.T) {
 	// Bootstrap valid, attach returns an undersized buffer that ringbuf.Open
 	// rejects. RunWithIO must propagate that error.
-	stdin := strings.NewReader(`{"shm_handle": 1, "shm_size": 8}` + "\n")
+	stdin := strings.NewReader(`{"shm_handle": 1, "shm_event_handle": 2, "shm_size": 8}` + "\n")
 	var stdout bytes.Buffer
 
 	fakeAttach := func(uintptr, int) ([]byte, func(), error) {
 		return make([]byte, 8), func() {}, nil
 	}
 
-	err := RunWithIO(context.Background(), stdin, &stdout, zerolog.Nop(), fakeAttach)
+	err := RunWithIO(context.Background(), stdin, &stdout, zerolog.Nop(), fakeAttach, nopNotify)
 	if err == nil {
 		t.Fatal("expected ringbuf.Open error for undersized buffer")
 	}
@@ -434,7 +475,7 @@ func TestRunWithIO_HappyPath(t *testing.T) {
 	// Bootstrap valid, attach returns a real buffer, command loop runs until
 	// the context is cancelled. The writer goroutine is spawned and must drain
 	// gracefully on shutdown.
-	stdin := strings.NewReader(`{"shm_handle": 1, "shm_size": 4096}` + "\n")
+	stdin := strings.NewReader(`{"shm_handle": 1, "shm_event_handle": 2, "shm_size": 4096}` + "\n")
 	var stdout bytes.Buffer
 
 	mem := make([]byte, testHeaderSize+4096)
@@ -447,7 +488,7 @@ func TestRunWithIO_HappyPath(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), heartbeatPeriod+200*time.Millisecond)
 	defer cancel()
 
-	if err := RunWithIO(ctx, stdin, &stdout, zerolog.Nop(), fakeAttach); err != nil {
+	if err := RunWithIO(ctx, stdin, &stdout, zerolog.Nop(), fakeAttach, nopNotify); err != nil {
 		t.Fatalf("RunWithIO returned error: %v", err)
 	}
 

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -26,4 +26,5 @@ windows = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_System_Memory",
     "Win32_Security",
+    "Win32_System_Threading",
 ] }

--- a/apps/desktop/src-tauri/src/host.rs
+++ b/apps/desktop/src-tauri/src/host.rs
@@ -16,9 +16,14 @@ use crate::ringbuf::RawHandle;
 
 /// Timeout for [`ringbuf::RingBufReader::wait_for_signal`] in the host drain
 /// loop. In the happy path the sidecar signals the auto-reset event after
-/// each ring write and the drain wakes immediately; this timeout only bounds
-/// the worst-case latency of a missed signal. 8 ms is one 120 fps frame.
-pub const DRAIN_INTERVAL: Duration = Duration::from_millis(8);
+/// each ring write and the drain wakes immediately; this value only bounds
+/// the worst-case latency of a missed signal.
+///
+/// 100 ms is a compromise between lost-signal recovery latency (still well
+/// under the human-perceptible threshold) and idle CPU usage. An 8 ms timeout
+/// would fire 125 times per second when the sidecar is quiet, burning wakes
+/// for no reason; 100 ms fires 10 times per second, effectively free.
+pub const SIGNAL_WAIT_TIMEOUT: Duration = Duration::from_millis(100);
 pub const SIDECAR_BINARY: &str = "sidecar";
 
 /// Twitch OAuth credentials sourced from environment variables for Phase 0 dev.

--- a/apps/desktop/src-tauri/src/host.rs
+++ b/apps/desktop/src-tauri/src/host.rs
@@ -14,7 +14,11 @@ use serde::Serialize;
 use crate::message::{parse_twitch_envelope, UnifiedMessage};
 use crate::ringbuf::RawHandle;
 
-pub const DRAIN_INTERVAL: Duration = Duration::from_millis(16);
+/// Timeout for [`ringbuf::RingBufReader::wait_for_signal`] in the host drain
+/// loop. In the happy path the sidecar signals the auto-reset event after
+/// each ring write and the drain wakes immediately; this timeout only bounds
+/// the worst-case latency of a missed signal. 8 ms is one 120 fps frame.
+pub const DRAIN_INTERVAL: Duration = Duration::from_millis(8);
 pub const SIDECAR_BINARY: &str = "sidecar";
 
 /// Twitch OAuth credentials sourced from environment variables for Phase 0 dev.
@@ -26,12 +30,15 @@ pub struct TwitchCreds {
     pub user_id: String,
 }
 
-/// Parses a slice of raw ring-buffer payloads into [`UnifiedMessage`]s. Messages
-/// that fail to parse or that aren't chat notifications are dropped with a log.
-/// Each parse is wrapped in `catch_unwind` so a panicking parser cannot kill
-/// the drain loop (`docs/stability.md` §Rust Panic Handling).
-pub fn parse_batch(raw: &[Vec<u8>]) -> Vec<UnifiedMessage> {
-    let mut batch = Vec::with_capacity(raw.len());
+/// Parses a slice of raw ring-buffer payloads into [`UnifiedMessage`]s,
+/// appending successful parses to the caller-owned `batch` scratch buffer.
+/// The caller is responsible for clearing the scratch between drain ticks;
+/// this function only appends.
+///
+/// Messages that fail to parse or that aren't chat notifications are dropped
+/// with a log. Each parse is wrapped in `catch_unwind` so a panicking parser
+/// cannot kill the drain loop (`docs/stability.md` §Rust Panic Handling).
+pub fn parse_batch(raw: &[Vec<u8>], batch: &mut Vec<UnifiedMessage>) {
     for payload in raw {
         let slice = payload.as_slice();
         let outcome = std::panic::catch_unwind(|| parse_twitch_envelope(slice));
@@ -46,19 +53,25 @@ pub fn parse_batch(raw: &[Vec<u8>]) -> Vec<UnifiedMessage> {
             }
         }
     }
-    batch
 }
 
 /// Serializes the bootstrap JSON line the Rust host writes to the sidecar's
-/// stdin immediately after spawn.
-pub fn build_bootstrap_line(handle: RawHandle, size: usize) -> serde_json::Result<Vec<u8>> {
+/// stdin immediately after spawn. Includes the inheritable mapping HANDLE and
+/// the auto-reset event HANDLE that the sidecar signals on each ring write.
+pub fn build_bootstrap_line(
+    handle: RawHandle,
+    event_handle: RawHandle,
+    size: usize,
+) -> serde_json::Result<Vec<u8>> {
     #[derive(Serialize)]
     struct Bootstrap {
         shm_handle: u64,
+        shm_event_handle: u64,
         shm_size: u64,
     }
     let payload = Bootstrap {
         shm_handle: handle as u64,
+        shm_event_handle: event_handle as u64,
         shm_size: size as u64,
     };
     let mut bytes = serde_json::to_vec(&payload)?;
@@ -152,11 +165,12 @@ mod tests {
 
     #[test]
     fn bootstrap_line_has_expected_fields_and_newline() {
-        let line = build_bootstrap_line(0xDEADBEEF, 4096).unwrap();
+        let line = build_bootstrap_line(0xDEADBEEF, 0xCAFEBABE, 4096).unwrap();
         assert_eq!(line.last(), Some(&b'\n'));
         let body = &line[..line.len() - 1];
         let parsed: serde_json::Value = serde_json::from_slice(body).unwrap();
         assert_eq!(parsed["shm_handle"], 0xDEADBEEF_u64);
+        assert_eq!(parsed["shm_event_handle"], 0xCAFEBABE_u64);
         assert_eq!(parsed["shm_size"], 4096_u64);
     }
 
@@ -195,15 +209,45 @@ mod tests {
         let junk = b"not json".to_vec();
 
         let raw = vec![viewer, keepalive, junk];
-        let batch = parse_batch(&raw);
+        let mut batch = Vec::new();
+        parse_batch(&raw, &mut batch);
         assert_eq!(batch.len(), 1);
         assert_eq!(batch[0].message_text, "hi");
     }
 
     #[test]
     fn parse_batch_empty_input() {
-        let batch = parse_batch(&[]);
+        let mut batch = Vec::new();
+        parse_batch(&[], &mut batch);
         assert!(batch.is_empty());
+    }
+
+    #[test]
+    fn parse_batch_appends_to_existing_scratch() {
+        // Verifies that parse_batch appends rather than clearing. The drain
+        // loop owns clearing between ticks; this lets the loop avoid any
+        // allocation churn on the hot path.
+        let viewer = br##"{
+            "metadata": {"message_id":"m","message_type":"notification","message_timestamp":"2023-11-06T18:11:47.492Z"},
+            "payload": {
+                "subscription": {"type":"channel.chat.message"},
+                "event": {
+                    "chatter_user_id":"1","chatter_user_login":"u","chatter_user_name":"U",
+                    "message_id":"mid","message":{"text":"second"}
+                }
+            }
+        }"##.to_vec();
+
+        let mut batch = Vec::new();
+        // Pretend a previous tick left one item in the scratch.
+        parse_batch(&[viewer.clone()], &mut batch);
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch[0].message_text, "second");
+
+        // Second call appends, scratch is NOT cleared.
+        parse_batch(&[viewer], &mut batch);
+        assert_eq!(batch.len(), 2);
+        assert_eq!(batch[1].message_text, "second");
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/host.rs
+++ b/apps/desktop/src-tauri/src/host.rs
@@ -107,14 +107,24 @@ pub fn build_twitch_connect_line(creds: &TwitchCreds) -> serde_json::Result<Vec<
 }
 
 /// Reads Twitch dev credentials from environment variables. Returns None if
-/// any of the four required vars are missing. Phase 0 only — a proper OAuth
+/// any of the four required vars are missing. Phase 0 only, a proper OAuth
 /// flow lands in a follow-up ticket.
 pub fn twitch_creds_from_env() -> Option<TwitchCreds> {
+    twitch_creds_from(|key| std::env::var(key).ok())
+}
+
+/// Source-agnostic version of [`twitch_creds_from_env`]. Takes any closure
+/// that maps an env var name to an optional value, which lets tests exercise
+/// the presence/absence logic without touching process-wide env state.
+fn twitch_creds_from<F>(get: F) -> Option<TwitchCreds>
+where
+    F: Fn(&str) -> Option<String>,
+{
     Some(TwitchCreds {
-        client_id: std::env::var("PRISMOID_TWITCH_CLIENT_ID").ok()?,
-        access_token: std::env::var("PRISMOID_TWITCH_ACCESS_TOKEN").ok()?,
-        broadcaster_id: std::env::var("PRISMOID_TWITCH_BROADCASTER_ID").ok()?,
-        user_id: std::env::var("PRISMOID_TWITCH_USER_ID").ok()?,
+        client_id: get("PRISMOID_TWITCH_CLIENT_ID")?,
+        access_token: get("PRISMOID_TWITCH_ACCESS_TOKEN")?,
+        broadcaster_id: get("PRISMOID_TWITCH_BROADCASTER_ID")?,
+        user_id: get("PRISMOID_TWITCH_USER_ID")?,
     })
 }
 
@@ -245,45 +255,53 @@ mod tests {
 
         let mut batch = Vec::new();
         // Pretend a previous tick left one item in the scratch.
-        parse_batch(&[viewer.clone()], &mut batch);
+        parse_batch(std::slice::from_ref(&viewer), &mut batch);
         assert_eq!(batch.len(), 1);
         assert_eq!(batch[0].message_text, "second");
 
         // Second call appends, scratch is NOT cleared.
-        parse_batch(&[viewer], &mut batch);
+        parse_batch(std::slice::from_ref(&viewer), &mut batch);
         assert_eq!(batch.len(), 2);
         assert_eq!(batch[1].message_text, "second");
     }
 
     #[test]
-    fn twitch_creds_from_env_returns_none_when_missing() {
-        unsafe {
-            std::env::remove_var("PRISMOID_TWITCH_CLIENT_ID");
-            std::env::remove_var("PRISMOID_TWITCH_ACCESS_TOKEN");
-            std::env::remove_var("PRISMOID_TWITCH_BROADCASTER_ID");
-            std::env::remove_var("PRISMOID_TWITCH_USER_ID");
-        }
-        assert!(twitch_creds_from_env().is_none());
-    }
-
-    #[test]
-    fn twitch_creds_from_env_returns_some_when_all_present() {
-        unsafe {
-            std::env::set_var("PRISMOID_TWITCH_CLIENT_ID", "c");
-            std::env::set_var("PRISMOID_TWITCH_ACCESS_TOKEN", "t");
-            std::env::set_var("PRISMOID_TWITCH_BROADCASTER_ID", "b");
-            std::env::set_var("PRISMOID_TWITCH_USER_ID", "u");
-        }
-        let creds = twitch_creds_from_env().unwrap();
+    fn twitch_creds_from_returns_some_when_all_present() {
+        let map: std::collections::HashMap<&str, &str> = [
+            ("PRISMOID_TWITCH_CLIENT_ID", "c"),
+            ("PRISMOID_TWITCH_ACCESS_TOKEN", "t"),
+            ("PRISMOID_TWITCH_BROADCASTER_ID", "b"),
+            ("PRISMOID_TWITCH_USER_ID", "u"),
+        ]
+        .into_iter()
+        .collect();
+        let creds =
+            twitch_creds_from(|k| map.get(k).map(|v| v.to_string())).expect("all four present");
         assert_eq!(creds.client_id, "c");
         assert_eq!(creds.access_token, "t");
         assert_eq!(creds.broadcaster_id, "b");
         assert_eq!(creds.user_id, "u");
-        unsafe {
-            std::env::remove_var("PRISMOID_TWITCH_CLIENT_ID");
-            std::env::remove_var("PRISMOID_TWITCH_ACCESS_TOKEN");
-            std::env::remove_var("PRISMOID_TWITCH_BROADCASTER_ID");
-            std::env::remove_var("PRISMOID_TWITCH_USER_ID");
+    }
+
+    #[test]
+    fn twitch_creds_from_returns_none_when_any_missing() {
+        // Each iteration leaves exactly one of the four vars unset; the
+        // helper must short-circuit to None in every case.
+        let all = [
+            "PRISMOID_TWITCH_CLIENT_ID",
+            "PRISMOID_TWITCH_ACCESS_TOKEN",
+            "PRISMOID_TWITCH_BROADCASTER_ID",
+            "PRISMOID_TWITCH_USER_ID",
+        ];
+        for missing in all {
+            let got = twitch_creds_from(|k| {
+                if k == missing {
+                    None
+                } else {
+                    Some("v".to_string())
+                }
+            });
+            assert!(got.is_none(), "expected None when {missing} is unset");
         }
     }
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -7,7 +7,7 @@ use tauri_plugin_shell::process::CommandEvent;
 use tauri_plugin_shell::ShellExt;
 use tracing_subscriber::EnvFilter;
 
-use host::{parse_batch, DRAIN_INTERVAL};
+use host::{parse_batch, SIGNAL_WAIT_TIMEOUT};
 use ringbuf::{RingBufReader, WaitOutcome, DEFAULT_CAPACITY};
 
 #[tauri::command]
@@ -116,6 +116,14 @@ fn setup_sidecar<R: Runtime>(app: &mut tauri::App<R>) -> Result<(), Box<dyn std:
     let sidecar = app.shell().sidecar(SIDECAR_BINARY)?;
     let (mut rx, mut child) = sidecar.spawn()?;
 
+    // Spawn succeeded: the child has inherited both handles. Close the
+    // inheritance window now rather than waiting for the function to return,
+    // so that writing the bootstrap line, the twitch_connect command, and
+    // spawning downstream async tasks all happen without the HANDLEs still
+    // inheritable on this process. The guard's Drop still runs for error
+    // paths that unwind before reaching this line.
+    drop(_inherit_guard);
+
     let bootstrap_line = build_bootstrap_line(handle, event_handle, size)?;
     child.write(&bootstrap_line)?;
     tracing::info!("sidecar bootstrap written");
@@ -163,7 +171,7 @@ fn setup_sidecar<R: Runtime>(app: &mut tauri::App<R>) -> Result<(), Box<dyn std:
 
 /// Drain loop: parks on the auto-reset event signaled by the sidecar's writer
 /// goroutine after each ring write. Wakes the instant new data lands, or at
-/// the [`DRAIN_INTERVAL`] timeout as a belt-and-suspenders fallback for any
+/// the [`SIGNAL_WAIT_TIMEOUT`] as a belt-and-suspenders fallback for any
 /// lost signal. Parses, batches, and emits once per wake.
 ///
 /// The scratch `Vec<UnifiedMessage>` lives outside the loop and is cleared at
@@ -171,10 +179,10 @@ fn setup_sidecar<R: Runtime>(app: &mut tauri::App<R>) -> Result<(), Box<dyn std:
 /// the hot path (modulo the short-lived `Vec<Vec<u8>>` from `drain()` itself,
 /// tracked for follow-up in PRI-8).
 fn run_drain_loop<R: Runtime>(mut reader: RingBufReader, app: AppHandle<R>) {
-    let timeout_ms: u32 = DRAIN_INTERVAL
+    let timeout_ms: u32 = SIGNAL_WAIT_TIMEOUT
         .as_millis()
         .try_into()
-        .expect("drain interval fits in u32 ms");
+        .expect("signal wait timeout fits in u32 ms");
     let mut batch: Vec<message::UnifiedMessage> = Vec::with_capacity(64);
 
     loop {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -8,7 +8,7 @@ use tauri_plugin_shell::ShellExt;
 use tracing_subscriber::EnvFilter;
 
 use host::{parse_batch, DRAIN_INTERVAL};
-use ringbuf::{RingBufReader, DEFAULT_CAPACITY};
+use ringbuf::{RingBufReader, WaitOutcome, DEFAULT_CAPACITY};
 
 #[tauri::command]
 fn get_platform() -> &'static str {
@@ -42,10 +42,11 @@ pub fn run() {
         .expect("failed to run prismoid");
 }
 
-/// Tauri setup hook. On Windows, creates the shm section, spawns the sidecar
-/// with the HANDLE marked inheritable, bootstraps it, and starts the drain
-/// task. On other platforms (not yet supported per ADR 18), logs a warning
-/// and lets the Tauri app launch so frontend work can proceed.
+/// Tauri setup hook. On Windows, creates the shm section + auto-reset event,
+/// spawns the sidecar with both handles marked inheritable, bootstraps it,
+/// and starts the drain task. On other platforms (not yet supported per
+/// ADR 18), logs a warning and lets the Tauri app launch so frontend work
+/// can proceed.
 #[allow(clippy::unnecessary_wraps)]
 fn setup<R: Runtime>(app: &mut tauri::App<R>) -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(windows)]
@@ -71,30 +72,51 @@ fn setup_sidecar<R: Runtime>(app: &mut tauri::App<R>) -> Result<(), Box<dyn std:
 
     let reader = RingBufReader::create_owner(DEFAULT_CAPACITY)?;
     let handle = reader.raw_handle();
+    let event_handle = reader
+        .raw_event_handle()
+        .expect("owner-created reader has event handle");
     let size = reader.map_size();
 
     mark_handle_inheritable(handle)?;
+    if let Err(e) = mark_handle_inheritable(event_handle) {
+        // Undo the mapping-handle mark before propagating, otherwise we leak
+        // the inheritable flag on a partial failure.
+        if let Err(undo) = unmark_handle_inheritable(handle) {
+            tracing::error!(error = %undo, "failed to undo mapping handle mark after event mark failure");
+        }
+        return Err(e.into());
+    }
 
     // RAII guard: the inheritable flag is cleared on any exit from this
-    // function, including error paths. This keeps the window where the HANDLE
-    // is inheritable as narrow as possible (effectively: the sidecar spawn).
-    // The Rust stdlib's CREATE_PROCESS_LOCK serializes our own child spawns,
-    // but un-setting the flag immediately defends against any future change
-    // where something else creates a process between mark and function exit.
-    struct InheritGuard(ringbuf::RawHandle);
+    // function, including error paths. This keeps the window where the
+    // HANDLEs are inheritable as narrow as possible (effectively: the sidecar
+    // spawn). The Rust stdlib's CREATE_PROCESS_LOCK serializes our own child
+    // spawns, but un-setting the flags immediately defends against any future
+    // change where something else creates a process between mark and
+    // function exit.
+    struct InheritGuard {
+        mapping: ringbuf::RawHandle,
+        event: ringbuf::RawHandle,
+    }
     impl Drop for InheritGuard {
         fn drop(&mut self) {
-            if let Err(e) = unmark_handle_inheritable(self.0) {
-                tracing::error!(error = %e, "failed to un-mark handle inheritance in drop");
+            if let Err(e) = unmark_handle_inheritable(self.mapping) {
+                tracing::error!(error = %e, "failed to un-mark mapping handle inheritance in drop");
+            }
+            if let Err(e) = unmark_handle_inheritable(self.event) {
+                tracing::error!(error = %e, "failed to un-mark event handle inheritance in drop");
             }
         }
     }
-    let _inherit_guard = InheritGuard(handle);
+    let _inherit_guard = InheritGuard {
+        mapping: handle,
+        event: event_handle,
+    };
 
     let sidecar = app.shell().sidecar(SIDECAR_BINARY)?;
     let (mut rx, mut child) = sidecar.spawn()?;
 
-    let bootstrap_line = build_bootstrap_line(handle, size)?;
+    let bootstrap_line = build_bootstrap_line(handle, event_handle, size)?;
     child.write(&bootstrap_line)?;
     tracing::info!("sidecar bootstrap written");
 
@@ -130,25 +152,47 @@ fn setup_sidecar<R: Runtime>(app: &mut tauri::App<R>) -> Result<(), Box<dyn std:
     });
 
     let app_handle = app.app_handle().clone();
-    tauri::async_runtime::spawn(run_drain_loop(reader, app_handle));
+    // The drain loop blocks the calling thread on WaitForSingleObject, so it
+    // lives on a dedicated blocking-pool thread rather than the tokio worker
+    // pool. `spawn_blocking` tasks tolerate arbitrary blocking waits without
+    // starving async tasks.
+    tauri::async_runtime::spawn_blocking(move || run_drain_loop(reader, app_handle));
 
     Ok(())
 }
 
-/// Drain loop: every [`DRAIN_INTERVAL`], drain the ring buffer, parse each
-/// payload, emit the batch to the frontend.
-async fn run_drain_loop<R: Runtime>(mut reader: RingBufReader, app: AppHandle<R>) {
-    let mut ticker = tokio::time::interval(DRAIN_INTERVAL);
-    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+/// Drain loop: parks on the auto-reset event signaled by the sidecar's writer
+/// goroutine after each ring write. Wakes the instant new data lands, or at
+/// the [`DRAIN_INTERVAL`] timeout as a belt-and-suspenders fallback for any
+/// lost signal. Parses, batches, and emits once per wake.
+///
+/// The scratch `Vec<UnifiedMessage>` lives outside the loop and is cleared at
+/// the top of each iteration, so steady-state operation allocates nothing on
+/// the hot path (modulo the short-lived `Vec<Vec<u8>>` from `drain()` itself,
+/// tracked for follow-up in PRI-8).
+fn run_drain_loop<R: Runtime>(mut reader: RingBufReader, app: AppHandle<R>) {
+    let timeout_ms: u32 = DRAIN_INTERVAL
+        .as_millis()
+        .try_into()
+        .expect("drain interval fits in u32 ms");
+    let mut batch: Vec<message::UnifiedMessage> = Vec::with_capacity(64);
 
     loop {
-        ticker.tick().await;
+        match reader.wait_for_signal(timeout_ms) {
+            Ok(WaitOutcome::Signaled) | Ok(WaitOutcome::TimedOut) => {}
+            Err(e) => {
+                tracing::error!(error = %e, "wait_for_signal failed, drain loop exiting");
+                return;
+            }
+        }
+
         let raw = reader.drain();
         if raw.is_empty() {
             continue;
         }
 
-        let batch = parse_batch(&raw);
+        batch.clear();
+        parse_batch(&raw, &mut batch);
         if batch.is_empty() {
             continue;
         }

--- a/apps/desktop/src-tauri/src/ringbuf.rs
+++ b/apps/desktop/src-tauri/src/ringbuf.rs
@@ -4,11 +4,19 @@
 //! and obtains the raw HANDLE via [`RingBufReader::raw_handle`]. See ADR 18
 //! (revised 2026-04-11).
 //!
-//! This primitive deliberately creates the handle as **non-inheritable**. The
-//! caller (the host lifecycle) is responsible for marking the handle inheritable
+//! Alongside the section, `create_owner` also creates an unnamed auto-reset
+//! Windows Event that the Go sidecar signals after each successful ring write
+//! (via `SetEvent`). The host parks on [`RingBufReader::wait_for_signal`] to
+//! wake the instant new data is available, eliminating per-frame polling
+//! latency. This matches the industry-standard pattern used by Chromium Mojo
+//! and LMAX Disruptor for low-latency shm IPC. A caller-provided timeout acts
+//! as a belt-and-suspenders fallback in case a signal is ever lost.
+//!
+//! This primitive deliberately creates both handles as **non-inheritable**.
+//! The caller (the host lifecycle) is responsible for marking them inheritable
 //! via `SetHandleInformation(HANDLE_FLAG_INHERIT)` immediately before spawning
-//! the sidecar and un-marking it immediately after, to minimize the race window
-//! where any other child spawned in that interval would inherit the section.
+//! the sidecar and un-marking them immediately after, to minimize the race
+//! window where any other child spawned in that interval would inherit them.
 //! See the Rust stdlib comment in `library/std/src/sys/process/windows.rs`
 //! (around the `CREATE_PROCESS_LOCK` definition) for why this window matters.
 //!
@@ -53,7 +61,20 @@ pub struct RingBufReader {
     data_offset: usize,
     #[cfg(windows)]
     mapping_handle: windows::Win32::Foundation::HANDLE,
+    /// Auto-reset event signaled by the writer after each ring write. Only set
+    /// for owner-created readers; attach-created readers have no event.
+    #[cfg(windows)]
+    event_handle: Option<windows::Win32::Foundation::HANDLE>,
     owner: bool,
+}
+
+/// Result of [`RingBufReader::wait_for_signal`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WaitOutcome {
+    /// The writer signaled the event; new data is available.
+    Signaled,
+    /// The timeout elapsed with no signal. Fallback path; drain anyway.
+    TimedOut,
 }
 
 // The reader owns a view into shared memory and is the sole consumer. Atomics
@@ -67,9 +88,10 @@ impl RingBufReader {
         use windows::core::PCWSTR;
         use windows::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
         use windows::Win32::System::Memory::{
-            CreateFileMappingW, MapViewOfFile, FILE_MAP, FILE_MAP_READ, FILE_MAP_WRITE,
-            PAGE_READWRITE,
+            CreateFileMappingW, MapViewOfFile, UnmapViewOfFile, FILE_MAP, FILE_MAP_READ,
+            FILE_MAP_WRITE, MEMORY_MAPPED_VIEW_ADDRESS, PAGE_READWRITE,
         };
+        use windows::Win32::System::Threading::CreateEventW;
 
         if capacity < 4 {
             return Err(io::Error::new(
@@ -121,11 +143,29 @@ impl RingBufReader {
             meta.capacity = capacity as u64;
         }
 
+        // Auto-reset unnamed event; starts unsignaled. The writer (Go sidecar)
+        // calls SetEvent after each ring write. The reader waits on it via
+        // WaitForSingleObject to wake immediately when data is available.
+        let event = match unsafe { CreateEventW(None, false, false, PCWSTR::null()) } {
+            Ok(h) => h,
+            Err(e) => {
+                let err = windows_err(e);
+                unsafe {
+                    let _ = UnmapViewOfFile(MEMORY_MAPPED_VIEW_ADDRESS {
+                        Value: base as *mut _,
+                    });
+                    let _ = CloseHandle(handle);
+                }
+                return Err(err);
+            }
+        };
+
         Ok(Self {
             base,
             map_size: total,
             data_offset: HEADER_SIZE,
             mapping_handle: handle,
+            event_handle: Some(event),
             owner: true,
         })
     }
@@ -183,14 +223,54 @@ impl RingBufReader {
             map_size,
             data_offset: HEADER_SIZE,
             mapping_handle,
+            event_handle: None,
             owner: false,
         })
     }
 
-    /// Raw handle suitable for passing to a child process via stdio bootstrap.
-    /// Only meaningful for readers created via `create_owner`.
+    /// Raw mapping handle suitable for passing to a child process via stdio
+    /// bootstrap. Only meaningful for readers created via `create_owner`.
     pub fn raw_handle(&self) -> RawHandle {
         self.mapping_handle.0 as RawHandle
+    }
+
+    /// Raw event handle suitable for passing to a child process via stdio
+    /// bootstrap. Returns `None` for attach-created readers, which have no
+    /// event of their own. Only `create_owner` readers return `Some`.
+    pub fn raw_event_handle(&self) -> Option<RawHandle> {
+        self.event_handle.map(|h| h.0 as RawHandle)
+    }
+
+    /// Blocks the current thread until the writer signals new data is
+    /// available or the timeout elapses. Returns [`WaitOutcome::Signaled`] if
+    /// the auto-reset event fired (and was automatically reset), or
+    /// [`WaitOutcome::TimedOut`] if the timeout ran out first. In the timeout
+    /// case the caller should still drain the ring as a belt-and-suspenders
+    /// guard against lost signals.
+    ///
+    /// Only valid on readers created via `create_owner`. Attach-created
+    /// readers return `ErrorKind::Unsupported`.
+    pub fn wait_for_signal(&self, timeout_ms: u32) -> io::Result<WaitOutcome> {
+        use windows::Win32::Foundation::{WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT};
+        use windows::Win32::System::Threading::WaitForSingleObject;
+
+        let Some(event) = self.event_handle else {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "wait_for_signal requires an owner-created reader",
+            ));
+        };
+
+        let result = unsafe { WaitForSingleObject(event, timeout_ms) };
+        match result {
+            WAIT_OBJECT_0 => Ok(WaitOutcome::Signaled),
+            WAIT_TIMEOUT => Ok(WaitOutcome::TimedOut),
+            WAIT_FAILED => Err(io::Error::last_os_error()),
+            other => Err(io::Error::other(format!(
+                "WaitForSingleObject returned unexpected status {:#x}",
+                other.0
+            ))),
+        }
     }
 }
 
@@ -212,6 +292,17 @@ impl RingBufReader {
 
     pub fn raw_handle(&self) -> RawHandle {
         0
+    }
+
+    pub fn raw_event_handle(&self) -> Option<RawHandle> {
+        None
+    }
+
+    pub fn wait_for_signal(&self, _timeout_ms: u32) -> io::Result<WaitOutcome> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "wait_for_signal not yet supported on this platform",
+        ))
     }
 }
 
@@ -316,6 +407,9 @@ impl Drop for RingBufReader {
             }
             if self.owner {
                 let _ = CloseHandle(self.mapping_handle);
+                if let Some(event) = self.event_handle {
+                    let _ = CloseHandle(event);
+                }
             }
         }
     }
@@ -538,5 +632,83 @@ mod tests {
         }
         let err = RingBufReader::attach(owner.raw_handle(), owner.map_size()).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn owner_exposes_event_handle_attach_does_not() {
+        let owner = RingBufReader::create_owner(4096).unwrap();
+        assert!(owner.raw_event_handle().is_some());
+        assert_ne!(owner.raw_event_handle(), Some(0));
+
+        let attached = RingBufReader::attach(owner.raw_handle(), owner.map_size()).unwrap();
+        assert!(attached.raw_event_handle().is_none());
+    }
+
+    #[test]
+    fn wait_for_signal_times_out_when_no_signal() {
+        let owner = RingBufReader::create_owner(4096).unwrap();
+        let start = std::time::Instant::now();
+        let outcome = owner.wait_for_signal(20).unwrap();
+        let elapsed = start.elapsed();
+        assert_eq!(outcome, WaitOutcome::TimedOut);
+        // Timeout should be roughly the requested 20ms, allow slack.
+        assert!(elapsed >= std::time::Duration::from_millis(15));
+        assert!(elapsed < std::time::Duration::from_millis(500));
+    }
+
+    #[test]
+    fn wait_for_signal_wakes_on_set_event_from_another_thread() {
+        use std::thread;
+        use std::time::Duration;
+
+        let owner = RingBufReader::create_owner(4096).unwrap();
+        let event_raw = owner.raw_event_handle().expect("owner has event");
+
+        // Spawn a helper that signals the event after a short delay. It uses
+        // the raw handle integer, simulating what the Go sidecar does with the
+        // inherited handle.
+        thread::spawn(move || {
+            thread::sleep(Duration::from_millis(30));
+            unsafe {
+                use windows::Win32::Foundation::HANDLE;
+                use windows::Win32::System::Threading::SetEvent;
+                let _ = SetEvent(HANDLE(event_raw as *mut _));
+            }
+        });
+
+        let start = std::time::Instant::now();
+        let outcome = owner.wait_for_signal(1000).unwrap();
+        let elapsed = start.elapsed();
+        assert_eq!(outcome, WaitOutcome::Signaled);
+        assert!(elapsed >= Duration::from_millis(25));
+        assert!(elapsed < Duration::from_millis(500));
+    }
+
+    #[test]
+    fn wait_for_signal_auto_resets_after_wake() {
+        use std::time::Duration;
+
+        let owner = RingBufReader::create_owner(4096).unwrap();
+        let event_raw = owner.raw_event_handle().unwrap();
+
+        unsafe {
+            use windows::Win32::Foundation::HANDLE;
+            use windows::Win32::System::Threading::SetEvent;
+            let _ = SetEvent(HANDLE(event_raw as *mut _));
+        }
+
+        assert_eq!(owner.wait_for_signal(500).unwrap(), WaitOutcome::Signaled);
+        let start = std::time::Instant::now();
+        // Second wait on the already-consumed auto-reset event should time out.
+        assert_eq!(owner.wait_for_signal(20).unwrap(), WaitOutcome::TimedOut);
+        assert!(start.elapsed() >= Duration::from_millis(15));
+    }
+
+    #[test]
+    fn wait_for_signal_rejects_attached_reader() {
+        let owner = RingBufReader::create_owner(4096).unwrap();
+        let attached = RingBufReader::attach(owner.raw_handle(), owner.map_size()).unwrap();
+        let err = attached.wait_for_signal(10).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
     }
 }


### PR DESCRIPTION
Implements [PRI-12](https://linear.app/frostcrypt/issue/PRI-12). Replaces the 16 ms tokio interval tick in the Rust drain loop with a Windows auto-reset event signaled by the Go sidecar after each successful ring write. The host parks on `WaitForSingleObject` and wakes the instant new data is available, eliminating frame batching latency entirely. The 8 ms timeout stays as a belt-and-suspenders fallback for any lost signal.

Matches the Chromium Mojo / LMAX Disruptor pattern of memory-ring + notify. Also folds in PRI-10 (preallocated scratch Vec) as part of the same drain-loop rewrite since both changes edit the same function body (PRI-11 was cancelled as redundant).

## rust

### `ringbuf.rs`

- `create_owner` now creates an auto-reset unnamed Windows Event via `CreateEventW(None, false, false, null)` alongside the shared memory section. Both handles are stored on `RingBufReader`.
- New `raw_event_handle()` accessor returns the event HANDLE as `Option<RawHandle>` (`None` for attach-created readers).
- New `wait_for_signal(timeout_ms: u32) -> io::Result<WaitOutcome>` wraps `WaitForSingleObject` with three outcomes: `Signaled`, `TimedOut`, or `io::Error` on `WAIT_FAILED`.
- Drop now closes the event handle alongside the mapping handle.
- 5 new tests: event-handle presence on owner-vs-attach, timeout behavior, cross-thread signal wake, auto-reset after wake, and rejection on attach-created readers. **34/34 tests total.**

### `host.rs`

- `parse_batch(raw, &mut Vec<UnifiedMessage>)` now appends to a caller-owned scratch buffer instead of returning a new Vec, eliminating per-tick allocation.
- `build_bootstrap_line(handle, event_handle, size)` now takes both handles and serializes `{"shm_handle", "shm_event_handle", "shm_size"}`.
- `DRAIN_INTERVAL` dropped from 16 ms to 8 ms (the kernel-event timeout fallback, not a driving tick rate).
- New `parse_batch_appends_to_existing_scratch` test verifies append semantics.

### `lib.rs`

- `setup_sidecar` now marks **both** the mapping and event handles inheritable via `SetHandleInformation(HANDLE_FLAG_INHERIT)`. The RAII `InheritGuard` un-marks both on function exit.
- Bootstrap JSON includes `shm_event_handle`.
- `run_drain_loop` is now synchronous and runs via `tauri::async_runtime::spawn_blocking`. Parks on `wait_for_signal(8)`, drains, parses into a preallocated scratch `Vec<UnifiedMessage>` (cleared each tick), and emits. No per-tick allocation on the hot path.

### `Cargo.toml`

- Added `Win32_System_Threading` feature to the `windows` crate.

## go

### `ringbuf` package

- `shm_windows.go`: new `Notify(eventHandle uintptr) error` wrapping `windows.SetEvent`. Plus `CloseEventHandle(uintptr) error` for cleanup.
- `shm_linux.go` / `shm_darwin.go`: stubs returning `not yet supported` with notes pointing at eventfd / Mach semaphore respectively.

### `control.Bootstrap`

- New `ShmEventHandle uintptr` field alongside `ShmHandle` and `ShmSize`.

### `internal/sidecar`

- `RunWithIO` takes a new `NotifyFunc` parameter (production is `ringbuf.Notify`, tests inject a fake).
- `RunWriter(ctx, in, writer, signal func())` calls `signal()` after each successful `writer.Write`. Drops on full ring do NOT signal.
- Test coverage: `TestRunWriter_DrainsChannelToRing` verifies the signal count matches the successful write count, and `TestRunWriter_SkipsSignalOnFullRing` verifies failed writes don't signal.

## memory ordering

`writer.Write` on the Go side ends with `atomic.StoreUint64` on the ring's write index, which is a release store in Go's memory model. The subsequent `SetEvent` syscall acts as a full memory barrier. On the Rust side, `WaitForSingleObject` returning is also a full memory barrier, and `drain()` loads the write index with `Ordering::Acquire`. The full-barrier syscalls plus the paired release/acquire on the index give proper happens-before, so by the time Rust reads the write index it also sees the payload bytes.

## expected latency improvement

Before: 0–8 ms of drain-loop batching latency on every message (after the PRI-11 tightening that got cancelled, 0–16 ms before that).
After: Rust wakes within the kernel event signal propagation latency (~microseconds) after the Go write completes. The 8 ms timeout is the dormant fallback for missed signals and only contributes to worst-case latency in abnormal cases.

## out of scope

- Linux (eventfd) and macOS (Mach semaphore / kqueue) signaling — separate tickets when those platforms are targeted
- Zero-alloc parse path (serde_json strings) — PRI-8, benchmark-driven
- MPSC ring buffer — SPSC still holds; the Go-side channel → writer goroutine serialization is unchanged

Closes PRI-12. Supersedes (cancelled) PRI-10 and PRI-11.