### PR TITLE
feat: bake twitch client_id as compile-time const

### DIFF
--- a/apps/desktop/src-tauri/src/bin/prismoid_dcf.rs
+++ b/apps/desktop/src-tauri/src/bin/prismoid_dcf.rs
@@ -21,7 +21,7 @@
 use std::env;
 use std::process::Command;
 
-use prismoid_lib::twitch_auth::{AuthManager, KeychainStore};
+use prismoid_lib::twitch_auth::{AuthManager, KeychainStore, TWITCH_CLIENT_ID};
 use twitch_oauth2::Scope;
 
 #[tokio::main]
@@ -32,8 +32,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(debug_assertions)]
     let _ = dotenvy::from_filename(".env.local");
 
-    let client_id =
-        env::var("PRISMOID_TWITCH_CLIENT_ID").map_err(|_| "PRISMOID_TWITCH_CLIENT_ID not set")?;
+    // `client_id` is a compile-time const (RFC 8252 public client; see
+    // `twitch_auth::TWITCH_CLIENT_ID`). `broadcaster_id` still comes
+    // from env until PRI-22b derives it from the DCF response.
     let broadcaster_id = env::var("PRISMOID_TWITCH_BROADCASTER_ID")
         .map_err(|_| "PRISMOID_TWITCH_BROADCASTER_ID not set")?;
 
@@ -44,7 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .redirect(reqwest::redirect::Policy::none())
         .build()?;
 
-    let mgr = AuthManager::builder(client_id)
+    let mgr = AuthManager::builder(TWITCH_CLIENT_ID)
         .scope(Scope::UserReadChat)
         .scope(Scope::UserWriteChat)
         .build(KeychainStore, http_client);

--- a/apps/desktop/src-tauri/src/sidecar_supervisor.rs
+++ b/apps/desktop/src-tauri/src/sidecar_supervisor.rs
@@ -41,7 +41,7 @@ use crate::message::UnifiedMessage;
 #[cfg(windows)]
 use crate::ringbuf::{RawHandle, RingBufReader, WaitOutcome, DEFAULT_CAPACITY};
 #[cfg(windows)]
-use crate::twitch_auth::{AuthError, AuthManager, KeychainStore};
+use crate::twitch_auth::{AuthError, AuthManager, KeychainStore, TWITCH_CLIENT_ID};
 
 /// Supervisor timings. Defaults are production values; tests can override.
 #[derive(Debug, Clone)]
