### PR TITLE
feat: single-account twitch auth, auto-derive broadcaster from dcf

### DIFF
--- a/apps/desktop/src-tauri/src/bin/prismoid_dcf.rs
+++ b/apps/desktop/src-tauri/src/bin/prismoid_dcf.rs
@@ -2,23 +2,25 @@
 //!
 //! Runs the Device Code Grant flow once, waits for the user to authorize
 //! in their browser, then persists the resulting access + refresh tokens
-//! into the OS keychain (ADR 37). After this runs successfully, the
-//! Tauri app supervisor's [`AuthManager::load_or_refresh`] picks up the
-//! tokens and auto-refreshes them for the full 30-day refresh-token
-//! lifetime without further manual steps.
+//! (plus the authenticated user_id / login) into the OS keychain
+//! (ADR 37). After this runs successfully, the Tauri app supervisor's
+//! [`AuthManager::load_or_refresh`] picks up the tokens and auto-refreshes
+//! them for the full 30-day refresh-token lifetime without further
+//! manual steps.
 //!
 //! Usage:
 //!
 //! ```sh
-//! export PRISMOID_TWITCH_CLIENT_ID=...
-//! export PRISMOID_TWITCH_BROADCASTER_ID=...
 //! cargo run --bin prismoid_dcf
 //! ```
 //!
+//! No env vars required: `client_id` is baked as a compile-time const
+//! (see `twitch_auth::TWITCH_CLIENT_ID`), and the broadcaster identifier
+//! is derived from the DCF response itself.
+//!
 //! The end-user DCF flow lands in a Tauri command + frontend button in
-//! PRI-22; this is a dev-only tool.
+//! PRI-22c; this is a dev-only tool.
 
-use std::env;
 use std::process::Command;
 
 use prismoid_lib::twitch_auth::{AuthManager, KeychainStore, TWITCH_CLIENT_ID};
@@ -26,18 +28,6 @@ use twitch_oauth2::Scope;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Dev-local .env.local fallback so this bin can be launched directly
-    // from cargo without setting env vars every shell. Matches what
-    // `lib::run` does for the Tauri entry point.
-    #[cfg(debug_assertions)]
-    let _ = dotenvy::from_filename(".env.local");
-
-    // `client_id` is a compile-time const (RFC 8252 public client; see
-    // `twitch_auth::TWITCH_CLIENT_ID`). `broadcaster_id` still comes
-    // from env until PRI-22b derives it from the DCF response.
-    let broadcaster_id = env::var("PRISMOID_TWITCH_BROADCASTER_ID")
-        .map_err(|_| "PRISMOID_TWITCH_BROADCASTER_ID not set")?;
-
     // OAuth HTTP client. Per oauth2-rs docs: disable redirects on the
     // client used for OAuth to avoid SSRF via redirect chains. Same
     // redirect-none pattern the supervisor uses.
@@ -67,10 +57,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .args(["/c", "start", "", details.verification_uri.as_ref()])
         .spawn();
 
-    let tokens = mgr.complete_device_flow(pending, &broadcaster_id).await?;
+    let tokens = mgr.complete_device_flow(pending).await?;
 
     println!();
