### PR TITLE
feat: twitch oauth library (dcf + keyring + refresh)

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -18,6 +18,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "aliri_braid"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df233d014e7a9ad9693f08f17eb198251fb75d94c345dcfa4bdedfecc67f24fb"
+dependencies = [
+ "aliri_braid_impl",
+]
+
+[[package]]
+name = "aliri_braid_impl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1eb7c4fcde1858a6796c18a729b661346d38e05a207e2d9028bce822fc20283"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,6 +80,206 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-object-pool"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333c456b97c3f2d50604e8b2624253b7f787208cb72eb75e64b0ad11b221652c"
+dependencies = [
+ "async-std",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.1",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-attributes",
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +315,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,13 +349,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "basic-cookies"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67bd8fd42c16bdb08688243dc5f0cc117a3ca9efeeaba3a345a18a6159ad96f7"
+dependencies = [
+ "lalrpop",
+ "lalrpop-util",
+ "regex",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -152,6 +420,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -282,6 +563,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -317,6 +600,23 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
 
 [[package]]
 name = "chrono"
@@ -383,6 +683,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,6 +699,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -458,6 +776,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,7 +805,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -499,7 +826,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -700,6 +1027,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,8 +1044,19 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -763,7 +1111,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
- "bit-set",
+ "bit-set 0.8.0",
  "cssparser 0.36.0",
  "foldhash 0.2.0",
  "html5ever 0.38.0",
@@ -841,6 +1189,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "ena"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -877,6 +1234,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.1",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,6 +1290,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -972,6 +1362,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,12 +1378,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1012,6 +1423,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1188,8 +1612,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1199,9 +1625,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1213,6 +1641,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -1301,6 +1730,18 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "gobject-sys"
@@ -1445,6 +1886,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -1455,12 +1907,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -1471,8 +1934,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1481,6 +1944,63 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "httpmock"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ec9586ee0910472dec1a1f0f8acf52f0fdde93aea74d70d4a3107b4be0fd5b"
+dependencies = [
+ "assert-json-diff",
+ "async-object-pool",
+ "async-std",
+ "async-trait",
+ "base64 0.21.7",
+ "basic-cookies",
+ "crossbeam-utils",
+ "form_urlencoded",
+ "futures-util",
+ "hyper 0.14.32",
+ "lazy_static",
+ "levenshtein",
+ "log",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_regex",
+ "similar",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
 
 [[package]]
 name = "hyper"
@@ -1492,14 +2012,29 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
+dependencies = [
+ "http 1.4.0",
+ "hyper 1.9.0",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1512,14 +2047,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.9.0",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1762,6 +2297,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1835,6 +2379,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1880,6 +2434,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "log",
+ "zeroize",
+]
+
+[[package]]
 name = "kuchikiki"
 version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1889,6 +2453,46 @@ dependencies = [
  "html5ever 0.29.1",
  "indexmap 2.13.1",
  "selectors 0.24.0",
+]
+
+[[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+dependencies = [
+ "ascii-canvas",
+ "bit-set 0.5.3",
+ "ena",
+ "itertools 0.11.0",
+ "lalrpop-util",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "string_cache 0.8.9",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -1902,6 +2506,12 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "levenshtein"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libappindicator"
@@ -1953,6 +2563,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1972,6 +2588,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+dependencies = [
+ "value-bag",
+]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac"
@@ -2329,6 +2954,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2370,6 +3001,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2403,6 +3040,16 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.13.1",
+]
 
 [[package]]
 name = "phf"
@@ -2592,10 +3239,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
 
 [[package]]
 name = "pkg-config"
@@ -2658,6 +3328,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2704,14 +3388,19 @@ dependencies = [
  "chrono",
  "criterion",
  "dotenvy",
+ "httpmock",
+ "keyring",
+ "reqwest",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-shell",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "twitch_oauth2",
  "windows",
 ]
 
@@ -2793,6 +3482,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.3",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.3",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2839,6 +3584,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2859,6 +3625,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2875,6 +3651,21 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rand_hc"
@@ -2927,6 +3718,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2999,19 +3801,25 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3021,6 +3829,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3039,6 +3861,94 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3051,6 +3961,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3109,6 +4028,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3224,6 +4166,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
+ "serde",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3331,7 +4283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3399,6 +4351,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3421,6 +4379,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "socket2"
@@ -3540,6 +4508,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -3678,7 +4652,7 @@ dependencies = [
  "glob",
  "gtk",
  "heck 0.5.0",
- "http",
+ "http 1.4.0",
  "jni",
  "libc",
  "log",
@@ -3823,7 +4797,7 @@ dependencies = [
  "cookie",
  "dpi",
  "gtk",
- "http",
+ "http 1.4.0",
  "jni",
  "objc2",
  "objc2-ui-kit",
@@ -3846,7 +4820,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e11ea2e6f801d275fdd890d6c9603736012742a1c33b96d0db788c9cdebf7f9e"
 dependencies = [
  "gtk",
- "http",
+ "http 1.4.0",
  "jni",
  "log",
  "objc2",
@@ -3878,7 +4852,7 @@ dependencies = [
  "dunce",
  "glob",
  "html5ever 0.29.1",
- "http",
+ "http 1.4.0",
  "infer",
  "json-patch",
  "kuchikiki",
@@ -3933,6 +4907,17 @@ checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
 dependencies = [
  "new_debug_unreachable",
  "utf-8",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
 ]
 
 [[package]]
@@ -4016,6 +5001,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4036,6 +5030,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4045,8 +5054,31 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "socket2",
+ "signal-hook-registry",
+ "socket2 0.6.3",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4191,8 +5223,8 @@ dependencies = [
  "bitflags 2.11.0",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -4302,6 +5334,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "twitch_oauth2"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08dc2f82af87d9794d20176d02b6b4e2f5301f59ba3faa0d6da61b33cd9ba620"
+dependencies = [
+ "aliri_braid",
+ "base64 0.22.1",
+ "displaydoc",
+ "futures",
+ "http 1.4.0",
+ "once_cell",
+ "rand 0.10.1",
+ "reqwest",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror 2.0.18",
+ "twitch_types",
+ "url",
+ "web-time",
+]
+
+[[package]]
+name = "twitch_types"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d8b75df4242373a919149324dff95f85b8c572adec6c00c8a315f4169eb1a29"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4373,6 +5438,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4426,6 +5497,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "version-compare"
@@ -4621,6 +5698,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4674,6 +5761,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4904,6 +6000,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5281,7 +6386,7 @@ dependencies = [
  "dunce",
  "gdkx11",
  "gtk",
- "http",
+ "http 1.4.0",
  "javascriptcore-rs",
  "jni",
  "libc",
@@ -5393,6 +6498,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -15,11 +15,23 @@ tauri = { version = "2.10", features = [] }
 tauri-plugin-shell = "2.3"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 dotenvy = "0.15"
+keyring = "3"
+reqwest = { version = "0.13", default-features = false, features = [
+    "rustls",
+    "json",
+] }
+twitch_oauth2 = { version = "0.17", default-features = false, features = ["reqwest"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["time"] }
+thiserror = "1"
+tokio = { version = "1", features = ["macros", "time"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dev-dependencies]
+criterion = "0.5"
+httpmock = "0.7"
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time"] }
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.61", features = [
@@ -34,9 +46,6 @@ windows = { version = "0.61", features = [
 # bench binary. Never enable in a release build; the exposed surface
 # includes raw ring-write primitives that skip back-pressure.
 __bench = []
-
-[dev-dependencies]
-criterion = "0.5"
 
 [[bench]]
 name = "drain_throughput"

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod host;
 mod message;
 pub mod ringbuf;
 mod sidecar_supervisor;
+pub mod twitch_auth;
 
 // Re-exports for the bench harness. Gated so the public crate surface
 // does not grow with bench-only plumbing in release builds.

--- a/apps/desktop/src-tauri/src/twitch_auth/errors.rs
+++ b/apps/desktop/src-tauri/src/twitch_auth/errors.rs
@@ -1,0 +1,50 @@
+//! Error type shared across the twitch_auth module.
+//!
+//! Each variant corresponds to a real decision branch a caller needs to
+//! make (re-auth UI per ADR 31, retry, surface to the user). Don't add
+//! variants unless the caller cares about the distinction.
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum AuthError {
+    /// No tokens have been persisted for this broadcaster. Supervisor's
+    /// correct response is to kick off the device flow.
+    #[error("no tokens stored for broadcaster {0}")]
+    NoTokens(String),
+
+    /// Refresh exchange succeeded with the server but the server said the
+    /// refresh token is invalid. Per ADR 31 this surfaces a re-auth UI;
+    /// do not retry with the same refresh token.
+    #[error("refresh token rejected; user must re-authenticate")]
+    RefreshTokenInvalid,
+
+    /// Device authorization flow ran past its deadline before the user
+    /// completed authorization. The caller should start a new flow.
+    #[error("device code expired before user authorized")]
+    DeviceCodeExpired,
+
+    /// User explicitly denied the authorization request.
+    #[error("user denied the device authorization")]
+    UserDenied,
+
+    /// Keyring / OS credential store error. Typically means the user
+    /// cancelled a prompt or the credential service is unavailable.
+    #[error(transparent)]
+    Keychain(#[from] keyring::Error),
+
+    /// Any other error from the OAuth stack (HTTP, URL parse, token
+    /// response decode, etc.). Callers that need finer-grained handling
+    /// can match on `self.source()`.
+    #[error("oauth2 stack error: {0}")]
+    OAuth(String),
+
+    /// JSON (de)serialization of the persisted token blob failed.
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+
+    /// Configuration error during AuthManager construction (malformed
+    /// URL, empty client id, etc.). Bug, not a runtime condition.
+    #[error("configuration error: {0}")]
+    Config(String),
+}

--- a/apps/desktop/src-tauri/src/twitch_auth/manager.rs
+++ b/apps/desktop/src-tauri/src/twitch_auth/manager.rs
@@ -1,0 +1,274 @@
+//! `AuthManager` — the façade callers interact with.
+//!
+//! Wraps the `twitch_oauth2` crate's Twitch-aware OAuth types + a
+//! [`TokenStore`] for keychain persistence. ADR 37 (DCF public client)
+//! and ADR 29 (proactive 5-min refresh) are enforced here.
+//!
+//! Three operations are exposed:
+//! - [`AuthManager::load_or_refresh`] — always-fresh tokens; refreshes
+//!   in-place if within ADR 29's threshold
+//! - [`AuthManager::start_device_flow`] — kicks off DCF, returns the
+//!   verification_uri for the caller to open in a browser
+//! - [`AuthManager::complete_device_flow`] — polls the token endpoint
+//!   until the user authorizes, persists the result
+
+use std::sync::Arc;
+
+use chrono::Utc;
+use twitch_oauth2::id::DeviceCodeResponse;
+use twitch_oauth2::tokens::{DeviceUserTokenBuilder, UserToken};
+use twitch_oauth2::types::{AccessToken, ClientId, RefreshToken};
+use twitch_oauth2::{Scope, TwitchToken};
+
+use super::errors::AuthError;
+use super::storage::TokenStore;
+use super::tokens::TwitchTokens;
+
+/// Proactive refresh threshold per ADR 29: refresh if the access token is
+/// within this many milliseconds of expiring.
+pub const REFRESH_THRESHOLD_MS: i64 = 5 * 60 * 1000;
+
+/// Builder for [`AuthManager`]. Base URLs aren't configurable because
+/// `twitch_oauth2` targets the production Twitch endpoints; tests use
+/// `mock_api` feature flag (out of scope for this PR).
+pub struct AuthManagerBuilder {
+    client_id: String,
+    scopes: Vec<Scope>,
+}
+
+impl AuthManagerBuilder {
+    pub fn new(client_id: impl Into<String>) -> Self {
+        Self {
+            client_id: client_id.into(),
+            scopes: Vec::new(),
+        }
+    }
+
+    /// Add a scope to request during the device flow. Scopes aren't
+    /// re-requested on refresh — Twitch returns whatever was originally
+    /// granted, or a subset.
+    #[must_use]
+    pub fn scope(mut self, scope: Scope) -> Self {
+        self.scopes.push(scope);
+        self
+    }
+
+    pub fn build<S: TokenStore + 'static>(
+        self,
+        store: S,
+        http_client: reqwest::Client,
+    ) -> AuthManager {
+        AuthManager {
+            client_id: ClientId::new(self.client_id),
+            scopes: self.scopes,
+            http_client,
+            store: Arc::new(store),
+        }
+    }
+}
+
+/// Stateful OAuth + keychain coordinator. Cheap to clone via the internal
+/// `Arc<TokenStore>` if the supervisor wants to share one across tasks.
+pub struct AuthManager {
+    client_id: ClientId,
+    scopes: Vec<Scope>,
+    http_client: reqwest::Client,
+    store: Arc<dyn TokenStore>,
+}
+
+impl AuthManager {
+    pub fn builder(client_id: impl Into<String>) -> AuthManagerBuilder {
+        AuthManagerBuilder::new(client_id)
+    }
+
+    /// Returns the shared HTTP client. Callers that need to reuse the
+    /// same redirect-disabled configuration (e.g. for other Twitch API
+    /// calls) can clone from here rather than building a second one.
+    #[must_use]
+    pub fn http_client(&self) -> &reqwest::Client {
+        &self.http_client
+    }
+
+    /// Loads stored tokens for the broadcaster, refreshing if within
+    /// [`REFRESH_THRESHOLD_MS`] of expiry. The refreshed tokens are
+    /// persisted (Twitch rotates the refresh token on every use).
+    pub async fn load_or_refresh(&self, broadcaster_id: &str) -> Result<TwitchTokens, AuthError> {
+        let Some(stored) = self.store.load(broadcaster_id)? else {
+            return Err(AuthError::NoTokens(broadcaster_id.to_owned()));
+        };
+
+        if !stored.needs_refresh(Utc::now().timestamp_millis(), REFRESH_THRESHOLD_MS) {
+            return Ok(stored);
+        }
+
+        let refreshed = self.refresh_tokens(&stored).await?;
+        self.store.save(broadcaster_id, &refreshed)?;
+        Ok(refreshed)
+    }
+
+    /// Requests a device code from Twitch. The returned response has
+    /// `verification_uri` which the caller should open in a browser,
+    /// and a `device_code` that [`AuthManager::complete_device_flow`]
+    /// needs to pair with.
+    ///
+    /// The returned builder is consumed on the next call, so start and
+    /// complete must happen in order on the same instance.
+    pub async fn start_device_flow(&self) -> Result<PendingDeviceFlow, AuthError> {
+        let mut builder = DeviceUserTokenBuilder::new(self.client_id.clone(), self.scopes.clone());
+        let details = builder
+            .start(&self.http_client)
+            .await
+            .map_err(|e| AuthError::OAuth(e.to_string()))?
+            .clone();
+        Ok(PendingDeviceFlow { builder, details })
+    }
+
+    /// Polls the Twitch token endpoint until the user authorizes the
+    /// device code. On success, the resulting tokens are persisted under
+    /// `broadcaster_id`.
+    pub async fn complete_device_flow(
+        &self,
+        mut pending: PendingDeviceFlow,
+        broadcaster_id: &str,
+    ) -> Result<TwitchTokens, AuthError> {
+        let user_token = pending
+            .builder
+            .wait_for_code(&self.http_client, tokio::time::sleep)
+            .await
+            .map_err(classify_device_flow_error)?;
+        let tokens = tokens_from_user_token(&user_token);
+        self.store.save(broadcaster_id, &tokens)?;
+        Ok(tokens)
+    }
+
+    async fn refresh_tokens(&self, stored: &TwitchTokens) -> Result<TwitchTokens, AuthError> {
+        // Reconstruct a UserToken from the stored credentials with no
+        // secret (public client per ADR 37), then call refresh_token to
+        // rotate both access and refresh tokens in-place.
+        let mut token = UserToken::from_existing(
+            &self.http_client,
+            AccessToken::new(stored.access_token.clone()),
+            Some(RefreshToken::new(stored.refresh_token.clone())),
+            None, // no client secret — public client
+        )
+        .await
+        .map_err(classify_refresh_error)?;
+
+        token
+            .refresh_token(&self.http_client)
+            .await
+            .map_err(classify_refresh_error)?;
+
+        Ok(tokens_from_user_token(&token))
+    }
+}
+
+/// Opaque handle returned by [`AuthManager::start_device_flow`], carrying
+/// the device code response (for UX: show verification URI) and the
+/// builder state (for [`AuthManager::complete_device_flow`] to resume
+/// polling). A single flow is consumed exactly once.
+pub struct PendingDeviceFlow {
+    builder: DeviceUserTokenBuilder,
+    details: DeviceCodeResponse,
+}
+
+impl PendingDeviceFlow {
+    #[must_use]
+    pub fn details(&self) -> &DeviceCodeResponse {
+        &self.details
+    }
+}
+
+fn tokens_from_user_token(token: &UserToken) -> TwitchTokens {
+    let expires_in_ms = i64::try_from(token.expires_in().as_millis()).unwrap_or(i64::MAX);
+    let now_ms = Utc::now().timestamp_millis();
+    TwitchTokens {
+        access_token: token.access_token.secret().to_owned(),
+        refresh_token: token
+            .refresh_token
+            .as_ref()
+            .map(|r| r.secret().to_owned())
+            .unwrap_or_default(),
+        expires_at_ms: now_ms.saturating_add(expires_in_ms),
+        scopes: token.scopes().iter().map(|s| s.to_string()).collect(),
+    }
+}
+
+fn classify_device_flow_error<E: std::fmt::Display>(err: E) -> AuthError {
+    let s = err.to_string();
+    if s.contains("access_denied") {
+        AuthError::UserDenied
+    } else if s.contains("expired_token") {
+        AuthError::DeviceCodeExpired
+    } else {
+        AuthError::OAuth(s)
+    }
+}
+
+fn classify_refresh_error<E: std::fmt::Display>(err: E) -> AuthError {
+    let s = err.to_string();
+    if s.contains("invalid_grant") || s.contains("Invalid refresh token") {
+        AuthError::RefreshTokenInvalid
+    } else {
+        AuthError::OAuth(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::twitch_auth::storage::MemoryStore;
+
+    fn test_http_client() -> reqwest::Client {
+        reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .expect("reqwest client")
+    }
+
+    #[tokio::test]
+    async fn load_or_refresh_returns_no_tokens_when_store_empty() {
+        let mgr = AuthManager::builder("test-client-id")
+            .build(MemoryStore::default(), test_http_client());
+
+        match mgr.load_or_refresh("b1").await {
+            Err(AuthError::NoTokens(id)) => assert_eq!(id, "b1"),
+            other => panic!("expected NoTokens, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn load_or_refresh_returns_fresh_tokens_verbatim() {
+        // Use a MemoryStoreHandle to share the store between manager and
+        // test assertions without having the manager take ownership.
+        let store = Arc::new(MemoryStore::default());
+
+        struct Handle(Arc<MemoryStore>);
+        impl TokenStore for Handle {
+            fn load(&self, id: &str) -> Result<Option<TwitchTokens>, AuthError> {
+                self.0.load(id)
+            }
+            fn save(&self, id: &str, t: &TwitchTokens) -> Result<(), AuthError> {
+                self.0.save(id, t)
+            }
+            fn delete(&self, id: &str) -> Result<(), AuthError> {
+                self.0.delete(id)
+            }
+        }
+
+        let mgr =
+            AuthManager::builder("test-client-id").build(Handle(store.clone()), test_http_client());
+
+        let fresh = TwitchTokens {
+            access_token: "at-fresh".into(),
+            refresh_token: "rt-fresh".into(),
+            expires_at_ms: Utc::now().timestamp_millis() + 60 * 60 * 1000,
+            scopes: vec!["user:read:chat".into()],
+        };
+        store.save("b1", &fresh).unwrap();
+
+        let got = mgr.load_or_refresh("b1").await.unwrap();
+        assert_eq!(got, fresh);
+    }
+}

--- a/apps/desktop/src-tauri/src/twitch_auth/manager.rs
+++ b/apps/desktop/src-tauri/src/twitch_auth/manager.rs
@@ -227,6 +227,54 @@ mod tests {
             .expect("reqwest client")
     }
 
+    #[test]
+    fn classify_device_flow_error_maps_access_denied() {
+        match classify_device_flow_error("access_denied") {
+            AuthError::UserDenied => {}
+            other => panic!("expected UserDenied, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_device_flow_error_maps_expired_token() {
+        match classify_device_flow_error("expired_token while polling") {
+            AuthError::DeviceCodeExpired => {}
+            other => panic!("expected DeviceCodeExpired, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_device_flow_error_falls_through_to_oauth() {
+        match classify_device_flow_error("some other failure") {
+            AuthError::OAuth(s) => assert!(s.contains("some other failure")),
+            other => panic!("expected OAuth, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_refresh_error_maps_invalid_grant() {
+        match classify_refresh_error("invalid_grant") {
+            AuthError::RefreshTokenInvalid => {}
+            other => panic!("expected RefreshTokenInvalid, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_refresh_error_maps_invalid_refresh_token_phrase() {
+        match classify_refresh_error("HTTP 400: Invalid refresh token") {
+            AuthError::RefreshTokenInvalid => {}
+            other => panic!("expected RefreshTokenInvalid, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_refresh_error_falls_through_to_oauth() {
+        match classify_refresh_error("connection reset by peer") {
+            AuthError::OAuth(s) => assert!(s.contains("connection reset")),
+            other => panic!("expected OAuth, got {other:?}"),
+        }
+    }
+
     #[tokio::test]
     async fn load_or_refresh_returns_no_tokens_when_store_empty() {
         let mgr = AuthManager::builder("test-client-id")

--- a/apps/desktop/src-tauri/src/twitch_auth/mod.rs
+++ b/apps/desktop/src-tauri/src/twitch_auth/mod.rs
@@ -1,0 +1,27 @@
+//! Twitch OAuth + keychain integration.
+//!
+//! Implements ADR 37 (Twitch Device Code Grant public client, tokens via
+//! `keyring-rs`), ADR 29 (proactive refresh 5 min before expiry), and
+//! ADR 31 (re-auth path on refresh failure). The flow:
+//!
+//! 1. At startup the supervisor calls [`AuthManager::load_or_refresh`]
+//!    for the broadcaster. If fresh, the access token is handed to the
+//!    sidecar via `twitch_connect`. If stale, the manager refreshes
+//!    transparently and persists the rotated refresh token.
+//! 2. On [`AuthError::NoTokens`] (first run / keychain cleared) or
+//!    [`AuthError::RefreshTokenInvalid`] (30-day inactive expiry), the
+//!    frontend kicks [`AuthManager::start_device_flow`] →
+//!    [`AuthManager::complete_device_flow`].
+//!
+//! The module is pure-logic and async-only; wiring into the supervisor
+//! lives in PRI-21.
+
+pub mod errors;
+pub mod manager;
+pub mod storage;
+pub mod tokens;
+
+pub use errors::AuthError;
+pub use manager::{AuthManager, AuthManagerBuilder, PendingDeviceFlow, REFRESH_THRESHOLD_MS};
+pub use storage::{KeychainStore, MemoryStore, TokenStore, KEYCHAIN_SERVICE};
+pub use tokens::TwitchTokens;

--- a/apps/desktop/src-tauri/src/twitch_auth/storage.rs
+++ b/apps/desktop/src-tauri/src/twitch_auth/storage.rs
@@ -1,0 +1,162 @@
+//! Persistence layer for [`TwitchTokens`].
+//!
+//! The [`TokenStore`] trait isolates keychain access behind a minimal
+//! interface so the manager and its tests can share the same call path.
+//! Prod uses [`KeychainStore`]; tests use [`MemoryStore`].
+//!
+//! Per ADR 37 the keychain layout is: service `prismoid.twitch`, account
+//! `<broadcaster_id>`, password is a serde-JSON blob of [`TwitchTokens`].
+//! One keychain prompt per save, one per load, atomic per broadcaster.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use keyring::Entry;
+
+use super::errors::AuthError;
+use super::tokens::TwitchTokens;
+
+/// Keychain service name. Kept as a const so both the Rust side and any
+/// future CLI tool / migration script read the same key.
+pub const KEYCHAIN_SERVICE: &str = "prismoid.twitch";
+
+/// Read/write/delete a persisted [`TwitchTokens`] blob, keyed by
+/// broadcaster ID. Impls must be `Send + Sync` so the manager can live
+/// behind an `Arc` shared with the supervisor task.
+pub trait TokenStore: Send + Sync {
+    fn load(&self, broadcaster_id: &str) -> Result<Option<TwitchTokens>, AuthError>;
+    fn save(&self, broadcaster_id: &str, tokens: &TwitchTokens) -> Result<(), AuthError>;
+    fn delete(&self, broadcaster_id: &str) -> Result<(), AuthError>;
+}
+
+/// Production [`TokenStore`] backed by the OS's native credential store
+/// (Windows Credential Manager / macOS Keychain / Linux Secret Service)
+/// via the `keyring` crate.
+///
+/// Construction does not touch the keychain; the backing store must have
+/// been initialized via `keyring::set_default_store` before any method
+/// on the produced `Entry` is called. The supervisor does this once at
+/// process start.
+#[derive(Default, Debug)]
+pub struct KeychainStore;
+
+impl TokenStore for KeychainStore {
+    fn load(&self, broadcaster_id: &str) -> Result<Option<TwitchTokens>, AuthError> {
+        let entry = Entry::new(KEYCHAIN_SERVICE, broadcaster_id)?;
+        match entry.get_password() {
+            Ok(blob) => {
+                let tokens: TwitchTokens = serde_json::from_str(&blob)?;
+                Ok(Some(tokens))
+            }
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(e) => Err(AuthError::Keychain(e)),
+        }
+    }
+
+    fn save(&self, broadcaster_id: &str, tokens: &TwitchTokens) -> Result<(), AuthError> {
+        let entry = Entry::new(KEYCHAIN_SERVICE, broadcaster_id)?;
+        let blob = serde_json::to_string(tokens)?;
+        entry.set_password(&blob)?;
+        Ok(())
+    }
+
+    fn delete(&self, broadcaster_id: &str) -> Result<(), AuthError> {
+        let entry = Entry::new(KEYCHAIN_SERVICE, broadcaster_id)?;
+        match entry.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+            Err(e) => Err(AuthError::Keychain(e)),
+        }
+    }
+}
+
+/// In-memory [`TokenStore`] for tests. Never touches the OS keychain so
+/// the test suite doesn't pop credential prompts, doesn't leak fixtures
+/// across runs, and doesn't conflict with any real user's saved tokens.
+#[derive(Default, Debug)]
+pub struct MemoryStore {
+    inner: Mutex<HashMap<String, TwitchTokens>>,
+}
+
+impl TokenStore for MemoryStore {
+    fn load(&self, broadcaster_id: &str) -> Result<Option<TwitchTokens>, AuthError> {
+        let guard = self.inner.lock().expect("MemoryStore mutex poisoned");
+        Ok(guard.get(broadcaster_id).cloned())
+    }
+
+    fn save(&self, broadcaster_id: &str, tokens: &TwitchTokens) -> Result<(), AuthError> {
+        let mut guard = self.inner.lock().expect("MemoryStore mutex poisoned");
+        guard.insert(broadcaster_id.to_owned(), tokens.clone());
+        Ok(())
+    }
+
+    fn delete(&self, broadcaster_id: &str) -> Result<(), AuthError> {
+        let mut guard = self.inner.lock().expect("MemoryStore mutex poisoned");
+        guard.remove(broadcaster_id);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> TwitchTokens {
+        TwitchTokens {
+            access_token: "at".into(),
+            refresh_token: "rt".into(),
+            expires_at_ms: 1_000_000,
+            scopes: vec!["user:read:chat".into()],
+        }
+    }
+
+    #[test]
+    fn memory_store_load_missing_returns_none() {
+        let store = MemoryStore::default();
+        assert!(store.load("unknown").unwrap().is_none());
+    }
+
+    #[test]
+    fn memory_store_save_then_load_returns_same() {
+        let store = MemoryStore::default();
+        let t = sample();
+        store.save("b1", &t).unwrap();
+        assert_eq!(store.load("b1").unwrap().unwrap(), t);
+    }
+
+    #[test]
+    fn memory_store_save_overwrites() {
+        let store = MemoryStore::default();
+        let mut t = sample();
+        store.save("b1", &t).unwrap();
+        t.access_token = "at2".into();
+        store.save("b1", &t).unwrap();
+        assert_eq!(store.load("b1").unwrap().unwrap(), t);
+    }
+
+    #[test]
+    fn memory_store_delete_removes_entry() {
+        let store = MemoryStore::default();
+        store.save("b1", &sample()).unwrap();
+        store.delete("b1").unwrap();
+        assert!(store.load("b1").unwrap().is_none());
+    }
+
+    #[test]
+    fn memory_store_delete_missing_is_noop() {
+        let store = MemoryStore::default();
+        store.delete("never-existed").unwrap();
+    }
+
+    #[test]
+    fn memory_store_broadcasters_are_isolated() {
+        let store = MemoryStore::default();
+        let mut a = sample();
+        a.access_token = "A".into();
+        let mut b = sample();
+        b.access_token = "B".into();
+        store.save("alpha", &a).unwrap();
+        store.save("beta", &b).unwrap();
+        assert_eq!(store.load("alpha").unwrap().unwrap().access_token, "A");
+        assert_eq!(store.load("beta").unwrap().unwrap().access_token, "B");
+    }
+}

--- a/apps/desktop/src-tauri/src/twitch_auth/tokens.rs
+++ b/apps/desktop/src-tauri/src/twitch_auth/tokens.rs
@@ -1,0 +1,82 @@
+//! Persistable token DTO.
+//!
+//! [`oauth2`] provides its own `BasicTokenResponse` at runtime, but that
+//! type isn't designed for serde-to-disk (secrets are wrapped opaquely and
+//! the shape isn't a stable wire format). `TwitchTokens` is what we
+//! actually store in the keychain: flat strings + an absolute expiry.
+
+use serde::{Deserialize, Serialize};
+
+/// A persisted Twitch OAuth credential set. One of these per broadcaster
+/// lives as a JSON blob in the keychain under service `prismoid.twitch`
+/// with account `<broadcaster_id>` (see ADR 37).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TwitchTokens {
+    pub access_token: String,
+    pub refresh_token: String,
+    /// Unix milliseconds at which `access_token` expires. Absolute time
+    /// is captured at save, not expires_in, so a sidecar that's been
+    /// asleep for hours still evaluates freshness correctly on wake.
+    pub expires_at_ms: i64,
+    /// Scopes granted. Carried so a scope-expansion feature can prompt
+    /// re-auth when needed without speculative re-auth on every launch.
+    pub scopes: Vec<String>,
+}
+
+impl TwitchTokens {
+    /// Returns true if the access token is either already expired or
+    /// within `threshold_ms` of expiring — either way the caller should
+    /// refresh before using it. ADR 29 pins the threshold to 5 min.
+    #[must_use]
+    pub fn needs_refresh(&self, now_ms: i64, threshold_ms: i64) -> bool {
+        now_ms + threshold_ms >= self.expires_at_ms
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample(expires_at_ms: i64) -> TwitchTokens {
+        TwitchTokens {
+            access_token: "at".into(),
+            refresh_token: "rt".into(),
+            expires_at_ms,
+            scopes: vec!["user:read:chat".into()],
+        }
+    }
+
+    #[test]
+    fn needs_refresh_fresh_token_returns_false() {
+        let t = sample(1_000_000);
+        assert!(!t.needs_refresh(0, 300_000));
+    }
+
+    #[test]
+    fn needs_refresh_exactly_at_threshold_returns_true() {
+        // now + threshold == expires_at is the boundary: the token has
+        // exactly `threshold` ms left. Refresh now, not later.
+        let t = sample(1_000_000);
+        assert!(t.needs_refresh(700_000, 300_000));
+    }
+
+    #[test]
+    fn needs_refresh_one_ms_before_threshold_returns_false() {
+        let t = sample(1_000_000);
+        assert!(!t.needs_refresh(699_999, 300_000));
+    }
+
+    #[test]
+    fn needs_refresh_already_expired_returns_true() {
+        let t = sample(500_000);
+        assert!(t.needs_refresh(1_000_000, 0));
+    }
+
+    #[test]
+    fn roundtrip_json_preserves_all_fields() {
+        let t = sample(1_234_567);
+        let blob = serde_json::to_string(&t).unwrap();
+        let back: TwitchTokens = serde_json::from_str(&blob).unwrap();
+        assert_eq!(t, back);
+    }
+}

--- a/apps/desktop/src-tauri/src/twitch_auth/tokens.rs
+++ b/apps/desktop/src-tauri/src/twitch_auth/tokens.rs
@@ -10,7 +10,12 @@ use serde::{Deserialize, Serialize};
 /// A persisted Twitch OAuth credential set. One of these per broadcaster
 /// lives as a JSON blob in the keychain under service `prismoid.twitch`
 /// with account `<broadcaster_id>` (see ADR 37).
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+///
+/// `Debug` is hand-rolled to redact token secrets. Any accidental
+/// `tracing::debug!("{tokens:?}")` or similar at a call site must not
+/// leak the access/refresh tokens to log files. Same pattern oauth2's
+/// `AccessToken` type uses.
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TwitchTokens {
     pub access_token: String,
     pub refresh_token: String,
@@ -21,6 +26,17 @@ pub struct TwitchTokens {
     /// Scopes granted. Carried so a scope-expansion feature can prompt
     /// re-auth when needed without speculative re-auth on every launch.
     pub scopes: Vec<String>,
+}
+
+impl std::fmt::Debug for TwitchTokens {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TwitchTokens")
+            .field("access_token", &"[redacted]")
+            .field("refresh_token", &"[redacted]")
+            .field("expires_at_ms", &self.expires_at_ms)
+            .field("scopes", &self.scopes)
+            .finish()
+    }
 }
 
 impl TwitchTokens {
@@ -78,5 +94,28 @@ mod tests {
         let blob = serde_json::to_string(&t).unwrap();
         let back: TwitchTokens = serde_json::from_str(&blob).unwrap();
         assert_eq!(t, back);
+    }
+
+    #[test]
+    fn debug_impl_redacts_secrets() {
+        let t = TwitchTokens {
+            access_token: "super-secret-access-xyz".into(),
+            refresh_token: "super-secret-refresh-xyz".into(),
+            expires_at_ms: 1_234_567,
+            scopes: vec!["user:read:chat".into()],
+        };
+        let debug_str = format!("{t:?}");
+        assert!(
+            !debug_str.contains("super-secret-access-xyz"),
+            "access_token leaked through Debug: {debug_str}"
+        );
+        assert!(
+            !debug_str.contains("super-secret-refresh-xyz"),
+            "refresh_token leaked through Debug: {debug_str}"
+        );
+        assert!(debug_str.contains("[redacted]"));
+        // Non-secret fields still observable for debugging.
+        assert!(debug_str.contains("1234567"));
+        assert!(debug_str.contains("user:read:chat"));
     }
 }


### PR DESCRIPTION
## Summary
Implements ADR 37 (Twitch Device Code Grant, keychain storage) + ADR 29 (proactive 5-min refresh) + ADR 31 (re-auth path on refresh failure) as a self-contained library module. No supervisor wiring yet — that's PRI-21 directly on top.

### Stack
- `twitch_oauth2 = "0.17"` (twitch-rs org) for DCF + refresh — handles Twitch's non-standard `scope`-as-array response that the generic `oauth2` crate rejects
- `keyring = "3"` for native OS credential storage (Windows Credential Manager / macOS Keychain / Linux Secret Service)
- `reqwest = "0.13"` (required by twitch_oauth2; bumped from 0.12)

### Layout (`apps/desktop/src-tauri/src/twitch_auth/`)
- `tokens.rs` — `TwitchTokens { access_token, refresh_token, expires_at_ms, scopes }` + `needs_refresh(now_ms, threshold_ms)`
- `storage.rs` — `TokenStore` trait, `KeychainStore` prod impl, `MemoryStore` for tests. Service name `prismoid.twitch`, account is broadcaster_id (ADR 37)
- `manager.rs` — `AuthManager` façade: `load_or_refresh`, `start_device_flow`, `complete_device_flow`
- `errors.rs` — `AuthError` with variants matching each caller decision branch (`NoTokens`, `RefreshTokenInvalid`, `DeviceCodeExpired`, `UserDenied`, ...)

## Test plan
- [x] `cargo test --lib twitch_auth` — 13/13 pass
  - Token `needs_refresh` boundary cases (fresh, exactly at threshold, 1ms before, already expired)
  - Token JSON round-trip
  - `MemoryStore` load/save/delete, broadcaster isolation, overwrite
  - `AuthManager::load_or_refresh` returns `NoTokens` when empty, returns fresh tokens verbatim
- [x] `cargo clippy --lib --tests -- -D warnings` — clean
- [x] Module hidden behind `pub mod twitch_auth` in `lib.rs`; supervisor ignores it until PRI-21

## Out of scope
- Supervisor wiring (PRI-21 — replace `.env.local` reader, trigger DCF on first run, `load_or_refresh` each iteration)
- Frontend re-auth UI (PRI-22 — button + Tauri commands)
- End-to-end DCF test against real Twitch (covered by manual run in PRI-21)