### PR TITLE
feat: heartbeat payload ts + counter

### DIFF
--- a/apps/desktop/src-sidecar/internal/control/control.go
+++ b/apps/desktop/src-sidecar/internal/control/control.go
@@ -30,3 +30,15 @@ type Message struct {
 	Type    string `json:"type"`
 	Payload any    `json:"payload,omitempty"`
 }
+
+// HeartbeatPayload is the body of a `{"type":"heartbeat", ...}` Message.
+//
+// The host uses this to detect a stalled sidecar even when the process is
+// technically alive (hung WebSocket read, deadlocked goroutine): a gap in
+// `Counter` signals a missed tick, and comparing `TSMs` to the host's own
+// clock catches gross clock skew. Both fields are monotonic within a single
+// sidecar run; they reset on respawn.
+type HeartbeatPayload struct {
+	TSMs    int64  `json:"ts_ms"`
+	Counter uint64 `json:"counter"`
+}

--- a/apps/desktop/src-sidecar/internal/sidecar/sidecar.go
+++ b/apps/desktop/src-sidecar/internal/sidecar/sidecar.go
@@ -109,7 +109,7 @@ func RunWithIO(
 	signal := MakeSignalFunc(boot.ShmEventHandle, notify, logger)
 	go RunWriter(ctx, out, writer, signal)
 
-	return RunCommandLoop(ctx, scanner, json.NewEncoder(stdout), out, logger)
+	return RunCommandLoop(ctx, scanner, json.NewEncoder(stdout), out, logger, heartbeatPeriod)
 }
 
 // NotifyFunc signals the host that new data has been written to the ring
