### PR TITLE
feat: wire oauth authmanager into supervisor + dcf seed bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 
 # Go
 **/bin/
+# Rust crates use `src/bin/` for additional binary targets — un-ignore
+# those so they stay tracked even when under the **/bin/ wildcard.
+!**/src/bin/
+!**/src/bin/**
 
 # Node
 **/node_modules/

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,6 +117,18 @@ checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
 dependencies = [
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -214,6 +237,17 @@ dependencies = [
  "event-listener 5.4.1",
  "futures-lite",
  "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -414,6 +448,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,6 +600,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,6 +710,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,6 +790,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -749,7 +821,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -762,7 +834,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -964,6 +1036,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b3aa68d7e7abee336255bd7248ea965cc393f3e70411135a6f6a4b651345d4"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
+ "dbus",
+ "fastrand",
+ "hkdf",
+ "num",
+ "once_cell",
+ "sha2",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,6 +1116,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1204,6 +1306,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1863,6 +1992,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2242,6 +2389,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,7 +2596,13 @@ version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
+ "byteorder",
+ "dbus-secret-service",
  "log",
+ "secret-service",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
  "zeroize",
 ]
 
@@ -2542,6 +2705,15 @@ name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libloading"
@@ -2755,6 +2927,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2770,10 +2955,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2964,6 +3213,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "os_pipe"
@@ -3896,7 +4155,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -3915,7 +4174,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -3924,7 +4183,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -4030,13 +4289,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "secret-service"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "sha2",
+ "zbus",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4277,6 +4568,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4455,6 +4757,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "string_cache"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4589,7 +4897,7 @@ checksum = "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dispatch2",
@@ -4886,6 +5194,19 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5377,6 +5698,17 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -6436,6 +6768,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6456,6 +6798,62 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-process",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener 5.4.1",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix",
+ "ordered-stream",
+ "rand 0.8.5",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant",
 ]
 
 [[package]]
@@ -6504,6 +6902,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"
@@ -6543,3 +6955,40 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -2,6 +2,9 @@
 name = "prismoid"
 version = "0.0.1"
 edition = "2021"
+# Disambiguate for `cargo run` / Tauri dev command — the `prismoid_dcf`
+# dev tool is a separate bin invoked via `cargo run --bin prismoid_dcf`.
+default-run = "prismoid"
 
 [lib]
 name = "prismoid_lib"
@@ -15,7 +18,7 @@ tauri = { version = "2.10", features = [] }
 tauri-plugin-shell = "2.3"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 dotenvy = "0.15"
