### PR TITLE
feat: bench harness for ring drain + parse hot path

### DIFF
--- a/apps/desktop/src-tauri/BENCHMARKS.md
+++ b/apps/desktop/src-tauri/BENCHMARKS.md
@@ -1,0 +1,67 @@
+# Ring buffer drain + parse benchmarks
+
+Microbenchmarks for the host's hot path. See
+[`benches/drain_throughput.rs`](benches/drain_throughput.rs) and PRI-15.
+
+## Running
+
+```sh
+# From apps/desktop/src-tauri
+cargo bench --features __bench
+```
+
+The `__bench` feature exposes internal writer + parser helpers to the
+bench binary only. It must be explicitly enabled; `cargo bench` without
+it will fail at link time with a missing-symbols error. The feature
+flag never ships in release builds.
+
+Criterion writes HTML reports to `target/criterion/<group>/<param>/report/`.
+
+## Groups
+
+- **`drain_only`** — `RingBufReader::drain()` on a ring pre-filled with
+  N copies of a representative Twitch `channel.chat.message` envelope
+  (~1.1 KiB each). Measures the cost of walking the ring + copying
+  bytes out into `Vec<Vec<u8>>`.
+- **`parse_only`** — `host::parse_batch` on a pre-built
+  `Vec<Vec<u8>>`. Measures `serde_json::from_slice` + timestamp parse
+  - flag-derivation, isolated from the ring.
+- **`drain_and_parse`** — the full supervisor-hot-loop shape:
+  pre-fill ring, drain, parse, emit-ready batch.
+
+Each group sweeps N ∈ {10, 100, 1000, 10000} and reports throughput in
+elements/sec.
+
+## Baseline
+
+Captured 2026-04-13 via `cargo bench --features __bench -- --warm-up-time 1 --measurement-time 3 --sample-size 30`.
+Reference machine: Windows 11, Ryzen desktop. Median times. Lower is better.
+
+| Group             | N=10    | N=100    | N=1000   | N=10000  |
+| ----------------- | ------- | -------- | -------- | -------- |
+| `drain_only`      | 16.7 µs | 16.9 µs  | 205.9 µs | 4.45 ms  |
+| `parse_only`      | 34.8 µs | 489.9 µs | 5.40 ms  | 49.85 ms |
+| `drain_and_parse` | 73.7 µs | 590.6 µs | 5.64 ms  | 55.84 ms |
+
+### Reading the numbers
+
+- Combined `drain_and_parse` at N=10000 = **55.8 ms**, i.e. ~179 k msg/sec
+  per drain-and-parse cycle — roughly **18× over** the 10k/sec peak target
+  from `docs/performance.md`. Headroom is comfortable.
+- `parse_only` dominates: ~5 µs per message, mostly `serde_json::from_slice`
+  doing owned-`String` field allocations. This is PRI-8's main lever
+  (simd-json or sonic-rs would plausibly cut it by 3-5×).
+- `drain_only` is ~440 ns/message at N=10000, almost all of which is the
+  per-message `Vec<u8>` allocation in `drain() -> Vec<Vec<u8>>`. Replacing
+  that with a callback-style `drain_with<F>` is PRI-8's secondary lever.
+- Small-N measurements (N=10) are dominated by fixed per-iteration
+  overhead (64 MiB `CreateFileMapping` first-page-touch, criterion
+  instrumentation). Compare relative deltas at N=1000+ for meaningful
+  signal.
+
+## Not running in CI
+
+CI intentionally does not run benches (too slow, too noisy, hardware
+variance dominates signal). Treat the numbers in this file as a local
+baseline against which PRI-8's before/after delta is the only thing
+that matters — the absolute values are not a contract.

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -42,6 +42,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,6 +270,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,6 +329,58 @@ dependencies = [
  "serde",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "combine"
@@ -397,6 +467,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,10 +512,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -682,6 +813,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "embed-resource"
@@ -1229,6 +1366,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1260,6 +1408,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1578,6 +1732,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is-wsl"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1585,6 +1750,15 @@ checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
 dependencies = [
  "is-docker",
  "once_cell",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -2137,6 +2311,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "open"
 version = "5.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2437,6 +2617,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "png"
 version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2494,6 +2702,7 @@ name = "prismoid"
 version = "0.0.1"
 dependencies = [
  "chrono",
+ "criterion",
  "dotenvy",
  "serde",
  "serde_json",
@@ -2690,6 +2899,26 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -3794,6 +4023,16 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -28,3 +28,17 @@ windows = { version = "0.61", features = [
     "Win32_Security",
     "Win32_System_Threading",
 ] }
+
+[features]
+# Opt-in feature that exposes internal write + parse helpers to the
+# bench binary. Never enable in a release build; the exposed surface
+# includes raw ring-write primitives that skip back-pressure.
+__bench = []
+
+[dev-dependencies]
+criterion = "0.5"
+
+[[bench]]
+name = "drain_throughput"
+harness = false
+required-features = ["__bench"]

--- a/apps/desktop/src-tauri/benches/drain_throughput.rs
+++ b/apps/desktop/src-tauri/benches/drain_throughput.rs
@@ -1,0 +1,158 @@
+//! Baseline benchmarks for the host's ring-buffer drain + parse hot path.
+//!
+//! Enabled only under `cargo bench --features __bench` (see `Cargo.toml`).
+//! Three groups:
+//! - `drain_only`    — `RingBufReader::drain()` on a pre-filled ring
+//! - `parse_only`    — `host::parse_batch` on a pre-built `Vec<Vec<u8>>`
+//! - `drain_and_parse` — the full hot-loop shape the supervisor runs
+//!
+//! See PRI-15 for why this lands first and PRI-8 for what the numbers
+//! are meant to gate.
+
+#[cfg(not(windows))]
+compile_error!(
+    "drain_throughput bench is windows-only: the ring buffer primitive is \
+     implemented on windows first (ADR 18)"
+);
+
+use criterion::{
+    black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput,
+};
+
+use prismoid_lib::ringbuf::RingBufReader;
+use prismoid_lib::{parse_batch, UnifiedMessage};
+
+/// Ring capacity large enough to hold the worst-case sweep point
+/// (`10_000 * TWITCH_MESSAGE.len()` ≈ 17 MiB) without wrapping during
+/// pre-fill, with headroom for the 4-byte length prefix per message
+/// and alignment. 64 MiB is cheap in a bench process and removes
+/// wrap-around effects as a confounder — under-sizing silently
+/// corrupts the ring and collapses measured latency to nanoseconds
+/// (drain fast-bails on a corrupt length prefix).
+const BENCH_CAPACITY: usize = 64 * 1024 * 1024;
+
+/// The parameter sweep. Covers the full range from a trivial batch up to
+/// the 10k/tick figure docs/performance.md calls out as the target.
+const SWEEP_SIZES: &[u32] = &[10, 100, 1_000, 10_000];
+
+/// Representative `channel.chat.message` EventSub notification, matching
+/// the envelope shape the Twitch WebSocket sends in production. Length
+/// is ~1.1 KiB, which lines up with a median real chat message plus the
+/// envelope overhead Twitch wraps around it.
+const TWITCH_MESSAGE: &[u8] = br##"{
+    "metadata": {
+        "message_id": "35064eb1-c4a5-5bd0-4a0b-3f3e9e9d5001",
+        "message_type": "notification",
+        "message_timestamp": "2026-04-12T20:15:32.847Z",
+        "subscription_type": "channel.chat.message",
+        "subscription_version": "1"
+    },
+    "payload": {
+        "subscription": {
+            "id": "abc123-def-456-ghi-789",
+            "status": "enabled",
+            "type": "channel.chat.message",
+            "version": "1",
+            "cost": 0,
+            "condition": {
+                "broadcaster_user_id": "570722168",
+                "user_id": "570722168"
+            },
+            "transport": {
+                "method": "websocket",
+                "session_id": "AgoQsess123-abc-def-ghi-jkl"
+            }
+        },
+        "event": {
+            "broadcaster_user_id": "570722168",
+            "broadcaster_user_login": "prismoiddev",
+            "broadcaster_user_name": "PrismoidDev",
+            "chatter_user_id": "123456789",
+            "chatter_user_login": "typical_viewer42",
+            "chatter_user_name": "Typical_Viewer42",
+            "message_id": "cc106a89-1814-919d-454c-f4f2f970aae7",
+            "message": {
+                "text": "this is a pretty average length chat message talking about the stream",
+                "fragments": [
+                    {"type": "text", "text": "this is a pretty average length chat message talking about the stream", "cheermote": null, "emote": null, "mention": null}
+                ]
+            },
+            "color": "#1E90FF",
+            "badges": [
+                {"set_id": "subscriber", "id": "12", "info": "12"},
+                {"set_id": "premium", "id": "1", "info": ""}
+            ],
+            "message_type": "text"
+        }
+    }
+}"##;
+
+fn drain_only(c: &mut Criterion) {
+    let mut group = c.benchmark_group("drain_only");
+    for &n in SWEEP_SIZES {
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+            b.iter_batched_ref(
+                || {
+                    let reader =
+                        RingBufReader::create_owner(BENCH_CAPACITY).expect("owner ring for bench");
+                    let payloads: Vec<&[u8]> = (0..n).map(|_| TWITCH_MESSAGE).collect();
+                    reader.__bench_write(&payloads);
+                    reader
+                },
+                |reader| {
+                    black_box(reader.drain());
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+fn parse_only(c: &mut Criterion) {
+    let mut group = c.benchmark_group("parse_only");
+    for &n in SWEEP_SIZES {
+        let raw: Vec<Vec<u8>> = (0..n).map(|_| TWITCH_MESSAGE.to_vec()).collect();
+        let mut batch: Vec<UnifiedMessage> = Vec::with_capacity(n as usize);
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &raw, |b, raw| {
+            b.iter(|| {
+                batch.clear();
+                parse_batch(raw, &mut batch);
+                black_box(&batch);
+            });
+        });
+    }
+    group.finish();
+}
+
+fn drain_and_parse(c: &mut Criterion) {
+    let mut group = c.benchmark_group("drain_and_parse");
+    for &n in SWEEP_SIZES {
+        let mut batch: Vec<UnifiedMessage> = Vec::with_capacity(n as usize);
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+            b.iter_batched_ref(
+                || {
+                    let reader =
+                        RingBufReader::create_owner(BENCH_CAPACITY).expect("owner ring for bench");
+                    let payloads: Vec<&[u8]> = (0..n).map(|_| TWITCH_MESSAGE).collect();
+                    reader.__bench_write(&payloads);
+                    reader
+                },
+                |reader| {
+                    batch.clear();
+                    let raw = reader.drain();
+                    parse_batch(&raw, &mut batch);
+                    black_box(&batch);
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, drain_only, parse_only, drain_and_parse);
+criterion_main!(benches);

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2,12 +2,21 @@ mod host;
 mod message;
 pub mod ringbuf;
 
+// Re-exports for the bench harness. Gated so the public crate surface
+// does not grow with bench-only plumbing in release builds.
+#[cfg(any(test, feature = "__bench"))]
+#[doc(hidden)]
+pub use host::parse_batch;
+#[cfg(any(test, feature = "__bench"))]
+#[doc(hidden)]
+pub use message::UnifiedMessage;
+
 use tauri::{AppHandle, Emitter, Manager, Runtime};
 use tauri_plugin_shell::process::CommandEvent;
 use tauri_plugin_shell::ShellExt;
 use tracing_subscriber::EnvFilter;
 
-use host::{parse_batch, SIGNAL_WAIT_TIMEOUT};
+use host::SIGNAL_WAIT_TIMEOUT;
 use ringbuf::{RingBufReader, WaitOutcome, DEFAULT_CAPACITY};
 
 #[tauri::command]
@@ -200,7 +209,7 @@ fn run_drain_loop<R: Runtime>(mut reader: RingBufReader, app: AppHandle<R>) {
         }
 
         batch.clear();
-        parse_batch(&raw, &mut batch);
+        host::parse_batch(&raw, &mut batch);
         if batch.is_empty() {
             continue;
         }

--- a/apps/desktop/src-tauri/src/ringbuf.rs
+++ b/apps/desktop/src-tauri/src/ringbuf.rs
@@ -423,14 +423,21 @@ fn windows_err(err: windows::core::Error) -> io::Error {
     io::Error::other(err)
 }
 
-#[cfg(all(test, windows))]
-mod tests {
-    use super::*;
-
-    fn write_to_buf(reader: &RingBufReader, payloads: &[&[u8]]) {
-        let (write_slot, _, capacity) = reader.header();
+/// Raw ring write path. Production writers live in the Go sidecar; this
+/// method exists only for in-process test fixtures and the benchmark
+/// harness, which need a Rust-side producer to exercise the drain hot
+/// loop without spawning a child.
+///
+/// Gated behind `#[cfg(any(test, feature = "__bench"))]` so the writer
+/// primitive never reaches a release build, and marked `#[doc(hidden)]`
+/// so it is not part of the crate's public API surface.
+#[cfg(all(windows, any(test, feature = "__bench")))]
+impl RingBufReader {
+    #[doc(hidden)]
+    pub fn __bench_write(&self, payloads: &[&[u8]]) {
+        let (write_slot, _, capacity) = self.header();
         let cap = capacity as usize;
-        let data = unsafe { reader.base.add(HEADER_SIZE) };
+        let data = self.data_ptr() as *mut u8;
 
         unsafe {
             let mut write_pos = (*write_slot).index.load(Ordering::Relaxed) as usize;
@@ -482,6 +489,11 @@ mod tests {
                 .store(write_pos as u64, Ordering::Release);
         }
     }
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
 
     #[test]
     fn rejects_capacity_too_small() {
@@ -506,7 +518,7 @@ mod tests {
     #[test]
     fn write_and_read_single_message() {
         let mut reader = RingBufReader::create_owner(4096).unwrap();
-        write_to_buf(&reader, &[b"hello world"]);
+        reader.__bench_write(&[b"hello world"]);
 
         let messages = reader.drain();
         assert_eq!(messages.len(), 1);
@@ -516,7 +528,7 @@ mod tests {
     #[test]
     fn write_and_read_multiple_messages() {
         let mut reader = RingBufReader::create_owner(4096).unwrap();
-        write_to_buf(&reader, &[b"msg1", b"msg two", b"third message"]);
+        reader.__bench_write(&[b"msg1", b"msg two", b"third message"]);
 
         let messages = reader.drain();
         assert_eq!(messages.len(), 3);
@@ -572,7 +584,7 @@ mod tests {
             (*read_slot).index.store(24, Ordering::Release);
         }
 
-        write_to_buf(&reader, &[b"ABCDEFGH"]);
+        reader.__bench_write(&[b"ABCDEFGH"]);
 
         let messages = reader.drain();
         assert_eq!(messages.len(), 1);
@@ -591,7 +603,7 @@ mod tests {
         let size = owner.map_size();
 
         let mut attached = RingBufReader::attach(handle, size).unwrap();
-        write_to_buf(&owner, &[b"cross-view message"]);
+        owner.__bench_write(&[b"cross-view message"]);
 
         let messages = attached.drain();
         assert_eq!(messages.len(), 1);


### PR DESCRIPTION
## Summary
Prerequisite for PRI-8 (zero-alloc drain). PRI-8's own acceptance says *"Only then optimize. Do not land this speculatively."* — this lands the harness + captures the baseline numbers so any future PRI-8 PR can show before/after delta.

### Stack
- `criterion = "0.5"` as dev-dep, `[[bench]] name = "drain_throughput" harness = false required-features = ["__bench"]`
- New `__bench` Cargo feature: opt-in flag that exposes the internal ring writer to the bench binary only. Never reaches release builds.
- `RingBufReader::__bench_write` promoted from `#[cfg(test)]` to `#[cfg(any(test, feature = "__bench"))] #[doc(hidden)] pub`, so benches can drive the ring without spawning a child Go sidecar
- `lib.rs` re-exports `parse_batch` and `UnifiedMessage` under the same cfg gate so the bench binary can call them

### Baseline (`BENCHMARKS.md`)

| Group             | N=10    | N=100    | N=1000   | N=10000  |
| ----------------- | ------- | -------- | -------- | -------- |
| `drain_only`      | 16.7 µs | 16.9 µs  | 205.9 µs | 4.45 ms  |
| `parse_only`      | 34.8 µs | 489.9 µs | 5.40 ms  | 49.85 ms |
| `drain_and_parse` | 73.7 µs | 590.6 µs | 5.64 ms  | 55.84 ms |

**Read:** `drain_and_parse` at N=10000 = 55.8 ms → ~179k msg/sec per drain cycle, 18× over the 10k/sec peak target from `docs/performance.md`. Plenty of headroom. `parse_only` dominates (serde_json's String-allocating deserializer); PRI-8's primary lever is simd-json or a callback-style drain API.

### Notes
- BENCH_CAPACITY bumped to 64 MiB after an initial 16 MiB run silently collapsed N=10000 to ~200 ns (ring wraparound → drain fast-bails on corrupt length). Comment in the bench documents the failure mode for future authors.
- CI does NOT run benches — hardware variance dominates signal and it's 30-60s per run. Developer-opt-in only.

## Test plan
- [x] `cargo test --lib --features __bench` — 34 pass (original tests use the promoted `__bench_write` method unchanged)
- [x] `cargo clippy --lib --tests --benches --features __bench -- -D warnings` — clean
- [x] `cargo bench --features __bench` captures the full sweep in ~2 min; numbers above are the median from that run

## Out of scope
- The actual zero-alloc drain optimization — that's PRI-8, gated on these numbers
- Allocation counting via `dhat-rs` — can be a follow-up if throughput deltas alone don't make the case