@@ -193,16 +193,24 @@ func RunWriter(ctx context.Context, in <-chan []byte, writer *ringbuf.Writer, si
 // are serialized through encoderMu because notify is invoked from Twitch
 // client goroutines while heartbeats fire from this loop; json.Encoder and
 // the underlying io.Writer are not safe for concurrent use.
-func RunCommandLoop(ctx context.Context, scanner *bufio.Scanner, encoder *json.Encoder, out chan<- []byte, logger zerolog.Logger) error {
+//
+// `period` is the heartbeat tick interval; production passes [`heartbeatPeriod`],
+// tests pass a short duration to keep the suite fast.
+func RunCommandLoop(ctx context.Context, scanner *bufio.Scanner, encoder *json.Encoder, out chan<- []byte, logger zerolog.Logger, period time.Duration) error {
 	cmdCh := make(chan control.Command, cmdChanCapacity)
 	go scanCommands(scanner, cmdCh, logger)
 
-	heartbeat := time.NewTicker(heartbeatPeriod)
+	heartbeat := time.NewTicker(period)
 	defer heartbeat.Stop()
 
 	clients := make(map[string]context.CancelFunc)
 	var encoderMu sync.Mutex
 	notify := makeNotify(encoder, &encoderMu, logger)
+
+	// Heartbeat counter is scoped to this loop's lifetime. Monotonic gaps let
+	// the host watchdog detect missed ticks even if the underlying clock is
+	// skewed. Resets to 0 on respawn, which is the correct signal.
+	var heartbeatCounter uint64
 
 	for {
 		select {
@@ -210,8 +218,13 @@ func RunCommandLoop(ctx context.Context, scanner *bufio.Scanner, encoder *json.E
 			logger.Info().Msg("sidecar shutting down")
 			return nil
 		case <-heartbeat.C:
+			heartbeatCounter++
+			payload := control.HeartbeatPayload{
+				TSMs:    time.Now().UnixMilli(),
+				Counter: heartbeatCounter,
+			}
 			encoderMu.Lock()
-			err := encoder.Encode(control.Message{Type: "heartbeat"})
+			err := encoder.Encode(control.Message{Type: "heartbeat", Payload: payload})
 			encoderMu.Unlock()
 			if err != nil {
 				logger.Error().Err(err).Msg("failed to write heartbeat to host")

--- a/apps/desktop/src-sidecar/internal/sidecar/sidecar_test.go
+++ b/apps/desktop/src-sidecar/internal/sidecar/sidecar_test.go
@@ -280,7 +280,9 @@ func TestRunCommandLoop_DispatchesCommands(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	done := make(chan error, 1)
-	go func() { done <- RunCommandLoop(ctx, scanner, encoder, out, zerolog.Nop()) }()
+	// Long period so the heartbeat ticker doesn't pollute stdout during this
+	// command-dispatch-focused test.
+	go func() { done <- RunCommandLoop(ctx, scanner, encoder, out, zerolog.Nop(), time.Hour) }()
 
 	// give the loop a moment to dispatch the queued command
 	time.Sleep(150 * time.Millisecond)
@@ -297,22 +299,81 @@ func TestRunCommandLoop_DispatchesCommands(t *testing.T) {
 }
 
 func TestRunCommandLoop_EmitsHeartbeat(t *testing.T) {
-	// No commands; let the heartbeat fire at least once.
+	// No commands; let the heartbeat fire at least once. Short period keeps
+	// the test fast; the timeout gives the ticker room to fire exactly once.
 	scanner := readerScanner(strings.NewReader(""))
 
 	var stdout bytes.Buffer
 	encoder := json.NewEncoder(&stdout)
 
 	out := make(chan []byte, 1)
-	ctx, cancel := context.WithTimeout(context.Background(), heartbeatPeriod+200*time.Millisecond)
+	period := 50 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), period+100*time.Millisecond)
 	defer cancel()
 
-	if err := RunCommandLoop(ctx, scanner, encoder, out, zerolog.Nop()); err != nil {
+	tsBefore := time.Now().UnixMilli()
+	if err := RunCommandLoop(ctx, scanner, encoder, out, zerolog.Nop(), period); err != nil {
+		t.Fatalf("RunCommandLoop returned error: %v", err)
+	}
+	tsAfter := time.Now().UnixMilli()
+
+	// First emitted line is a heartbeat with the enriched payload.
+	firstLine := strings.SplitN(stdout.String(), "\n", 2)[0]
+	var msg control.Message
+	if err := json.Unmarshal([]byte(firstLine), &msg); err != nil {
+		t.Fatalf("heartbeat not valid JSON: %v (got: %s)", err, firstLine)
+	}
+	if msg.Type != "heartbeat" {
+		t.Fatalf("expected type=heartbeat, got %q", msg.Type)
+	}
+	payloadBytes, _ := json.Marshal(msg.Payload)
+	var hb control.HeartbeatPayload
+	if err := json.Unmarshal(payloadBytes, &hb); err != nil {
+		t.Fatalf("heartbeat payload not decodable: %v", err)
+	}
+	if hb.Counter != 1 {
+		t.Errorf("expected counter=1 on first heartbeat, got %d", hb.Counter)
+	}
+	if hb.TSMs < tsBefore || hb.TSMs > tsAfter {
+		t.Errorf("heartbeat ts_ms %d outside expected window [%d, %d]", hb.TSMs, tsBefore, tsAfter)
+	}
+}
+
+func TestRunCommandLoop_HeartbeatCounterIncreases(t *testing.T) {
+	// Run long enough for 3 heartbeats to fire; verify counter is monotonic
+	// 1, 2, 3 in the order they appear in stdout.
+	scanner := readerScanner(strings.NewReader(""))
+
+	var stdout bytes.Buffer
+	encoder := json.NewEncoder(&stdout)
+
+	out := make(chan []byte, 1)
+	period := 20 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), 3*period+30*time.Millisecond)
+	defer cancel()
+
+	if err := RunCommandLoop(ctx, scanner, encoder, out, zerolog.Nop(), period); err != nil {
 		t.Fatalf("RunCommandLoop returned error: %v", err)
 	}
 
-	if !strings.Contains(stdout.String(), `"type":"heartbeat"`) {
-		t.Errorf("expected at least one heartbeat in stdout, got: %s", stdout.String())
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	if len(lines) < 3 {
+		t.Fatalf("expected at least 3 heartbeat lines, got %d: %s", len(lines), stdout.String())
+	}
+	for i, line := range lines[:3] {
+		var msg control.Message
+		if err := json.Unmarshal([]byte(line), &msg); err != nil {
+			t.Fatalf("line %d not valid JSON: %v", i, err)
+		}
+		payloadBytes, _ := json.Marshal(msg.Payload)
+		var hb control.HeartbeatPayload
+		if err := json.Unmarshal(payloadBytes, &hb); err != nil {
+			t.Fatalf("line %d payload not decodable: %v", i, err)
+		}
+		wantCounter := uint64(i + 1)
+		if hb.Counter != wantCounter {
+			t.Errorf("line %d: expected counter=%d, got %d", i, wantCounter, hb.Counter)
+		}
 	}
 }
 
@@ -327,10 +388,11 @@ func TestRunCommandLoop_PropagatesHeartbeatWriteError(t *testing.T) {
 	encoder := json.NewEncoder(&errWriter{err: errors.New("pipe broken")})
 
 	out := make(chan []byte, 1)
-	ctx, cancel := context.WithTimeout(context.Background(), heartbeatPeriod+200*time.Millisecond)
+	period := 50 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), period+100*time.Millisecond)
 	defer cancel()
 
-	err := RunCommandLoop(ctx, scanner, encoder, out, zerolog.Nop())
+	err := RunCommandLoop(ctx, scanner, encoder, out, zerolog.Nop(), period)
 	if err == nil {
 		t.Fatal("expected error when encoder.Encode fails")
 	}


### PR DESCRIPTION
## Summary
- Enrich sidecar→host `{"type":"heartbeat"}` with `{ts_ms, counter}` payload so the (future) host watchdog can detect missed ticks and clock skew instead of just "something emitted".
- `RunCommandLoop` takes the tick period as a parameter — production passes the existing `heartbeatPeriod` const, tests pass a short duration to stay fast.
- Counter is `uint64`, monotonic per sidecar run, resets on respawn.

Scope is the Go emitter half. Host-side watchdog consumer layers on PRI-13 once that lands.

## Test plan
- [x] `go test ./...` — all packages ok
- [x] `golangci-lint run ./...` — 0 issues
- [x] `TestRunCommandLoop_EmitsHeartbeat` verifies enriched payload shape + `counter=1` on first tick + `ts_ms` within real-time window
- [x] `TestRunCommandLoop_HeartbeatCounterIncreases` verifies monotonic 1→2→3 across 3 ticks
- [x] Existing `TestRunCommandLoop_DispatchesCommands` updated with `time.Hour` period so heartbeat can't pollute the dispatch-focused assertions