-keyring = "3"
+keyring = { version = "3", default-features = false }
 reqwest = { version = "0.13", default-features = false, features = [
     "rustls",
     "json",
@@ -40,6 +43,13 @@ windows = { version = "0.61", features = [
     "Win32_Security",
     "Win32_System_Threading",
 ] }
+keyring = { version = "3", default-features = false, features = ["windows-native"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+keyring = { version = "3", default-features = false, features = ["apple-native"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+keyring = { version = "3", default-features = false, features = ["sync-secret-service", "crypto-rust"] }
 
 [features]
 # Opt-in feature that exposes internal write + parse helpers to the

--- a/apps/desktop/src-tauri/src/bin/prismoid_dcf.rs
+++ b/apps/desktop/src-tauri/src/bin/prismoid_dcf.rs
@@ -1,0 +1,87 @@
+//! Developer tool: interactively seed the Twitch OAuth keychain entry.
+//!
+//! Runs the Device Code Grant flow once, waits for the user to authorize
+//! in their browser, then persists the resulting access + refresh tokens
+//! into the OS keychain (ADR 37). After this runs successfully, the
+//! Tauri app supervisor's [`AuthManager::load_or_refresh`] picks up the
+//! tokens and auto-refreshes them for the full 30-day refresh-token
+//! lifetime without further manual steps.
+//!
+//! Usage:
+//!
+//! ```sh
+//! export PRISMOID_TWITCH_CLIENT_ID=...
+//! export PRISMOID_TWITCH_BROADCASTER_ID=...
+//! cargo run --bin prismoid_dcf
+//! ```
+//!
+//! The end-user DCF flow lands in a Tauri command + frontend button in
+//! PRI-22; this is a dev-only tool.
+
+use std::env;
+use std::process::Command;
+
+use prismoid_lib::twitch_auth::{AuthManager, KeychainStore};
+use twitch_oauth2::Scope;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Dev-local .env.local fallback so this bin can be launched directly
+    // from cargo without setting env vars every shell. Matches what
+    // `lib::run` does for the Tauri entry point.
+    #[cfg(debug_assertions)]
+    let _ = dotenvy::from_filename(".env.local");
+
+    let client_id =
+        env::var("PRISMOID_TWITCH_CLIENT_ID").map_err(|_| "PRISMOID_TWITCH_CLIENT_ID not set")?;
+    let broadcaster_id = env::var("PRISMOID_TWITCH_BROADCASTER_ID")
+        .map_err(|_| "PRISMOID_TWITCH_BROADCASTER_ID not set")?;
+
+    // OAuth HTTP client. Per oauth2-rs docs: disable redirects on the
+    // client used for OAuth to avoid SSRF via redirect chains. Same
+    // redirect-none pattern the supervisor uses.
+    let http_client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()?;
+
+    let mgr = AuthManager::builder(client_id)
+        .scope(Scope::UserReadChat)
+        .scope(Scope::UserWriteChat)
+        .build(KeychainStore, http_client);
+
+    println!("Starting Twitch Device Code Grant flow...");
+    let pending = mgr.start_device_flow().await?;
+    let details = pending.details();
+
+    println!();
+    println!("Open this URL in your browser and approve the authorization:");
+    println!("  {}", details.verification_uri);
+    println!();
+    println!("Waiting for authorization (this polls until you click Authorize)...");
+
+    // Best-effort: open the verification URL in the user's default browser.
+    // Windows-specific; on macOS we'd use `open`, on Linux `xdg-open`. This
+    // bin is a dev tool and ADR 36 locks Windows-first.
+    let _ = Command::new("cmd")
+        .args(["/c", "start", "", details.verification_uri.as_ref()])
+        .spawn();
+
+    let tokens = mgr.complete_device_flow(pending, &broadcaster_id).await?;
+
+    println!();
+    println!("✓ Authorized and persisted to keychain under `prismoid.twitch:{broadcaster_id}`");
+    println!(
+        "  access_token: [redacted, {} chars]",
+        tokens.access_token.len()
+    );
+    println!(
+        "  refresh_token: [redacted, {} chars]",
+        tokens.refresh_token.len()
+    );
+    println!("  expires_at_ms: {}", tokens.expires_at_ms);
+    println!("  scopes: {:?}", tokens.scopes);
+    println!();
+    println!("The supervisor will now auto-refresh this token within 5 min of expiry (ADR 29).");
+
+    Ok(())
+}

--- a/apps/desktop/src-tauri/src/host.rs
+++ b/apps/desktop/src-tauri/src/host.rs
@@ -106,28 +106,6 @@ pub fn build_twitch_connect_line(creds: &TwitchCreds) -> serde_json::Result<Vec<
     Ok(bytes)
 }
 
-/// Reads Twitch dev credentials from environment variables. Returns None if
-/// any of the four required vars are missing. Phase 0 only, a proper OAuth
-/// flow lands in a follow-up ticket.
-pub fn twitch_creds_from_env() -> Option<TwitchCreds> {
-    twitch_creds_from(|key| std::env::var(key).ok())
-}
-
-/// Source-agnostic version of [`twitch_creds_from_env`]. Takes any closure
-/// that maps an env var name to an optional value, which lets tests exercise
-/// the presence/absence logic without touching process-wide env state.
-fn twitch_creds_from<F>(get: F) -> Option<TwitchCreds>
-where
-    F: Fn(&str) -> Option<String>,
-{
-    Some(TwitchCreds {
-        client_id: get("PRISMOID_TWITCH_CLIENT_ID")?,
-        access_token: get("PRISMOID_TWITCH_ACCESS_TOKEN")?,
-        broadcaster_id: get("PRISMOID_TWITCH_BROADCASTER_ID")?,
-        user_id: get("PRISMOID_TWITCH_USER_ID")?,
-    })
-}
-
 /// Marks a shared memory HANDLE inheritable just before spawning a child
 /// process. See ADR 18 for why this is necessary.
 #[cfg(windows)]
@@ -263,46 +241,6 @@ mod tests {
         parse_batch(std::slice::from_ref(&viewer), &mut batch);
         assert_eq!(batch.len(), 2);
         assert_eq!(batch[1].message_text, "second");
-    }
-
-    #[test]
-    fn twitch_creds_from_returns_some_when_all_present() {
-        let map: std::collections::HashMap<&str, &str> = [
-            ("PRISMOID_TWITCH_CLIENT_ID", "c"),
-            ("PRISMOID_TWITCH_ACCESS_TOKEN", "t"),
-            ("PRISMOID_TWITCH_BROADCASTER_ID", "b"),
-            ("PRISMOID_TWITCH_USER_ID", "u"),
-        ]
-        .into_iter()
-        .collect();
-        let creds =
-            twitch_creds_from(|k| map.get(k).map(|v| v.to_string())).expect("all four present");
-        assert_eq!(creds.client_id, "c");
-        assert_eq!(creds.access_token, "t");
-        assert_eq!(creds.broadcaster_id, "b");
-        assert_eq!(creds.user_id, "u");
-    }
-
-    #[test]
-    fn twitch_creds_from_returns_none_when_any_missing() {
-        // Each iteration leaves exactly one of the four vars unset; the
-        // helper must short-circuit to None in every case.
-        let all = [
-            "PRISMOID_TWITCH_CLIENT_ID",
-            "PRISMOID_TWITCH_ACCESS_TOKEN",
-            "PRISMOID_TWITCH_BROADCASTER_ID",
-            "PRISMOID_TWITCH_USER_ID",
-        ];
-        for missing in all {
-            let got = twitch_creds_from(|k| {
-                if k == missing {
-                    None
-                } else {
-                    Some("v".to_string())
-                }
-            });
-            assert!(got.is_none(), "expected None when {missing} is unset");
-        }
     }
 
     #[cfg(windows)]

--- a/apps/desktop/src-tauri/src/sidecar_supervisor.rs
+++ b/apps/desktop/src-tauri/src/sidecar_supervisor.rs
@@ -34,13 +34,14 @@ use tauri_plugin_shell::{
 #[cfg(windows)]
 use crate::host::{
     build_bootstrap_line, build_twitch_connect_line, mark_handle_inheritable, parse_batch,
-    twitch_creds_from_env, unmark_handle_inheritable, TwitchCreds, SIDECAR_BINARY,
-    SIGNAL_WAIT_TIMEOUT,
+    unmark_handle_inheritable, TwitchCreds, SIDECAR_BINARY, SIGNAL_WAIT_TIMEOUT,
 };
 #[cfg(windows)]
 use crate::message::UnifiedMessage;
 #[cfg(windows)]
 use crate::ringbuf::{RawHandle, RingBufReader, WaitOutcome, DEFAULT_CAPACITY};
+#[cfg(windows)]
+use crate::twitch_auth::{AuthError, AuthManager, KeychainStore};
 
 /// Supervisor timings. Defaults are production values; tests can override.
 #[derive(Debug, Clone)]
@@ -98,13 +99,39 @@ pub fn spawn<R: Runtime>(app: AppHandle<R>) {
 
 #[cfg(windows)]
 async fn supervise<R: Runtime>(app: AppHandle<R>, cfg: SupervisorConfig) {
-    // Credentials are read once at supervisor start. The OAuth + refresh
-    // flow will replace this lookup in a later ticket; until then
-    // .env.local loaded by `lib::run` is the only source.
-    let creds = twitch_creds_from_env();
-    if creds.is_none() {
-        tracing::warn!("PRISMOID_TWITCH_* env vars not all set; launching without auto-connect");
-    }
+    // Non-secret identity config (client_id + broadcaster/user) comes from
+    // env vars. The access + refresh tokens live in the OS keychain,
+    // seeded via `cargo run --bin prismoid_dcf`, rotated automatically
+    // below (ADR 29: refresh 5 min before expiry; ADR 37: Twitch DCF
+    // public client). See PRI-21.
+    let Ok(client_id) = std::env::var("PRISMOID_TWITCH_CLIENT_ID") else {
+        tracing::error!(
+            "PRISMOID_TWITCH_CLIENT_ID not set; supervisor idling. \
+             Set it in .env.local and restart."
+        );
+        return;
+    };
+    let Ok(broadcaster_id) = std::env::var("PRISMOID_TWITCH_BROADCASTER_ID") else {
+        tracing::error!("PRISMOID_TWITCH_BROADCASTER_ID not set; supervisor idling.");
+        return;
+    };
+    // Single-account per platform today (ADR 30): user_id defaults to
+    // broadcaster_id. An explicit env override exists for the edge case
+    // of a mod account watching a different channel.
+    let user_id =
+        std::env::var("PRISMOID_TWITCH_USER_ID").unwrap_or_else(|_| broadcaster_id.clone());
+
+    let http_client = match reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!(error = %e, "failed to build reqwest client; supervisor idling");
+            return;
+        }
+    };
+    let auth = AuthManager::builder(&client_id).build(KeychainStore, http_client);
 
     let mut attempt: u32 = 0;
     let mut backoff = cfg.initial_backoff;
@@ -112,9 +139,42 @@ async fn supervise<R: Runtime>(app: AppHandle<R>, cfg: SupervisorConfig) {
     loop {
         attempt += 1;
         emit_status(&app, "spawning", attempt, None);
-        let started = Instant::now();
 
-        match run_once(&app, attempt, creds.as_ref()).await {
+        // Pull a fresh access token per iteration. Auto-refresh happens
+        // inside load_or_refresh when we're within 5 min of expiry.
+        let tokens = match auth.load_or_refresh(&broadcaster_id).await {
+            Ok(t) => t,
+            Err(AuthError::NoTokens(_)) | Err(AuthError::RefreshTokenInvalid) => {
+                tracing::warn!(
+                    broadcaster = %broadcaster_id,
+                    "no valid Twitch tokens in keychain; run `cargo run --bin prismoid_dcf` to seed"
+                );
+                emit_status(&app, "waiting_for_auth", attempt, None);
+                // Poll the keychain every 30 s so the user can seed
+                // mid-run without a restart. Not a respawn-pressure
+                // scenario, so we stay on a fixed interval rather than
+                // the exponential ladder.
+                tokio::time::sleep(Duration::from_secs(30)).await;
+                continue;
+            }
+            Err(e) => {
+                tracing::error!(error = %e, attempt, "token refresh failed; backing off");
+                emit_status(&app, "backoff", attempt, Some(backoff.as_millis() as u64));
+                tokio::time::sleep(backoff).await;
+                backoff = next_backoff(backoff, &cfg);
+                continue;
+            }
+        };
+
+        let creds = TwitchCreds {
+            client_id: client_id.clone(),
+            access_token: tokens.access_token,
+            broadcaster_id: broadcaster_id.clone(),
+            user_id: user_id.clone(),
+        };
+
+        let started = Instant::now();
+        match run_once(&app, attempt, Some(&creds)).await {
             Ok(()) => tracing::info!(attempt, "sidecar iteration ended"),
             Err(e) => tracing::error!(error = %e, attempt, "sidecar iteration failed"),
         }

--- a/apps/desktop/src/components/ChatFeed.tsx
+++ b/apps/desktop/src/components/ChatFeed.tsx
@@ -51,13 +51,23 @@ const ChatFeed: Component = () => {
   });
 
   onMount(() => {
+    // Capture the unlisten handle into a closure so we can register
+    // onCleanup synchronously inside onMount (Solid's lifecycle only
+    // tracks cleanups registered inside its render/root scope; calling
+    // onCleanup from inside a .then() callback logs the warning
+    // "cleanups created outside a createRoot or render will never be
+    // run" and leaks listeners on HMR/unmount).
+    let unlisten: (() => void) | undefined;
     listen<ChatMessage[]>("chat_messages", (event) => {
       addMessages(event.payload);
     })
-      .then((unlisten) => onCleanup(() => unlisten()))
+      .then((fn) => {
+        unlisten = fn;
+      })
       .catch((err) =>
         console.error("failed to listen for chat messages:", err),
       );
+    onCleanup(() => unlisten?.());
   });
 
   return (


### PR DESCRIPTION
## Summary
Makes PRI-20's OAuth library load-bearing. The supervisor pulls a fresh access token from the keychain every iteration via `AuthManager::load_or_refresh`; first-run seeding is handled by a new `prismoid_dcf` dev bin. `.env.local` no longer needs `PRISMOID_TWITCH_ACCESS_TOKEN` — tokens live in Windows Credential Manager / macOS Keychain / Linux Secret Service and refresh transparently 5 min before expiry (ADR 29).

### Stack wiring
- `sidecar_supervisor::supervise` now constructs an `AuthManager` at startup and calls `load_or_refresh(broadcaster_id)` per iteration. On `NoTokens` / `RefreshTokenInvalid`, emits `sidecar_status { state: "waiting_for_auth" }` and polls the keychain every 30 s so the user can seed mid-run without restarting
- Deletes `host::twitch_creds_from_env` + the private env-reader helper — obsolete with AuthManager
- New `src/bin/prismoid_dcf.rs` — interactive DCF seeder. Reads `PRISMOID_TWITCH_CLIENT_ID` + `PRISMOID_TWITCH_BROADCASTER_ID` from env, runs the Twitch Device Code Grant flow, opens the verification URL in the default browser, persists the resulting tokens to the keychain
- Cargo `default-run = "prismoid"` so Tauri's bare `cargo run` still targets the main binary with the new bin added

### keyring Cargo gotcha (catch-worthy)
`keyring = "3"` with no features enabled silently falls back to an **in-memory mock store** that reports `Ok` on save but returns `NoEntry` on load in a different process. This PR enables `windows-native` / `apple-native` / `sync-secret-service` per target so real OS keychains get used. Verified by seeding via `prismoid_dcf` and observing the supervisor pick up the token on next poll cycle.

### `.gitignore` fix
`**/bin/` was swallowing Rust's canonical `src/bin/` layout. Added a narrow un-ignore so the new bin stays tracked.

### Frontend lifecycle fix
`ChatFeed.tsx` was calling `onCleanup(...)` from inside a `listen().then(unlisten => onCleanup(...))` — after the synchronous render context exited. Solid warned with *"cleanups created outside a createRoot or render will never be run"* and HMR reloads leaked listeners, causing visible message duplication on frontend reload. Fixed by capturing the unlisten handle into a closure and calling `onCleanup` synchronously inside `onMount`.

## Test plan
- [x] `cargo test --lib` — 57 pass
- [x] `cargo clippy --lib --bins --tests -- -D warnings` — clean
- [x] **Manual E2E**:
  1. `cargo run --bin prismoid_dcf` → browser opens to twitch.tv/activate, user authorizes, tokens land in Credential Manager under `prismoid.twitch:<broadcaster_id>`
  2. `cargo tauri dev` → supervisor logs `bootstrap written attempt=1` → `sent twitch_connect attempt=1` → sidecar logs `connected to eventsub` + `subscribed to channel.chat.message` → live chat messages render in the app

## Out of scope
- Frontend DCF UI (PRI-22) — the seed bin is developer-facing; a "Login with Twitch" button lands in a follow-up
- Mock-driven supervisor tests for the new token-refresh branches — PRI-14