### PR TITLE
feat: twitch helix http client with 429 retry

### DIFF
--- a/apps/desktop/src-sidecar/internal/twitch/client_test.go
+++ b/apps/desktop/src-sidecar/internal/twitch/client_test.go
@@ -1,0 +1,226 @@
+package twitch
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type followResp struct {
+	Data []struct {
+		UserName string `json:"user_name"`
+	} `json:"data"`
+}
+
+func newHelixTestClient(srv *httptest.Server) *HelixClient {
+	return &HelixClient{
+		HTTPClient:  srv.Client(),
+		BaseURL:     srv.URL,
+		ClientID:    "cid",
+		AccessToken: "tok",
+	}
+}
+
+func TestHelixClient_GetSendsAuthHeadersAndDecodesBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/users/follows" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Client-Id"); got != "cid" {
+			t.Errorf("Client-Id = %q, want cid", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer tok" {
+			t.Errorf("Authorization = %q, want %q", got, "Bearer tok")
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":[{"user_name":"alice"}]}`))
+	}))
+	defer srv.Close()
+
+	var out followResp
+	if err := newHelixTestClient(srv).Get(context.Background(), "/users/follows", &out); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(out.Data) != 1 || out.Data[0].UserName != "alice" {
+		t.Fatalf("unexpected body: %+v", out)
+	}
+}
+
+func TestHelixClient_PostSendsJSONBody(t *testing.T) {
+	var gotCT string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotCT = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	body := map[string]string{"k": "v"}
+	if err := newHelixTestClient(srv).Post(context.Background(), "/anything", body, nil); err != nil {
+		t.Fatalf("Post: %v", err)
+	}
+	if gotCT != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", gotCT)
+	}
+}
+
+func TestHelixClient_DeleteWorksWithNilDst(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Fatalf("expected DELETE, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	if err := newHelixTestClient(srv).Delete(context.Background(), "/moderation/bans", nil); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+}
+
+func TestHelixClient_401ReturnsUnauthorizedSentinel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"Unauthorized","status":401,"message":"Invalid OAuth token"}`))
+	}))
+	defer srv.Close()
+
+	var out followResp
+	err := newHelixTestClient(srv).Get(context.Background(), "/users", &out)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, ErrUnauthorized) {
+		t.Errorf("errors.Is(err, ErrUnauthorized) = false, want true (err=%v)", err)
+	}
+	var he *HelixError
+	if !errors.As(err, &he) {
+		t.Fatalf("expected *HelixError, got %T", err)
+	}
+	if he.Status != 401 || he.Message != "Invalid OAuth token" {
+		t.Errorf("HelixError fields = %+v, want Status=401 Message=%q", he, "Invalid OAuth token")
+	}
+}
+
+func TestHelixClient_NonJSONErrorBodyStillSurfaces(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`<html>gateway timeout</html>`))
+	}))
+	defer srv.Close()
+
+	var out followResp
+	err := newHelixTestClient(srv).Get(context.Background(), "/anything", &out)
+	var he *HelixError
+	if !errors.As(err, &he) {
+		t.Fatalf("expected *HelixError, got %T: %v", err, err)
+	}
+	if he.Status != 500 {
+		t.Errorf("Status = %d, want 500", he.Status)
+	}
+	if he.Message == "" {
+		t.Error("expected Message to carry raw body on non-JSON error, got empty")
+	}
+}
+
+func TestHelixClient_429RetriesOnceWithResetHeader(t *testing.T) {
+	// Twitch's `Ratelimit-Reset` is in whole Unix seconds, so this test uses
+	// a reset value in the past (0) to exercise the retry path without
+	// making the test suite wait a full second for the next tick.
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := calls.Add(1)
+		if n == 1 {
+			w.Header().Set("Ratelimit-Reset", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":"Too Many Requests","status":429}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer srv.Close()
+
+	var out followResp
+	if err := newHelixTestClient(srv).Get(context.Background(), "/ok-after-retry", &out); err != nil {
+		t.Fatalf("Get after retry: %v", err)
+	}
+	if calls.Load() != 2 {
+		t.Errorf("expected 2 calls (first 429, then 200), got %d", calls.Load())
+	}
+}
+
+func TestHelixClient_429TwiceReturnsRateLimited(t *testing.T) {
+	// Reset very close to now so the retry fires quickly.
+	reset := time.Now().Add(10 * time.Millisecond).Unix()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Ratelimit-Reset", strconv.FormatInt(reset, 10))
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	var out followResp
+	err := newHelixTestClient(srv).Get(context.Background(), "/always-429", &out)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, ErrRateLimited) {
+		t.Errorf("errors.Is(err, ErrRateLimited) = false, want true (err=%v)", err)
+	}
+}
+
+func TestHelixClient_ContextCancelledDuringRetrySleep(t *testing.T) {
+	// Reset 2 seconds out so the wait is always ≥1s after Twitch's Unix-
+	// seconds truncation. Cancelling at 30ms reliably interrupts it.
+	reset := time.Now().Add(2 * time.Second).Unix()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Ratelimit-Reset", strconv.FormatInt(reset, 10))
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		cancel()
+	}()
+
+	var out followResp
+	err := newHelixTestClient(srv).Get(ctx, "/slow-reset", &out)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestHelixClient_BaseURLDefaultsWhenEmpty(t *testing.T) {
+	// We can't hit the real api.twitch.tv in a test, so we can only verify
+	// that a HelixClient with BaseURL="" attempts to resolve the default
+	// host. Using an HTTPClient with a Transport that captures the URL
+	// without dialing proves the base-url path without network.
+	var capturedURL string
+	c := &HelixClient{
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			capturedURL = r.URL.String()
+			return nil, errSentinelNoopTransport
+		})},
+		ClientID:    "cid",
+		AccessToken: "tok",
+	}
+	_ = c.Get(context.Background(), "/users", nil)
+	if capturedURL != "https://api.twitch.tv/helix/users" {
+		t.Errorf("expected default base URL, got %s", capturedURL)
+	}
+}
+
+var errSentinelNoopTransport = errors.New("noop transport")
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }

--- a/apps/desktop/src-sidecar/internal/twitch/helix.go
+++ b/apps/desktop/src-sidecar/internal/twitch/helix.go
@@ -4,21 +4,227 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
+	"time"
 )
 
 const defaultHelixBase = "https://api.twitch.tv/helix"
 
-// Subscribe creates an EventSub subscription for channel.chat.message via the Helix API.
-// helixBase can be overridden for testing; pass "" to use the default.
-func Subscribe(ctx context.Context, helixBase, sessionID, broadcasterID, userID, accessToken, clientID string) error {
-	if helixBase == "" {
-		helixBase = defaultHelixBase
+// ErrUnauthorized is a sentinel returned (wrapped inside [HelixError]) when
+// the Helix API responds with 401. Callers use `errors.Is(err, ErrUnauthorized)`
+// to decide whether to kick off a token refresh.
+var ErrUnauthorized = errors.New("twitch helix: unauthorized")
+
+// ErrRateLimited is returned after a 429 response when the automatic
+// one-shot retry has already been consumed. Callers should back off per
+// the per-provider token bucket (ADR 27 / PRI-20) before trying again.
+var ErrRateLimited = errors.New("twitch helix: rate limit exceeded after retry")
+
+// HelixError is the structured error body Helix returns on 4xx/5xx.
+// Docs: https://dev.twitch.tv/docs/api/reference/ (error shape is documented
+// per endpoint, but the envelope is always `{error, status, message}`).
+type HelixError struct {
+	Status  int    `json:"status"`
+	Code    string `json:"error"`
+	Message string `json:"message"`
+}
+
+func (e *HelixError) Error() string {
+	return fmt.Sprintf("twitch helix %d %s: %s", e.Status, e.Code, e.Message)
+}
+
+// Is lets `errors.Is(err, ErrUnauthorized)` / `errors.Is(err, ErrRateLimited)`
+// succeed regardless of how the HelixError is wrapped up the call stack.
+func (e *HelixError) Is(target error) bool {
+	switch target {
+	case ErrUnauthorized:
+		return e.Status == http.StatusUnauthorized
+	case ErrRateLimited:
+		return e.Status == http.StatusTooManyRequests
+	}
+	return false
+}
+
+// HelixClient is a thin HTTP client for the Twitch Helix REST API. It owns
+// the auth headers (Client-Id, Bearer token), base URL override for tests,
+// and handles the Helix one-shot retry semantics on 429.
+//
+// Scope is deliberately narrow: no token bucket rate limiter (ADR 27 /
+// PRI-20), no OAuth refresh on 401 (lives with the OAuth module). Callers
+// receive `ErrUnauthorized` and decide whether to refresh + retry.
+type HelixClient struct {
+	HTTPClient  *http.Client
+	BaseURL     string
+	ClientID    string
+	AccessToken string
+}
+
+// Do sends a request and decodes the JSON response into dst (nil for "don't
+// care about the body"). On 429, it sleeps until `Ratelimit-Reset` and
+// retries exactly once; a second 429 returns [ErrRateLimited].
+//
+// Context cancellation during the retry sleep returns `ctx.Err()`.
+func (c *HelixClient) Do(ctx context.Context, method, path string, reqBody, dst any) error {
+	for attempt := 0; attempt < 2; attempt++ {
+		resp, err := c.doOnce(ctx, method, path, reqBody)
+		if err != nil {
+			return err
+		}
+
+		if resp.StatusCode == http.StatusTooManyRequests {
+			resetAt := parseRatelimitReset(resp.Header.Get("Ratelimit-Reset"))
+			closeBody(resp)
+			if attempt == 0 {
+				if err := waitUntil(ctx, resetAt); err != nil {
+					return err
+				}
+				continue
+			}
+			return &HelixError{Status: http.StatusTooManyRequests, Code: "Too Many Requests", Message: "rate limit exceeded"}
+		}
+
+		return decodeResponse(resp, dst)
+	}
+	// Unreachable: the loop either returns or continues, and we only `continue`
+	// on the first attempt.
+	return errors.New("twitch helix: impossible retry state")
+}
+
+// Get is a convenience wrapper for GET requests.
+func (c *HelixClient) Get(ctx context.Context, path string, dst any) error {
+	return c.Do(ctx, http.MethodGet, path, nil, dst)
+}
+
+// Post is a convenience wrapper for POST requests.
+func (c *HelixClient) Post(ctx context.Context, path string, reqBody, dst any) error {
+	return c.Do(ctx, http.MethodPost, path, reqBody, dst)
+}
+
+// Delete is a convenience wrapper for DELETE requests.
+func (c *HelixClient) Delete(ctx context.Context, path string, dst any) error {
+	return c.Do(ctx, http.MethodDelete, path, nil, dst)
+}
+
+func (c *HelixClient) doOnce(ctx context.Context, method, path string, reqBody any) (*http.Response, error) {
+	base := c.BaseURL
+	if base == "" {
+		base = defaultHelixBase
 	}
 
-	body, err := json.Marshal(SubscriptionRequest{
+	var body io.Reader
+	if reqBody != nil {
+		buf, err := json.Marshal(reqBody)
+		if err != nil {
+			return nil, fmt.Errorf("marshal helix request body: %w", err)
+		}
+		body = bytes.NewReader(buf)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, base+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("build helix request: %w", err)
+	}
+	req.Header.Set("Client-Id", c.ClientID)
+	req.Header.Set("Authorization", "Bearer "+c.AccessToken)
+	if reqBody != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	httpClient := c.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("helix request: %w", err)
+	}
+	return resp, nil
+}
+
+// decodeResponse consumes resp.Body. Returns a structured HelixError for any
+// non-2xx response; decodes JSON into dst for 2xx. A nil dst means the
+// caller does not need the body (202 Accepted etc.).
+func decodeResponse(resp *http.Response, dst any) error {
+	defer closeBody(resp)
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		buf, _ := io.ReadAll(resp.Body)
+		he := &HelixError{Status: resp.StatusCode}
+		// Best-effort decode. A non-JSON error body still surfaces via Message
+		// with the raw bytes so callers can log it.
+		if json.Unmarshal(buf, he) != nil {
+			he.Message = string(buf)
+		}
+		return he
+	}
+
+	if dst == nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(dst); err != nil {
+		return fmt.Errorf("decode helix response: %w", err)
+	}
+	return nil
+}
+
+func closeBody(resp *http.Response) {
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+}
+
+// parseRatelimitReset returns the absolute time the bucket refills. Twitch
+// sends `Ratelimit-Reset` as a Unix-seconds timestamp. An empty or malformed
+// value falls back to "retry immediately" (zero time).
+func parseRatelimitReset(header string) time.Time {
+	if header == "" {
+		return time.Time{}
+	}
+	ts, err := strconv.ParseInt(header, 10, 64)
+	if err != nil {
+		return time.Time{}
+	}
+	return time.Unix(ts, 0)
+}
+
+// waitUntil blocks until either the deadline passes or ctx is cancelled.
+// A zero-value deadline returns immediately.
+func waitUntil(ctx context.Context, deadline time.Time) error {
+	if deadline.IsZero() {
+		return nil
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(remaining)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// Subscribe creates an EventSub subscription for channel.chat.message via
+// the Helix API. `helixBase` can be overridden for testing; pass "" to use
+// the default. The signature is kept for the existing caller in eventsub.go;
+// internally it now goes through [HelixClient].
+func Subscribe(ctx context.Context, helixBase, sessionID, broadcasterID, userID, accessToken, clientID string) error {
+	client := &HelixClient{
+		BaseURL:     helixBase,
+		ClientID:    clientID,
+		AccessToken: accessToken,
+	}
+	req := SubscriptionRequest{
 		Type:    "channel.chat.message",
 		Version: "1",
 		Condition: map[string]string{
@@ -29,40 +235,28 @@ func Subscribe(ctx context.Context, helixBase, sessionID, broadcasterID, userID,
 			Method:    "websocket",
 			SessionID: sessionID,
 		},
-	})
-	if err != nil {
-		return fmt.Errorf("marshal subscription request: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, helixBase+"/eventsub/subscriptions", bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("create request: %w", err)
+	err := client.Post(ctx, "/eventsub/subscriptions", req, nil)
+	if err == nil {
+		return nil
 	}
-	req.Header.Set("Authorization", "Bearer "+accessToken)
-	req.Header.Set("Client-Id", clientID)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("helix request: %w", err)
+	// Preserve the existing callers' error surface: EventSub code uses
+	// errors.As against *AuthError to decide whether to surface an
+	// `auth_error` notification to the host. Map 401 onto that shape.
+	if errors.Is(err, ErrUnauthorized) {
+		var he *HelixError
+		if errors.As(err, &he) {
+			return &AuthError{Status: he.Status, Body: he.Error()}
+		}
 	}
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, readErr := io.ReadAll(resp.Body)
-	if readErr != nil {
-		return fmt.Errorf("read helix response (status %d): %w", resp.StatusCode, readErr)
-	}
-
-	if resp.StatusCode == http.StatusUnauthorized {
-		return &AuthError{Status: resp.StatusCode, Body: string(respBody)}
-	}
-	if resp.StatusCode != http.StatusAccepted {
-		return fmt.Errorf("helix returned %d: %s", resp.StatusCode, respBody)
-	}
-
-	return nil
+	return err
 }
 
+// AuthError is the legacy 401 error type for EventSub callers that predate
+// [HelixError]. Kept for backward compatibility with eventsub.go; new code
+// should check `errors.Is(err, ErrUnauthorized)` against a HelixError
+// directly instead.
 type AuthError struct {
 	Status int
 	Body   string


### PR DESCRIPTION
## Summary
- New `HelixClient{HTTPClient, BaseURL, ClientID, AccessToken}` with `Do`/`Get`/`Post`/`Delete`
- Structured `HelixError{Status, Code, Message}` deserialized from Helix's documented `{error, status, message}` error envelope
- Sentinels `ErrUnauthorized` / `ErrRateLimited` via `HelixError.Is(target error)` so callers use `errors.Is` regardless of wrapping
- One-shot 429 retry honoring `Ratelimit-Reset`; second 429 returns `ErrRateLimited`
- Context cancellation during retry sleep returns `ctx.Err()`
- Existing `Subscribe` refactored to delegate to `HelixClient`; legacy `AuthError` wrapper preserved so `eventsub.go`'s `errors.As` check keeps working
- `BaseURL` defaults to `https://api.twitch.tv/helix` when empty; tests point it at `httptest.NewServer`

Scope deliberately narrow: no token bucket rate limiter (ADR 27 / PRI-20) and no OAuth refresh-on-401 (lives with the OAuth module from ADR 37 / PRI-16 follow-up). Callers receive `ErrUnauthorized` and decide whether to refresh + retry.

## Test plan
- [x] `go test ./...` — all packages ok, twitch takes ~40s (existing slow EventSub reconnect tests, unrelated)
- [x] `golangci-lint run ./...` — 0 issues
- [x] 9 new tests in `client_test.go`:
  - `GetSendsAuthHeadersAndDecodesBody` — Client-Id + Bearer + JSON decode
  - `PostSendsJSONBody` — Content-Type set on bodies
  - `DeleteWorksWithNilDst` — skip body decode for 2xx no-content
  - `401ReturnsUnauthorizedSentinel` — `errors.Is(err, ErrUnauthorized)` and `errors.As` to `*HelixError`
  - `NonJSONErrorBodyStillSurfaces` — raw HTML body lands in `Message`
  - `429RetriesOnceWithResetHeader` — 2 HTTP calls after one 429
  - `429TwiceReturnsRateLimited` — sentinel on retry exhaustion
  - `ContextCancelledDuringRetrySleep` — `errors.Is(err, context.Canceled)` when ctx fires mid-sleep
  - `BaseURLDefaultsWhenEmpty` — fallback to production base URL
- [x] All existing `Subscribe*` tests still pass unchanged — the refactor is behavior-preserving