### PR TITLE
feat: mod action command dispatch (scaffold, no helix yet)

### DIFF
--- a/apps/desktop/src-sidecar/internal/control/control.go
+++ b/apps/desktop/src-sidecar/internal/control/control.go
@@ -16,13 +16,32 @@ type Bootstrap struct {
 
 // Command is a control-plane message from the Rust host received over stdin
 // after the Bootstrap message. Each command targets a single platform client.
+//
+// The Command is an intentionally flat struct with all possible fields as
+// omitempty — not an envelope with a typed payload. When the handler count
+// grows past ~8 distinct commands, split into envelope+args. Until then the
+// flat shape is the simpler thing to serialize on the Rust side.
 type Command struct {
-	Cmd           string `json:"cmd"`
-	Channel       string `json:"channel,omitempty"`
-	Token         string `json:"token,omitempty"`
-	ClientID      string `json:"client_id,omitempty"`
+	Cmd      string `json:"cmd"`
+	Channel  string `json:"channel,omitempty"`
+	Token    string `json:"token,omitempty"`
+	ClientID string `json:"client_id,omitempty"`
+
+	// BroadcasterID is the channel the command operates against. Used by
+	// twitch_connect (subscribe to this channel's chat) and by mod actions
+	// (the channel the mod action happens in).
 	BroadcasterID string `json:"broadcaster_id,omitempty"`
-	UserID        string `json:"user_id,omitempty"`
+	// UserID is the acting user's ID — the self ID for twitch_connect, the
+	// moderator's ID for mod actions. Twitch Helix's moderation endpoints
+	// require the moderator_id to match the token's authenticated user.
+	UserID string `json:"user_id,omitempty"`
+
+	// Mod action fields. Only set by ban_user / unban_user / timeout_user /
+	// delete_message commands.
+	TargetUserID    string `json:"target_user_id,omitempty"`
+	DurationSeconds int    `json:"duration_seconds,omitempty"`
+	Reason          string `json:"reason,omitempty"`
+	MessageID       string `json:"message_id,omitempty"`
 }
 
 // Message is a notification the sidecar writes to stdout for the Rust host.

--- a/apps/desktop/src-sidecar/internal/sidecar/sidecar.go
+++ b/apps/desktop/src-sidecar/internal/sidecar/sidecar.go
@@ -252,9 +252,110 @@ func DispatchCommand(ctx context.Context, cmd control.Command, clients map[strin
 		HandleTwitchConnect(ctx, cmd, clients, out, notify, logger)
 	case "twitch_disconnect":
 		HandleTwitchDisconnect(cmd, clients, logger)
+	case "ban_user":
+		HandleBanUser(cmd, logger)
+	case "unban_user":
+		HandleUnbanUser(cmd, logger)
+	case "timeout_user":
+		HandleTimeoutUser(cmd, logger)
+	case "delete_message":
+		HandleDeleteMessage(cmd, logger)
 	default:
 		logger.Info().Str("cmd", cmd.Cmd).Str("channel", cmd.Channel).Msg("received command")
 	}
+}
+
+// Twitch Helix enforces a 1209600-second (14-day) maximum on timeouts;
+// anything longer must be a permanent ban. Mirrored here so the log-only
+// scaffold rejects values that the real Helix call would reject anyway,
+// keeping the protocol contract consistent between the scaffold and the
+// real implementation that lands in a follow-up.
+const maxTimeoutSeconds = 1209600
+
+// HandleBanUser logs the intended ban. Helix integration (POST
+// /moderation/bans with body `{data: {user_id, reason}}`) lands in a
+// follow-up PR; this scaffold exists to lock the host→sidecar protocol
+// shape before the API client is built.
+func HandleBanUser(cmd control.Command, logger zerolog.Logger) {
+	if cmd.BroadcasterID == "" || cmd.TargetUserID == "" {
+		logger.Warn().
+			Str("cmd", cmd.Cmd).
+			Str("broadcaster", cmd.BroadcasterID).
+			Str("target", cmd.TargetUserID).
+			Msg("ban_user missing required field; ignoring")
+		return
+	}
+	logger.Info().
+		Str("broadcaster", cmd.BroadcasterID).
+		Str("target", cmd.TargetUserID).
+		Str("reason", cmd.Reason).
+		Msg("ban_user (scaffold: no Helix call yet)")
+}
+
+// HandleUnbanUser logs the intended unban. Helix: DELETE
+// /moderation/bans?user_id=<id>&broadcaster_id=<id>&moderator_id=<id>.
+func HandleUnbanUser(cmd control.Command, logger zerolog.Logger) {
+	if cmd.BroadcasterID == "" || cmd.TargetUserID == "" {
+		logger.Warn().
+			Str("cmd", cmd.Cmd).
+			Str("broadcaster", cmd.BroadcasterID).
+			Str("target", cmd.TargetUserID).
+			Msg("unban_user missing required field; ignoring")
+		return
+	}
+	logger.Info().
+		Str("broadcaster", cmd.BroadcasterID).
+		Str("target", cmd.TargetUserID).
+		Msg("unban_user (scaffold: no Helix call yet)")
+}
+
+// HandleTimeoutUser logs the intended timeout. Helix: POST /moderation/bans
+// with body `{data: {user_id, duration, reason}}`, where duration is
+// 1..1209600 seconds. Values outside that range are rejected locally to
+// match Helix semantics and surface misuse in logs.
+func HandleTimeoutUser(cmd control.Command, logger zerolog.Logger) {
+	if cmd.BroadcasterID == "" || cmd.TargetUserID == "" {
+		logger.Warn().
+			Str("cmd", cmd.Cmd).
+			Str("broadcaster", cmd.BroadcasterID).
+			Str("target", cmd.TargetUserID).
+			Msg("timeout_user missing required field; ignoring")
+		return
+	}
+	if cmd.DurationSeconds < 1 || cmd.DurationSeconds > maxTimeoutSeconds {
+		logger.Warn().
+			Str("cmd", cmd.Cmd).
+			Int("duration_seconds", cmd.DurationSeconds).
+			Int("max_duration_seconds", maxTimeoutSeconds).
+			Msg("timeout_user duration out of range [1, 1209600]; ignoring")
+		return
+	}
+	logger.Info().
+		Str("broadcaster", cmd.BroadcasterID).
+		Str("target", cmd.TargetUserID).
+		Int("duration_seconds", cmd.DurationSeconds).
+		Str("reason", cmd.Reason).
+		Msg("timeout_user (scaffold: no Helix call yet)")
+}
+
+// HandleDeleteMessage logs the intended deletion. Helix: DELETE
+// /moderation/chat?broadcaster_id=<id>&moderator_id=<id>&message_id=<id>.
+// Message-less deletion (clear all chat) is deliberately not supported by
+// this command — a separate `clear_chat` command would handle that when
+// needed.
+func HandleDeleteMessage(cmd control.Command, logger zerolog.Logger) {
+	if cmd.BroadcasterID == "" || cmd.MessageID == "" {
+		logger.Warn().
+			Str("cmd", cmd.Cmd).
+			Str("broadcaster", cmd.BroadcasterID).
+			Str("message_id", cmd.MessageID).
+			Msg("delete_message missing required field; ignoring")
+		return
+	}
+	logger.Info().
+		Str("broadcaster", cmd.BroadcasterID).
+		Str("message_id", cmd.MessageID).
+		Msg("delete_message (scaffold: no Helix call yet)")
 }
 
 // HandleTwitchConnect spawns a Twitch EventSub client for the broadcaster in

--- a/apps/desktop/src-sidecar/internal/sidecar/sidecar_test.go
+++ b/apps/desktop/src-sidecar/internal/sidecar/sidecar_test.go
@@ -267,6 +267,117 @@ func TestDispatchCommand_IgnoresUnknown(t *testing.T) {
 	}
 }
 