-    println!("✓ Authorized and persisted to keychain under `prismoid.twitch:{broadcaster_id}`");
+    println!(
+        "✓ Authorized and persisted to keychain — logged in as @{} (user_id {})",
+        tokens.login, tokens.user_id
+    );
     println!(
         "  access_token: [redacted, {} chars]",
         tokens.access_token.len()

--- a/apps/desktop/src-tauri/src/bin/prismoid_dcf.rs
+++ b/apps/desktop/src-tauri/src/bin/prismoid_dcf.rs
@@ -59,20 +59,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let tokens = mgr.complete_device_flow(pending).await?;
 
+    // Intentionally print only the public login handle, not user_id
+    // or token lengths. Even non-sensitive fields from a struct that
+    // carries OAuth secrets flow through the same set_password sink,
+    // and piping them to stdout trips CodeQL's cleartext-logging
+    // taint analysis + risks leaking them to terminal-capture tools
+    // (tee, script) without adding UX value — `@<login>` alone tells
+    // the dev they authorized the right account.
     println!();
-    println!(
-        "✓ Authorized and persisted to keychain — logged in as @{} (user_id {})",
-        tokens.login, tokens.user_id
-    );
-    println!(
-        "  access_token: [redacted, {} chars]",
-        tokens.access_token.len()
-    );
-    println!(
-        "  refresh_token: [redacted, {} chars]",
-        tokens.refresh_token.len()
-    );
-    println!("  expires_at_ms: {}", tokens.expires_at_ms);
+    println!("✓ Authorized — logged in as @{}", tokens.login);
     println!("  scopes: {:?}", tokens.scopes);
     println!();
     println!("The supervisor will now auto-refresh this token within 5 min of expiry (ADR 29).");

--- a/apps/desktop/src-tauri/src/sidecar_supervisor.rs
+++ b/apps/desktop/src-tauri/src/sidecar_supervisor.rs
@@ -100,20 +100,12 @@ pub fn spawn<R: Runtime>(app: AppHandle<R>) {
 #[cfg(windows)]
 async fn supervise<R: Runtime>(app: AppHandle<R>, cfg: SupervisorConfig) {
     // `client_id` is a compile-time const (RFC 8252 public client; not a
-    // secret). `broadcaster_id` still comes from env until PRI-22b
-    // auto-derives it from the DCF response's user_id. Tokens themselves
-    // live in the OS keychain, seeded via `cargo run --bin prismoid_dcf`
-    // and rotated automatically below (ADR 29).
-    let Ok(broadcaster_id) = std::env::var("PRISMOID_TWITCH_BROADCASTER_ID") else {
-        tracing::error!("PRISMOID_TWITCH_BROADCASTER_ID not set; supervisor idling.");
-        return;
-    };
-    // Single-account per platform today (ADR 30): user_id defaults to
-    // broadcaster_id. An explicit env override exists for the edge case
-    // of a mod account watching a different channel.
-    let user_id =
-        std::env::var("PRISMOID_TWITCH_USER_ID").unwrap_or_else(|_| broadcaster_id.clone());
-
+    // secret). The broadcaster/user identifiers ride inside the persisted
+    // [`TwitchTokens`] itself (populated from the DCF response, stable
+    // across refresh) so the supervisor never needs env vars or user
+    // input for them. Tokens live in the OS keychain, seeded via
+    // `cargo run --bin prismoid_dcf` and rotated automatically below
+    // (ADR 29).
     let http_client = match reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
         .build()
@@ -135,11 +127,10 @@ async fn supervise<R: Runtime>(app: AppHandle<R>, cfg: SupervisorConfig) {
 
         // Pull a fresh access token per iteration. Auto-refresh happens
         // inside load_or_refresh when we're within 5 min of expiry.
-        let tokens = match auth.load_or_refresh(&broadcaster_id).await {
+        let tokens = match auth.load_or_refresh().await {
             Ok(t) => t,
-            Err(AuthError::NoTokens(_)) | Err(AuthError::RefreshTokenInvalid) => {
+            Err(AuthError::NoTokens) | Err(AuthError::RefreshTokenInvalid) => {
                 tracing::warn!(
-                    broadcaster = %broadcaster_id,
                     "no valid Twitch tokens in keychain; run `cargo run --bin prismoid_dcf` to seed"
                 );
                 emit_status(&app, "waiting_for_auth", attempt, None);
@@ -159,11 +150,14 @@ async fn supervise<R: Runtime>(app: AppHandle<R>, cfg: SupervisorConfig) {
             }
         };
 
+        // Single-account per ADR 30: the authenticated Twitch user IS
+        // the broadcaster. `user_id` doubles as broadcaster_id in
+        // EventSub's `channel.chat.message` subscription condition.
         let creds = TwitchCreds {
             client_id: TWITCH_CLIENT_ID.to_owned(),
             access_token: tokens.access_token,
-            broadcaster_id: broadcaster_id.clone(),
-            user_id: user_id.clone(),
+            broadcaster_id: tokens.user_id.clone(),
+            user_id: tokens.user_id,
         };
 
         let started = Instant::now();

--- a/apps/desktop/src-tauri/src/sidecar_supervisor.rs
+++ b/apps/desktop/src-tauri/src/sidecar_supervisor.rs
@@ -153,11 +153,12 @@ async fn supervise<R: Runtime>(app: AppHandle<R>, cfg: SupervisorConfig) {
         // Single-account per ADR 30: the authenticated Twitch user IS
         // the broadcaster. `user_id` doubles as broadcaster_id in
         // EventSub's `channel.chat.message` subscription condition.
+        let uid = tokens.user_id;
         let creds = TwitchCreds {
             client_id: TWITCH_CLIENT_ID.to_owned(),
             access_token: tokens.access_token,
-            broadcaster_id: tokens.user_id.clone(),
-            user_id: tokens.user_id,
+            broadcaster_id: uid.clone(),
+            user_id: uid,
         };
 
         let started = Instant::now();

--- a/apps/desktop/src-tauri/src/twitch_auth/errors.rs
+++ b/apps/desktop/src-tauri/src/twitch_auth/errors.rs
@@ -8,10 +8,10 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum AuthError {
-    /// No tokens have been persisted for this broadcaster. Supervisor's
-    /// correct response is to kick off the device flow.
-    #[error("no tokens stored for broadcaster {0}")]
-    NoTokens(String),
+    /// No tokens have been persisted. Supervisor's correct response is
+    /// to kick off the device flow (or idle for the frontend to do so).
+    #[error("no tokens stored")]
+    NoTokens,
 
     /// Refresh exchange succeeded with the server but the server said the
     /// refresh token is invalid. Per ADR 31 this surfaces a re-auth UI;

--- a/apps/desktop/src-tauri/src/twitch_auth/manager.rs
+++ b/apps/desktop/src-tauri/src/twitch_auth/manager.rs
@@ -104,19 +104,7 @@ impl AuthManager {
             return Ok(stored);
         }
 
-        match self.refresh_tokens(&stored).await {
-            Ok(refreshed) => {
-                self.store.save(&refreshed)?;
-                Ok(refreshed)
-            }
-            Err(AuthError::RefreshTokenInvalid) => {
-                // Swallow the delete error: the caller cares about the
-                // auth failure, not a keychain cleanup hiccup.
-                let _ = self.store.delete();
-                Err(AuthError::RefreshTokenInvalid)
-            }
-            Err(e) => Err(e),
-        }
+        handle_refresh_result(self.refresh_tokens(&stored).await, self.store.as_ref())
     }
 
     /// Requests a device code from Twitch. The returned response has
@@ -210,6 +198,34 @@ fn tokens_from_user_token(token: &UserToken) -> Result<TwitchTokens, AuthError> 
         user_id,
         login,
     })
+}
+
+/// Post-processes the result of a refresh exchange: persists success,
+/// wipes stored tokens on `RefreshTokenInvalid` (so the supervisor's
+/// 30-second retry loop doesn't hammer Twitch's refresh endpoint with
+/// a known-dead token every tick), propagates other errors unchanged.
+///
+/// Extracted as a pure function over `&dyn TokenStore` so the behavior
+/// is testable without mocking the HTTP refresh itself (the
+/// `twitch_oauth2` side of that is covered manually via the
+/// `prismoid_dcf` E2E, with a proper mock harness tracked in PRI-14).
+fn handle_refresh_result(
+    result: Result<TwitchTokens, AuthError>,
+    store: &dyn TokenStore,
+) -> Result<TwitchTokens, AuthError> {
+    match result {
+        Ok(refreshed) => {
+            store.save(&refreshed)?;
+            Ok(refreshed)
+        }
+        Err(AuthError::RefreshTokenInvalid) => {
+            // Swallow the delete error: the caller cares about the
+            // auth failure, not a keychain cleanup hiccup.
+            let _ = store.delete();
+            Err(AuthError::RefreshTokenInvalid)
+        }
+        Err(e) => Err(e),
+    }
 }
 
 /// Rejects a half-initialized identity. `UserToken.user_id` / `login`
@@ -335,6 +351,59 @@ mod tests {
             Err(AuthError::OAuth(_)) => {}
             other => panic!("expected OAuth, got {other:?}"),
         }
+    }
+
+    fn sample_tokens() -> TwitchTokens {
+        TwitchTokens {
+            access_token: "at-new".into(),
+            refresh_token: "rt-new".into(),
+            expires_at_ms: 1_000_000,
+            scopes: vec!["user:read:chat".into()],
+            user_id: "570722168".into(),
+            login: "impulseb23".into(),
+        }
+    }
+
+    #[test]
+    fn handle_refresh_result_persists_on_success() {
+        let store = MemoryStore::default();
+        let fresh = sample_tokens();
+        let got = handle_refresh_result(Ok(fresh.clone()), &store).unwrap();
+        assert_eq!(got, fresh);
+        assert_eq!(
+            store.load().unwrap().unwrap(),
+            fresh,
+            "refreshed tokens must land in the store"
+        );
+    }
+
+    #[test]
+    fn handle_refresh_result_deletes_on_refresh_token_invalid() {
+        let store = MemoryStore::default();
+        // Seed the store with stale tokens the caller is trying to refresh.
+        store.save(&sample_tokens()).unwrap();
+        assert!(store.load().unwrap().is_some());
+
+        let err = handle_refresh_result(Err(AuthError::RefreshTokenInvalid), &store).unwrap_err();
+        assert!(matches!(err, AuthError::RefreshTokenInvalid));
+        assert!(
+            store.load().unwrap().is_none(),
+            "stale tokens must be evicted so the supervisor doesn't retry against them"
+        );
+    }
+
+    #[test]
+    fn handle_refresh_result_propagates_other_errors_without_touching_store() {
+        let store = MemoryStore::default();
+        store.save(&sample_tokens()).unwrap();
+
+        let err =
+            handle_refresh_result(Err(AuthError::OAuth("network".into())), &store).unwrap_err();
+        assert!(matches!(err, AuthError::OAuth(_)));
+        assert!(
+            store.load().unwrap().is_some(),
+            "transient errors must not evict tokens — refresh might succeed next tick"
+        );
     }
 
     #[tokio::test]

--- a/apps/desktop/src-tauri/src/twitch_auth/manager.rs
+++ b/apps/desktop/src-tauri/src/twitch_auth/manager.rs
@@ -10,6 +10,7 @@
 //! the DCF response's `UserToken.user_id` / `UserToken.login`).
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use chrono::Utc;
 use twitch_oauth2::id::DeviceCodeResponse;
@@ -184,8 +185,6 @@ fn tokens_from_user_token(token: &UserToken) -> Result<TwitchTokens, AuthError> 
     let login = token.login.to_string();
     validate_identity(&user_id, &login)?;
 
-    let expires_in_ms = i64::try_from(token.expires_in().as_millis()).unwrap_or(i64::MAX);
-    let now_ms = Utc::now().timestamp_millis();
     Ok(TwitchTokens {
         access_token: token.access_token.secret().to_owned(),
         refresh_token: token
@@ -193,11 +192,23 @@ fn tokens_from_user_token(token: &UserToken) -> Result<TwitchTokens, AuthError> 
             .as_ref()
             .map(|r| r.secret().to_owned())
             .unwrap_or_default(),
-        expires_at_ms: now_ms.saturating_add(expires_in_ms),
+        expires_at_ms: compute_expires_at_ms(Utc::now().timestamp_millis(), token.expires_in()),
         scopes: token.scopes().iter().map(|s| s.to_string()).collect(),
         user_id,
         login,
     })
+}
+
+/// Overflow-safe absolute expiry timestamp. `Duration::as_millis` returns
+/// `u128`, whose range exceeds `i64`, and the sum `now_ms + expires_in_ms`
+/// can overflow near `i64::MAX`. Both are saturated rather than panicking:
+/// an absurd timestamp is safer than a crash inside the supervisor's hot
+/// path. A saturated value just means `needs_refresh` never fires
+/// proactively, which degrades gracefully to reactive refresh on the next
+/// Twitch 401.
+fn compute_expires_at_ms(now_ms: i64, expires_in: Duration) -> i64 {
+    let expires_in_ms = i64::try_from(expires_in.as_millis()).unwrap_or(i64::MAX);
+    now_ms.saturating_add(expires_in_ms)
 }
 
 /// Post-processes the result of a refresh exchange: persists success,
@@ -322,6 +333,33 @@ mod tests {
             AuthError::OAuth(s) => assert!(s.contains("connection reset")),
             other => panic!("expected OAuth, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn compute_expires_at_ms_happy_path() {
+        let got = compute_expires_at_ms(1_000, Duration::from_secs(3600));
+        assert_eq!(got, 1_000 + 3_600_000);
+    }
+
+    #[test]
+    fn compute_expires_at_ms_zero_duration_returns_now() {
+        let got = compute_expires_at_ms(12_345, Duration::from_secs(0));
+        assert_eq!(got, 12_345);
+    }
+
+    #[test]
+    fn compute_expires_at_ms_saturates_on_duration_overflow() {
+        // Duration::MAX.as_millis() exceeds i64 — try_from falls back to
+        // i64::MAX; then saturating_add clamps the sum to i64::MAX.
+        let got = compute_expires_at_ms(0, Duration::MAX);
+        assert_eq!(got, i64::MAX);
+    }
+
+    #[test]
+    fn compute_expires_at_ms_saturates_on_sum_overflow() {
+        // now_ms already near the ceiling → sum saturates, no panic.
+        let got = compute_expires_at_ms(i64::MAX - 10, Duration::from_secs(3600));
+        assert_eq!(got, i64::MAX);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/twitch_auth/manager.rs
+++ b/apps/desktop/src-tauri/src/twitch_auth/manager.rs
@@ -4,13 +4,10 @@
 //! [`TokenStore`] for keychain persistence. ADR 37 (DCF public client)
 //! and ADR 29 (proactive 5-min refresh) are enforced here.
 //!
-//! Three operations are exposed:
-//! - [`AuthManager::load_or_refresh`] — always-fresh tokens; refreshes
-//!   in-place if within ADR 29's threshold
-//! - [`AuthManager::start_device_flow`] — kicks off DCF, returns the
-//!   verification_uri for the caller to open in a browser
-//! - [`AuthManager::complete_device_flow`] — polls the token endpoint
-//!   until the user authorizes, persists the result
+//! Single-account per ADR 30: `load_or_refresh` / `complete_device_flow`
+//! take no broadcaster_id argument — the store holds exactly one entry.
+//! The user_id + login land on the returned `TwitchTokens` (sourced from
+//! the DCF response's `UserToken.user_id` / `UserToken.login`).
 
 use std::sync::Arc;
 
@@ -89,12 +86,12 @@ impl AuthManager {
         &self.http_client
     }
 
-    /// Loads stored tokens for the broadcaster, refreshing if within
-    /// [`REFRESH_THRESHOLD_MS`] of expiry. The refreshed tokens are
-    /// persisted (Twitch rotates the refresh token on every use).
-    pub async fn load_or_refresh(&self, broadcaster_id: &str) -> Result<TwitchTokens, AuthError> {
-        let Some(stored) = self.store.load(broadcaster_id)? else {
-            return Err(AuthError::NoTokens(broadcaster_id.to_owned()));
+    /// Loads stored tokens, refreshing if within [`REFRESH_THRESHOLD_MS`]
+    /// of expiry. The refreshed tokens are persisted (Twitch rotates the
+    /// refresh token on every use).
+    pub async fn load_or_refresh(&self) -> Result<TwitchTokens, AuthError> {
+        let Some(stored) = self.store.load()? else {
+            return Err(AuthError::NoTokens);
         };
 
         if !stored.needs_refresh(Utc::now().timestamp_millis(), REFRESH_THRESHOLD_MS) {
@@ -102,7 +99,7 @@ impl AuthManager {
         }
 
         let refreshed = self.refresh_tokens(&stored).await?;
-        self.store.save(broadcaster_id, &refreshed)?;
+        self.store.save(&refreshed)?;
         Ok(refreshed)
     }
 
@@ -124,12 +121,11 @@ impl AuthManager {
     }
 
     /// Polls the Twitch token endpoint until the user authorizes the
-    /// device code. On success, the resulting tokens are persisted under
-    /// `broadcaster_id`.
+    /// device code. On success, the resulting tokens (with user_id and
+    /// login populated from the DCF response) are persisted.
     pub async fn complete_device_flow(
         &self,
         mut pending: PendingDeviceFlow,
-        broadcaster_id: &str,
     ) -> Result<TwitchTokens, AuthError> {
         let user_token = pending
             .builder
@@ -137,7 +133,7 @@ impl AuthManager {
             .await
             .map_err(classify_device_flow_error)?;
         let tokens = tokens_from_user_token(&user_token);
-        self.store.save(broadcaster_id, &tokens)?;
+        self.store.save(&tokens)?;
         Ok(tokens)
     }
 
@@ -191,6 +187,8 @@ fn tokens_from_user_token(token: &UserToken) -> TwitchTokens {
             .unwrap_or_default(),
         expires_at_ms: now_ms.saturating_add(expires_in_ms),
         scopes: token.scopes().iter().map(|s| s.to_string()).collect(),
+        user_id: token.user_id.to_string(),
+        login: token.login.to_string(),
     }
 }
 
@@ -280,28 +278,27 @@ mod tests {
         let mgr = AuthManager::builder("test-client-id")
             .build(MemoryStore::default(), test_http_client());
 
-        match mgr.load_or_refresh("b1").await {
-            Err(AuthError::NoTokens(id)) => assert_eq!(id, "b1"),
+        match mgr.load_or_refresh().await {
+            Err(AuthError::NoTokens) => {}
             other => panic!("expected NoTokens, got {other:?}"),
         }
     }
 
     #[tokio::test]
     async fn load_or_refresh_returns_fresh_tokens_verbatim() {
-        // Use a MemoryStoreHandle to share the store between manager and
-        // test assertions without having the manager take ownership.
+        // Share the store with the test via a trait wrapper around Arc.
         let store = Arc::new(MemoryStore::default());
 
         struct Handle(Arc<MemoryStore>);
         impl TokenStore for Handle {
-            fn load(&self, id: &str) -> Result<Option<TwitchTokens>, AuthError> {
-                self.0.load(id)
+            fn load(&self) -> Result<Option<TwitchTokens>, AuthError> {
+                self.0.load()
             }
-            fn save(&self, id: &str, t: &TwitchTokens) -> Result<(), AuthError> {
-                self.0.save(id, t)
+            fn save(&self, t: &TwitchTokens) -> Result<(), AuthError> {
+                self.0.save(t)
             }
-            fn delete(&self, id: &str) -> Result<(), AuthError> {
-                self.0.delete(id)
+            fn delete(&self) -> Result<(), AuthError> {
+                self.0.delete()
             }
         }
 
@@ -313,10 +310,12 @@ mod tests {
             refresh_token: "rt-fresh".into(),
             expires_at_ms: Utc::now().timestamp_millis() + 60 * 60 * 1000,
             scopes: vec!["user:read:chat".into()],
+            user_id: "570722168".into(),
+            login: "impulseb23".into(),
         };
-        store.save("b1", &fresh).unwrap();
+        store.save(&fresh).unwrap();
 
-        let got = mgr.load_or_refresh("b1").await.unwrap();
+        let got = mgr.load_or_refresh().await.unwrap();
         assert_eq!(got, fresh);
     }
 }

--- a/apps/desktop/src-tauri/src/twitch_auth/manager.rs
+++ b/apps/desktop/src-tauri/src/twitch_auth/manager.rs
@@ -89,6 +89,12 @@ impl AuthManager {
     /// Loads stored tokens, refreshing if within [`REFRESH_THRESHOLD_MS`]
     /// of expiry. The refreshed tokens are persisted (Twitch rotates the
     /// refresh token on every use).
+    ///
+    /// On [`AuthError::RefreshTokenInvalid`] the stored entry is deleted
+    /// before returning. Without this the supervisor's 30-second
+    /// retry loop would call the Twitch refresh endpoint every tick
+    /// against a known-dead token until the user re-seeds — a cheap
+    /// request storm that we owe Twitch not to make.
     pub async fn load_or_refresh(&self) -> Result<TwitchTokens, AuthError> {
         let Some(stored) = self.store.load()? else {
             return Err(AuthError::NoTokens);
@@ -98,9 +104,19 @@ impl AuthManager {
             return Ok(stored);
         }
 
-        let refreshed = self.refresh_tokens(&stored).await?;
-        self.store.save(&refreshed)?;
-        Ok(refreshed)
+        match self.refresh_tokens(&stored).await {
+            Ok(refreshed) => {
+                self.store.save(&refreshed)?;
+                Ok(refreshed)
+            }
+            Err(AuthError::RefreshTokenInvalid) => {
+                // Swallow the delete error: the caller cares about the
+                // auth failure, not a keychain cleanup hiccup.
+                let _ = self.store.delete();
+                Err(AuthError::RefreshTokenInvalid)
+            }
+            Err(e) => Err(e),
+        }
     }
 
     /// Requests a device code from Twitch. The returned response has
@@ -132,7 +148,7 @@ impl AuthManager {
             .wait_for_code(&self.http_client, tokio::time::sleep)
             .await
             .map_err(classify_device_flow_error)?;
-        let tokens = tokens_from_user_token(&user_token);
+        let tokens = tokens_from_user_token(&user_token)?;
         self.store.save(&tokens)?;
         Ok(tokens)
     }
@@ -155,7 +171,7 @@ impl AuthManager {
             .await
             .map_err(classify_refresh_error)?;
 
-        Ok(tokens_from_user_token(&token))
+        tokens_from_user_token(&token)
     }
 }
 
@@ -175,10 +191,14 @@ impl PendingDeviceFlow {
     }
 }
 
-fn tokens_from_user_token(token: &UserToken) -> TwitchTokens {
+fn tokens_from_user_token(token: &UserToken) -> Result<TwitchTokens, AuthError> {
+    let user_id = token.user_id.to_string();
+    let login = token.login.to_string();
+    validate_identity(&user_id, &login)?;
+
     let expires_in_ms = i64::try_from(token.expires_in().as_millis()).unwrap_or(i64::MAX);
     let now_ms = Utc::now().timestamp_millis();
-    TwitchTokens {
+    Ok(TwitchTokens {
         access_token: token.access_token.secret().to_owned(),
         refresh_token: token
             .refresh_token
@@ -187,9 +207,24 @@ fn tokens_from_user_token(token: &UserToken) -> TwitchTokens {
             .unwrap_or_default(),
         expires_at_ms: now_ms.saturating_add(expires_in_ms),
         scopes: token.scopes().iter().map(|s| s.to_string()).collect(),
-        user_id: token.user_id.to_string(),
-        login: token.login.to_string(),
+        user_id,
+        login,
+    })
+}
+
+/// Rejects a half-initialized identity. `UserToken.user_id` / `login`
+/// are populated by `validate_token` during `from_existing` and must
+/// remain non-empty across `refresh_token`. An empty value here means
+/// the `twitch_oauth2` crate returned a half-initialized token —
+/// persisting it would silently break the supervisor's EventSub
+/// subscribe (blank `broadcaster_user_id` → opaque 400).
+fn validate_identity(user_id: &str, login: &str) -> Result<(), AuthError> {
+    if user_id.is_empty() || login.is_empty() {
+        return Err(AuthError::OAuth(
+            "twitch_oauth2 returned token with empty user_id or login".into(),
+        ));
     }
+    Ok(())
 }
 
 fn classify_device_flow_error<E: std::fmt::Display>(err: E) -> AuthError {
@@ -269,6 +304,35 @@ mod tests {
     fn classify_refresh_error_falls_through_to_oauth() {
         match classify_refresh_error("connection reset by peer") {
             AuthError::OAuth(s) => assert!(s.contains("connection reset")),
+            other => panic!("expected OAuth, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_identity_accepts_both_populated() {
+        validate_identity("570722168", "impulseb23").expect("populated identity must pass");
+    }
+
+    #[test]
+    fn validate_identity_rejects_empty_user_id() {
+        match validate_identity("", "impulseb23") {
+            Err(AuthError::OAuth(s)) => assert!(s.contains("empty user_id or login")),
+            other => panic!("expected OAuth, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_identity_rejects_empty_login() {
+        match validate_identity("570722168", "") {
+            Err(AuthError::OAuth(s)) => assert!(s.contains("empty user_id or login")),
+            other => panic!("expected OAuth, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_identity_rejects_both_empty() {
+        match validate_identity("", "") {
+            Err(AuthError::OAuth(_)) => {}
             other => panic!("expected OAuth, got {other:?}"),
         }
     }

--- a/apps/desktop/src-tauri/src/twitch_auth/storage.rs
+++ b/apps/desktop/src-tauri/src/twitch_auth/storage.rs
@@ -1,14 +1,14 @@
 //! Persistence layer for [`TwitchTokens`].
 //!
-//! The [`TokenStore`] trait isolates keychain access behind a minimal
-//! interface so the manager and its tests can share the same call path.
-//! Prod uses [`KeychainStore`]; tests use [`MemoryStore`].
+//! Single-account per ADR 30: one blob per app under a fixed
+//! `(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT)` pair. The `TokenStore` trait
+//! isolates keychain access behind a minimal interface so the manager
+//! and its tests can share the same call path.
 //!
-//! Per ADR 37 the keychain layout is: service `prismoid.twitch`, account
-//! `<broadcaster_id>`, password is a serde-JSON blob of [`TwitchTokens`].
-//! One keychain prompt per save, one per load, atomic per broadcaster.
+//! A future "multi-account" feature would keep this trait's shape and
+//! add a sibling `MultiTokenStore` keyed by broadcaster_id. Today
+//! one account is all we need.
 
-use std::collections::HashMap;
 use std::sync::Mutex;
 
 use keyring::Entry;
@@ -16,33 +16,32 @@ use keyring::Entry;
 use super::errors::AuthError;
 use super::tokens::TwitchTokens;
 
-/// Keychain service name. Kept as a const so both the Rust side and any
-/// future CLI tool / migration script read the same key.
+/// Keychain service name. All Prismoid-Twitch entries live under this.
 pub const KEYCHAIN_SERVICE: &str = "prismoid.twitch";
 
-/// Read/write/delete a persisted [`TwitchTokens`] blob, keyed by
-/// broadcaster ID. Impls must be `Send + Sync` so the manager can live
-/// behind an `Arc` shared with the supervisor task.
+/// Keychain account name for the single-account slot. ADR 30 pins
+/// one-account-per-platform in v1. The entry's stored blob carries the
+/// actual user_id/login inside it (see [`TwitchTokens`]).
+pub const KEYCHAIN_ACCOUNT: &str = "active";
+
+/// Read/write/delete the persisted [`TwitchTokens`] for the single
+/// active Twitch account. Impls must be `Send + Sync` so the manager
+/// can live behind an `Arc` shared with the supervisor task.
 pub trait TokenStore: Send + Sync {
-    fn load(&self, broadcaster_id: &str) -> Result<Option<TwitchTokens>, AuthError>;
-    fn save(&self, broadcaster_id: &str, tokens: &TwitchTokens) -> Result<(), AuthError>;
-    fn delete(&self, broadcaster_id: &str) -> Result<(), AuthError>;
+    fn load(&self) -> Result<Option<TwitchTokens>, AuthError>;
+    fn save(&self, tokens: &TwitchTokens) -> Result<(), AuthError>;
+    fn delete(&self) -> Result<(), AuthError>;
 }
 
 /// Production [`TokenStore`] backed by the OS's native credential store
 /// (Windows Credential Manager / macOS Keychain / Linux Secret Service)
 /// via the `keyring` crate.
-///
-/// Construction does not touch the keychain; the backing store must have
-/// been initialized via `keyring::set_default_store` before any method
-/// on the produced `Entry` is called. The supervisor does this once at
-/// process start.
 #[derive(Default, Debug)]
 pub struct KeychainStore;
 
 impl TokenStore for KeychainStore {
-    fn load(&self, broadcaster_id: &str) -> Result<Option<TwitchTokens>, AuthError> {
-        let entry = Entry::new(KEYCHAIN_SERVICE, broadcaster_id)?;
+    fn load(&self) -> Result<Option<TwitchTokens>, AuthError> {
+        let entry = Entry::new(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT)?;
         match entry.get_password() {
             Ok(blob) => {
                 let tokens: TwitchTokens = serde_json::from_str(&blob)?;
@@ -53,15 +52,15 @@ impl TokenStore for KeychainStore {
         }
     }
 
-    fn save(&self, broadcaster_id: &str, tokens: &TwitchTokens) -> Result<(), AuthError> {
-        let entry = Entry::new(KEYCHAIN_SERVICE, broadcaster_id)?;
+    fn save(&self, tokens: &TwitchTokens) -> Result<(), AuthError> {
+        let entry = Entry::new(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT)?;
         let blob = serde_json::to_string(tokens)?;
         entry.set_password(&blob)?;
         Ok(())
     }
 
-    fn delete(&self, broadcaster_id: &str) -> Result<(), AuthError> {
-        let entry = Entry::new(KEYCHAIN_SERVICE, broadcaster_id)?;
+    fn delete(&self) -> Result<(), AuthError> {
+        let entry = Entry::new(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT)?;
         match entry.delete_credential() {
             Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
             Err(e) => Err(AuthError::Keychain(e)),
@@ -74,24 +73,24 @@ impl TokenStore for KeychainStore {
 /// across runs, and doesn't conflict with any real user's saved tokens.
 #[derive(Default, Debug)]
 pub struct MemoryStore {
-    inner: Mutex<HashMap<String, TwitchTokens>>,
+    inner: Mutex<Option<TwitchTokens>>,
 }
 
 impl TokenStore for MemoryStore {
-    fn load(&self, broadcaster_id: &str) -> Result<Option<TwitchTokens>, AuthError> {
+    fn load(&self) -> Result<Option<TwitchTokens>, AuthError> {
         let guard = self.inner.lock().expect("MemoryStore mutex poisoned");
-        Ok(guard.get(broadcaster_id).cloned())
+        Ok(guard.clone())
     }
 
-    fn save(&self, broadcaster_id: &str, tokens: &TwitchTokens) -> Result<(), AuthError> {
+    fn save(&self, tokens: &TwitchTokens) -> Result<(), AuthError> {
         let mut guard = self.inner.lock().expect("MemoryStore mutex poisoned");
-        guard.insert(broadcaster_id.to_owned(), tokens.clone());
+        *guard = Some(tokens.clone());
         Ok(())
     }
 
-    fn delete(&self, broadcaster_id: &str) -> Result<(), AuthError> {
+    fn delete(&self) -> Result<(), AuthError> {
         let mut guard = self.inner.lock().expect("MemoryStore mutex poisoned");
-        guard.remove(broadcaster_id);
+        *guard = None;
         Ok(())
     }
 }
@@ -106,57 +105,46 @@ mod tests {
             refresh_token: "rt".into(),
             expires_at_ms: 1_000_000,
             scopes: vec!["user:read:chat".into()],
+            user_id: "570722168".into(),
+            login: "impulseb23".into(),
         }
     }
 
     #[test]
     fn memory_store_load_missing_returns_none() {
         let store = MemoryStore::default();
-        assert!(store.load("unknown").unwrap().is_none());
+        assert!(store.load().unwrap().is_none());
     }
 
     #[test]
     fn memory_store_save_then_load_returns_same() {
         let store = MemoryStore::default();
         let t = sample();
-        store.save("b1", &t).unwrap();
-        assert_eq!(store.load("b1").unwrap().unwrap(), t);
+        store.save(&t).unwrap();
+        assert_eq!(store.load().unwrap().unwrap(), t);
     }
 
     #[test]
     fn memory_store_save_overwrites() {
         let store = MemoryStore::default();
         let mut t = sample();
-        store.save("b1", &t).unwrap();
+        store.save(&t).unwrap();
         t.access_token = "at2".into();
-        store.save("b1", &t).unwrap();
-        assert_eq!(store.load("b1").unwrap().unwrap(), t);
+        store.save(&t).unwrap();
+        assert_eq!(store.load().unwrap().unwrap(), t);
     }
 
     #[test]
     fn memory_store_delete_removes_entry() {
         let store = MemoryStore::default();
-        store.save("b1", &sample()).unwrap();
-        store.delete("b1").unwrap();
-        assert!(store.load("b1").unwrap().is_none());
+        store.save(&sample()).unwrap();
+        store.delete().unwrap();
+        assert!(store.load().unwrap().is_none());
     }
 
     #[test]
     fn memory_store_delete_missing_is_noop() {
         let store = MemoryStore::default();
-        store.delete("never-existed").unwrap();
-    }
-
-    #[test]
-    fn memory_store_broadcasters_are_isolated() {
-        let store = MemoryStore::default();
-        let mut a = sample();
-        a.access_token = "A".into();
-        let mut b = sample();
-        b.access_token = "B".into();
-        store.save("alpha", &a).unwrap();
-        store.save("beta", &b).unwrap();
-        assert_eq!(store.load("alpha").unwrap().unwrap().access_token, "A");
-        assert_eq!(store.load("beta").unwrap().unwrap().access_token, "B");
+        store.delete().unwrap();
     }
 }

--- a/apps/desktop/src-tauri/src/twitch_auth/tokens.rs
+++ b/apps/desktop/src-tauri/src/twitch_auth/tokens.rs
@@ -7,9 +7,12 @@
 
 use serde::{Deserialize, Serialize};
 
-/// A persisted Twitch OAuth credential set. One of these per broadcaster
-/// lives as a JSON blob in the keychain under service `prismoid.twitch`
-/// with account `<broadcaster_id>` (see ADR 37).
+/// A persisted Twitch OAuth credential set. Single-account per ADR 30:
+/// one blob per app under service `prismoid.twitch`, account
+/// `KEYCHAIN_ACCOUNT` (see `storage.rs`). `user_id` and `login` are the
+/// authenticated Twitch user's identifiers (from the DCF response) —
+/// carried with the token so the supervisor doesn't need to prompt the
+/// user for their own broadcaster ID.
 ///
 /// `Debug` is hand-rolled to redact token secrets. Any accidental
 /// `tracing::debug!("{tokens:?}")` or similar at a call site must not
@@ -26,6 +29,14 @@ pub struct TwitchTokens {
     /// Scopes granted. Carried so a scope-expansion feature can prompt
     /// re-auth when needed without speculative re-auth on every launch.
     pub scopes: Vec<String>,
+    /// Twitch user_id of the authenticated account, from the DCF
+    /// response. Used as `broadcaster_user_id` in EventSub subscriptions.
+    /// Stable across token refreshes.
+    pub user_id: String,
+    /// Twitch login (handle) of the authenticated account. Used for UI
+    /// display ("Logged in as @<login>") and diagnostic logs. Stable
+    /// across token refreshes.
+    pub login: String,
 }
 
 impl std::fmt::Debug for TwitchTokens {
@@ -35,6 +46,8 @@ impl std::fmt::Debug for TwitchTokens {
             .field("refresh_token", &"[redacted]")
             .field("expires_at_ms", &self.expires_at_ms)
             .field("scopes", &self.scopes)
+            .field("user_id", &self.user_id)
+            .field("login", &self.login)
             .finish()
     }
 }
@@ -59,6 +72,8 @@ mod tests {
             refresh_token: "rt".into(),
             expires_at_ms,
             scopes: vec!["user:read:chat".into()],
+            user_id: "123".into(),
+            login: "someone".into(),
         }
     }
 
@@ -103,6 +118,8 @@ mod tests {
             refresh_token: "super-secret-refresh-xyz".into(),
             expires_at_ms: 1_234_567,
             scopes: vec!["user:read:chat".into()],
+            user_id: "570722168".into(),
+            login: "impulseb23".into(),
         };
         let debug_str = format!("{t:?}");
         assert!(
@@ -117,5 +134,7 @@ mod tests {
         // Non-secret fields still observable for debugging.
         assert!(debug_str.contains("1234567"));
         assert!(debug_str.contains("user:read:chat"));
+        assert!(debug_str.contains("570722168"));
+        assert!(debug_str.contains("impulseb23"));
     }
 }


### PR DESCRIPTION
## Summary
Second slice of the Phase 1 UI-chrome work (PRI-22b). The supervisor and DCF seed bin no longer need any env vars — broadcaster identity rides inside the persisted `TwitchTokens` blob and comes directly from the DCF response's `UserToken.user_id` / `UserToken.login`.

Combined with PRI-22a (client_id bake-in, #59), a Jynxzi-tier user now needs **zero config** to authenticate: install, run the DCF flow, done. The supervisor picks up the tokens from the keychain on next poll.

### Changes
- `tokens.rs`: `TwitchTokens` gains `user_id: String` + `login: String`. Populated in `tokens_from_user_token` from the DCF/refresh response. Stable across refresh. Debug impl + tests updated.
- `storage.rs`: `TokenStore` trait drops the `broadcaster_id` parameter from every method. New const `KEYCHAIN_ACCOUNT = "active"` — single-account slot per ADR 30. `MemoryStore` collapses from `HashMap<String, TwitchTokens>` to `Mutex<Option<TwitchTokens>>`.
- `manager.rs`: `load_or_refresh()` / `complete_device_flow(pending)` take no broadcaster_id. Error variant simplified to unit `AuthError::NoTokens`.
- `sidecar_supervisor.rs`: drops `PRISMOID_TWITCH_BROADCASTER_ID` / `PRISMOID_TWITCH_USER_ID` env lookups. The supervisor reads the broadcaster_id/user_id off the loaded `TwitchTokens` (the authenticated user IS the broadcaster per ADR 30).
- `bin/prismoid_dcf.rs`: drops the broadcaster env read. Prints "logged in as @\<login\> (user_id \<id\>)" on success so the user can verify the right account landed in the keychain.

### Multi-account upgrade path (if we ever want it)
Keep the trait shape, add a sibling `MultiTokenStore` keyed by `broadcaster_id`. Today one account is all we need.

## Test plan
- [x] `cargo test --lib` — 56 pass (was 57; `memory_store_broadcasters_are_isolated` removed, not meaningful with single-account)
- [x] `cargo clippy --lib --bins --tests -- -D warnings` — clean
- [ ] Manual re-seed + E2E pending on post-merge integration — behavior equivalence with PRI-21 E2E (DCF → keychain → supervisor → eventsub → chat render) already verified; this PR's change is only the key-shape

## Out of scope
- Frontend "Login with Twitch" button + Tauri commands — PRI-22c
- Re-auth modal on `RefreshTokenInvalid` — PRI-22d