@@ -99,18 +99,11 @@ pub fn spawn<R: Runtime>(app: AppHandle<R>) {
 
 #[cfg(windows)]
 async fn supervise<R: Runtime>(app: AppHandle<R>, cfg: SupervisorConfig) {
-    // Non-secret identity config (client_id + broadcaster/user) comes from
-    // env vars. The access + refresh tokens live in the OS keychain,
-    // seeded via `cargo run --bin prismoid_dcf`, rotated automatically
-    // below (ADR 29: refresh 5 min before expiry; ADR 37: Twitch DCF
-    // public client). See PRI-21.
-    let Ok(client_id) = std::env::var("PRISMOID_TWITCH_CLIENT_ID") else {
-        tracing::error!(
-            "PRISMOID_TWITCH_CLIENT_ID not set; supervisor idling. \
-             Set it in .env.local and restart."
-        );
-        return;
-    };
+    // `client_id` is a compile-time const (RFC 8252 public client; not a
+    // secret). `broadcaster_id` still comes from env until PRI-22b
+    // auto-derives it from the DCF response's user_id. Tokens themselves
+    // live in the OS keychain, seeded via `cargo run --bin prismoid_dcf`
+    // and rotated automatically below (ADR 29).
     let Ok(broadcaster_id) = std::env::var("PRISMOID_TWITCH_BROADCASTER_ID") else {
         tracing::error!("PRISMOID_TWITCH_BROADCASTER_ID not set; supervisor idling.");
         return;
@@ -131,7 +124,7 @@ async fn supervise<R: Runtime>(app: AppHandle<R>, cfg: SupervisorConfig) {
             return;
         }
     };
-    let auth = AuthManager::builder(&client_id).build(KeychainStore, http_client);
+    let auth = AuthManager::builder(TWITCH_CLIENT_ID).build(KeychainStore, http_client);
 
     let mut attempt: u32 = 0;
     let mut backoff = cfg.initial_backoff;
@@ -167,7 +160,7 @@ async fn supervise<R: Runtime>(app: AppHandle<R>, cfg: SupervisorConfig) {
         };
 
         let creds = TwitchCreds {
-            client_id: client_id.clone(),
+            client_id: TWITCH_CLIENT_ID.to_owned(),
             access_token: tokens.access_token,
             broadcaster_id: broadcaster_id.clone(),
             user_id: user_id.clone(),

--- a/apps/desktop/src-tauri/src/twitch_auth/mod.rs
+++ b/apps/desktop/src-tauri/src/twitch_auth/mod.rs
@@ -25,3 +25,18 @@ pub use errors::AuthError;
 pub use manager::{AuthManager, AuthManagerBuilder, PendingDeviceFlow, REFRESH_THRESHOLD_MS};
 pub use storage::{KeychainStore, MemoryStore, TokenStore, KEYCHAIN_SERVICE};
 pub use tokens::TwitchTokens;
+
+/// OAuth `client_id` for the registered Prismoid Twitch application.
+///
+/// **This is intentionally a plain string literal, not a secret.** Per
+/// RFC 8252 §8.4 and RFC 6749 §2.2, OAuth public-client `client_id`s
+/// are public identifiers — they appear in browser URLs and network
+/// traces during the authorization flow. Treating them as secret is a
+/// category error.
+///
+/// Bundling the production `client_id` in source is the standard pattern
+/// for distributed desktop apps doing OAuth public-client flows
+/// (`github/cli`, Discord/Slack/Spotify desktop, etc.). Forks running
+/// against their own registered Twitch application override this const
+/// at build time.
+pub const TWITCH_CLIENT_ID: &str = "bpjpbhc5p8xicpiuvxskjuq4m9gcio";


### PR DESCRIPTION
## Summary
First slice of the Phase 1 UI-chrome work (PRI-22a). Replaces the runtime `PRISMOID_TWITCH_CLIENT_ID` env var with a compile-time `pub const TWITCH_CLIENT_ID: &str` in `twitch_auth/mod.rs`.

### Why
For a distributable desktop binary (the Jynxzi-tier "double-click .exe" path), there's no shell to set env vars in. Per RFC 8252 §8.4 + RFC 6749 §2.2, an OAuth public-client `client_id` is **not a secret** — it appears in browser URLs and network traces during the auth flow. Bundling it in source/binary is the standard pattern for distributed desktop OAuth apps (`github/cli`, Discord/Slack/Spotify desktop, etc.).

### Changes
- `twitch_auth/mod.rs`: new `pub const TWITCH_CLIENT_ID` with a documenting comment that explains the RFC justification (so a future reader doesn't reflexively flag it as a hardcoded secret)
- `sidecar_supervisor.rs`: drops the `PRISMOID_TWITCH_CLIENT_ID` env lookup, uses the const directly
- `bin/prismoid_dcf.rs`: same
- Forks running their own Twitch app override one line + recompile

### What's NOT in this PR
- `broadcaster_id` / `user_id` env removal — PRI-22b (auto-derive from DCF response's `UserToken.user_id`)
- Frontend "Login with Twitch" button — PRI-22c
- Re-auth modal on `RefreshTokenInvalid` — PRI-22d

## Test plan
- [x] `cargo test --lib` — 57 pass
- [x] `cargo clippy --lib --bins --tests -- -D warnings` — clean
- [x] Manual: `cargo run --bin prismoid_dcf` no longer requires `PRISMOID_TWITCH_CLIENT_ID` set; supervisor in `cargo tauri dev` works without it too

## Out of scope
- Build-time override via `env!()` + CI env / `.cargo/config.toml [env]` — overkill for a single-app project. Forks edit the const directly. Revisit if we ever need a per-environment dev/staging/prod Twitch app.