+// bufLogger returns a zerolog logger that writes JSON lines to the returned
+// buffer, for assertions on log content in mod-action scaffolding tests.
+func bufLogger() (zerolog.Logger, *bytes.Buffer) {
+	var buf bytes.Buffer
+	return zerolog.New(&buf), &buf
+}
+
+func TestDispatchCommand_RoutesModActions(t *testing.T) {
+	clients := make(map[string]context.CancelFunc)
+	out := make(chan []byte, 1)
+
+	cases := []struct {
+		name string
+		cmd  control.Command
+		want string
+	}{
+		{
+			name: "ban_user",
+			cmd:  control.Command{Cmd: "ban_user", BroadcasterID: "b1", TargetUserID: "t1", Reason: "rule violation"},
+			want: "ban_user (scaffold",
+		},
+		{
+			name: "unban_user",
+			cmd:  control.Command{Cmd: "unban_user", BroadcasterID: "b1", TargetUserID: "t1"},
+			want: "unban_user (scaffold",
+		},
+		{
+			name: "timeout_user",
+			cmd:  control.Command{Cmd: "timeout_user", BroadcasterID: "b1", TargetUserID: "t1", DurationSeconds: 60},
+			want: "timeout_user (scaffold",
+		},
+		{
+			name: "delete_message",
+			cmd:  control.Command{Cmd: "delete_message", BroadcasterID: "b1", MessageID: "m1"},
+			want: "delete_message (scaffold",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			logger, buf := bufLogger()
+			DispatchCommand(context.Background(), tc.cmd, clients, out, func(string, any) {}, logger)
+			if !strings.Contains(buf.String(), tc.want) {
+				t.Errorf("expected log to contain %q, got %s", tc.want, buf.String())
+			}
+		})
+	}
+}
+
+func TestHandleBanUser_MissingTargetIgnored(t *testing.T) {
+	logger, buf := bufLogger()
+	HandleBanUser(control.Command{Cmd: "ban_user", BroadcasterID: "b1"}, logger)
+	if !strings.Contains(buf.String(), "missing required field") {
+		t.Errorf("expected warn about missing field, got %s", buf.String())
+	}
+	if strings.Contains(buf.String(), "scaffold") {
+		t.Errorf("scaffold-info line should NOT fire on validation failure, got %s", buf.String())
+	}
+}
+
+func TestHandleUnbanUser_MissingTargetIgnored(t *testing.T) {
+	logger, buf := bufLogger()
+	HandleUnbanUser(control.Command{Cmd: "unban_user", BroadcasterID: "b1"}, logger)
+	if !strings.Contains(buf.String(), "missing required field") {
+		t.Errorf("expected warn about missing field, got %s", buf.String())
+	}
+}
+
+func TestHandleTimeoutUser_RejectsOutOfRangeDuration(t *testing.T) {
+	// Helix enforces 1..1209600 seconds. Values outside this range must be
+	// rejected by the scaffold to stay consistent with the real endpoint.
+	cases := []struct {
+		name     string
+		duration int
+	}{
+		{"zero", 0},
+		{"negative", -1},
+		{"over_14_days", 1209601},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			logger, buf := bufLogger()
+			HandleTimeoutUser(control.Command{
+				Cmd:             "timeout_user",
+				BroadcasterID:   "b1",
+				TargetUserID:    "t1",
+				DurationSeconds: tc.duration,
+			}, logger)
+			if !strings.Contains(buf.String(), "out of range") {
+				t.Errorf("expected out-of-range warn for duration=%d, got %s", tc.duration, buf.String())
+			}
+		})
+	}
+}
+
+func TestHandleTimeoutUser_MissingTargetIgnored(t *testing.T) {
+	logger, buf := bufLogger()
+	HandleTimeoutUser(control.Command{Cmd: "timeout_user", BroadcasterID: "b1", DurationSeconds: 60}, logger)
+	if !strings.Contains(buf.String(), "missing required field") {
+		t.Errorf("expected warn about missing field, got %s", buf.String())
+	}
+}
+
+func TestHandleDeleteMessage_MissingMessageIDIgnored(t *testing.T) {
+	logger, buf := bufLogger()
+	HandleDeleteMessage(control.Command{Cmd: "delete_message", BroadcasterID: "b1"}, logger)
+	if !strings.Contains(buf.String(), "missing required field") {
+		t.Errorf("expected warn about missing field, got %s", buf.String())
+	}
+}
+
 func TestRunCommandLoop_DispatchesCommands(t *testing.T) {
 	// Pre-load the scanner with one twitch_connect, then close stdin so
 	// scanCommands exits cleanly. The loop itself stops when ctx is cancelled.


### PR DESCRIPTION
## Summary
- Extend `control.Command` with `TargetUserID`, `DurationSeconds`, `Reason`, `MessageID` — additive, all `omitempty`
- New dispatch cases + handlers for `ban_user`, `unban_user`, `timeout_user`, `delete_message`
- Each handler validates required fields per the Helix semantics it'll eventually call (timeout bound to the documented 1..1209600-second range) and log-only returns on misuse
- Locks the host→sidecar protocol now so a follow-up PR can wire the real POST /moderation/bans etc. without re-negotiating field names

Follow-up: rate-limited Helix client (PRI-20) and the actual API calls land on top of this scaffold once both it and PRI-19 (HelixClient) merge.

## Test plan
- [x] `go test ./...` — all packages ok
- [x] `golangci-lint run ./...` — 0 issues
- [x] `TestDispatchCommand_RoutesModActions` table-tests all four new cmd values
- [x] `TestHandleBanUser_MissingTargetIgnored` / `TestHandleUnbanUser_MissingTargetIgnored` / `TestHandleTimeoutUser_MissingTargetIgnored` / `TestHandleDeleteMessage_MissingMessageIDIgnored` — validation fires on missing required fields
- [x] `TestHandleTimeoutUser_RejectsOutOfRangeDuration` sub-cases: zero / negative / over-14-days
- [x] Existing `TestDispatchCommand_IgnoresUnknown` still passes — unknown cmds still fall through