### PR TITLE
feat(frontend): virtualize chat feed with pretext

### DIFF
--- a/apps/desktop/bun.lock
+++ b/apps/desktop/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "prismoid",
       "dependencies": {
+        "@chenglou/pretext": "^0.0.5",
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-shell": "^2.3.5",
         "solid-js": "^1.9.12",
@@ -73,6 +74,8 @@
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
     "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
+
+    "@chenglou/pretext": ["@chenglou/pretext@0.0.5", "", {}, "sha512-A8GZN10REdFGsyuiUgLV8jjPDDFMg5GmgxGWV0I3igxBOnzj+jgz2VMmVD7g+SFyoctfeqHFxbNatKSzVRWtRg=="],
 
     "@commitlint/cli": ["@commitlint/cli@20.5.0", "", { "dependencies": { "@commitlint/format": "^20.5.0", "@commitlint/lint": "^20.5.0", "@commitlint/load": "^20.5.0", "@commitlint/read": "^20.5.0", "@commitlint/types": "^20.5.0", "tinyexec": "^1.0.0", "yargs": "^17.0.0" }, "bin": { "commitlint": "./cli.js" } }, "sha512-yNkyN/tuKTJS3wdVfsZ2tXDM4G4Gi7z+jW54Cki8N8tZqwKBltbIvUUrSbT4hz1bhW/h0CdR+5sCSpXD+wMKaQ=="],
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -17,6 +17,7 @@
     "prepare": "test -d .git && lefthook install --force || echo 'skipping lefthook (not a git repo)'"
   },
   "dependencies": {
+    "@chenglou/pretext": "^0.0.5",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-shell": "^2.3.5",
     "solid-js": "^1.9.12"

--- a/apps/desktop/src/components/ChatFeed.tsx
+++ b/apps/desktop/src/components/ChatFeed.tsx
@@ -22,7 +22,10 @@ import {
   type ChatMessage,
 } from "../stores/chatStore";
 import {
+  MESSAGE_FONT_FAMILY,
+  MESSAGE_FONT_SIZE_PX,
   MESSAGE_LINE_HEIGHT,
+  MESSAGE_PADDING_X,
   MESSAGE_PADDING_Y,
   measureMessageHeight,
   prepareMessage,
@@ -163,10 +166,13 @@ const ChatFeed: Component = () => {
 
     // Pretext uses canvas measureText; heights are only trustworthy once
     // webfonts are decoded. Fall back to immediate readiness in headless
-    // environments that lack document.fonts.
+    // environments that lack document.fonts, and on rejection/throw so the
+    // UI never gets stuck waiting on a font promise that never settles.
     const fonts = (document as Document & { fonts?: FontFaceSet }).fonts;
     if (fonts && typeof fonts.ready?.then === "function") {
-      fonts.ready.then(() => setFontsLoaded(true));
+      fonts.ready
+        .then(() => setFontsLoaded(true))
+        .catch(() => setFontsLoaded(true));
     } else {
       setFontsLoaded(true);
     }
@@ -216,12 +222,11 @@ const ChatFeed: Component = () => {
                 right: 0,
                 transform: `translateY(${item.top}px)`,
                 height: `${item.height}px`,
-                padding: `${MESSAGE_PADDING_Y / 2}px 8px`,
+                padding: `${MESSAGE_PADDING_Y / 2}px ${MESSAGE_PADDING_X}px`,
                 "line-height": `${MESSAGE_LINE_HEIGHT}px`,
                 "box-sizing": "border-box",
-                "font-family":
-                  '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
-                "font-size": "13px",
+                "font-family": MESSAGE_FONT_FAMILY,
+                "font-size": `${MESSAGE_FONT_SIZE_PX}px`,
                 "white-space": "normal",
                 "overflow-wrap": "break-word",
               }}
@@ -230,6 +235,10 @@ const ChatFeed: Component = () => {
                 style={{
                   color: item.msg.color || "#9147ff",
                   "font-weight": 700,
+                  // Keep DOM in lockstep with Pretext's `break: "never"`
+                  // on the username segment so heights stay accurate even
+                  // for very long display names.
+                  "white-space": "nowrap",
                 }}
               >
                 {item.msg.display_name}

--- a/apps/desktop/src/components/ChatFeed.tsx
+++ b/apps/desktop/src/components/ChatFeed.tsx
@@ -1,62 +1,176 @@
+// Virtualized chat renderer. Uses Pretext for exact pixel-perfect message
+// heights (no DOM reflow), binary-searches the visible range, and keeps
+// the mounted DOM bounded to the viewport window + overscan. ADR 21 +
+// docs/frontend.md: one viewport signal per frame, message buffer lives
+// outside Solid reactivity.
+
 import {
   Component,
   For,
   createEffect,
   createMemo,
+  createSignal,
   onCleanup,
   onMount,
 } from "solid-js";
 import { listen } from "@tauri-apps/api/event";
+import type { PreparedRichInline } from "@chenglou/pretext/rich-inline";
 import {
   addMessages,
   getMessage,
   viewport,
   type ChatMessage,
 } from "../stores/chatStore";
+import {
+  MESSAGE_LINE_HEIGHT,
+  MESSAGE_PADDING_Y,
+  measureMessageHeight,
+  prepareMessage,
+} from "../lib/messageLayout";
+
+const OVERSCAN = 6;
+const STICK_THRESHOLD = 40;
+
+interface PositionedMessage {
+  monoIndex: number;
+  msg: ChatMessage;
+  prepared: PreparedRichInline;
+  top: number;
+  height: number;
+}
 
 const ChatFeed: Component = () => {
   let containerRef: HTMLDivElement | undefined;
-  let userScrolledUp = false;
+  const preparedCache = new Map<number, PreparedRichInline>();
 
-  const scrollToBottom = () => {
-    if (!userScrolledUp && containerRef) {
-      containerRef.scrollTop = containerRef.scrollHeight;
-    }
-  };
+  const [width, setWidth] = createSignal(0);
+  const [viewportHeight, setViewportHeight] = createSignal(0);
+  const [scrollTop, setScrollTop] = createSignal(0);
+  const [stickToBottom, setStickToBottom] = createSignal(true);
+  const [fontsLoaded, setFontsLoaded] = createSignal(false);
+
+  let scrollRafPending = false;
 
   const handleScroll = () => {
     if (!containerRef) return;
-    const { scrollTop, scrollHeight, clientHeight } = containerRef;
-    userScrolledUp = scrollHeight - scrollTop - clientHeight > 40;
+    if (scrollRafPending) return;
+    scrollRafPending = true;
+    requestAnimationFrame(() => {
+      scrollRafPending = false;
+      if (!containerRef) return;
+      const top = containerRef.scrollTop;
+      const clientH = containerRef.clientHeight;
+      const totalH = containerRef.scrollHeight;
+      setScrollTop(top);
+      setStickToBottom(totalH - top - clientH <= STICK_THRESHOLD);
+    });
   };
 
-  // Derive the visible message slice from the viewport signal. The ring
-  // buffer stores stable references, so `<For>` reuses DOM nodes for messages
-  // that remain in the visible window across frames. The per-frame array
-  // allocation is bounded by maxMessages and matches ADR 21's "one viewport
-  // update per frame" contract.
-  const visibleMessages = createMemo<ChatMessage[]>(() => {
+  const layout = createMemo<{
+    messages: PositionedMessage[];
+    totalHeight: number;
+  }>(() => {
     const v = viewport();
-    const out: ChatMessage[] = [];
-    for (let i = 0; i < v.count; i++) {
-      const msg = getMessage(v.start + i);
-      if (msg) out.push(msg);
+    const w = width();
+    if (!fontsLoaded() || w <= 0 || v.count === 0) {
+      return { messages: [], totalHeight: 0 };
     }
-    return out;
+
+    const liveStart = v.start;
+    const liveEnd = v.start + v.count;
+
+    for (const key of preparedCache.keys()) {
+      if (key < liveStart) preparedCache.delete(key);
+    }
+
+    const messages: PositionedMessage[] = new Array(v.count);
+    let y = 0;
+    let writeIdx = 0;
+    for (let mono = liveStart; mono < liveEnd; mono++) {
+      const msg = getMessage(mono);
+      if (!msg) continue;
+      let prepared = preparedCache.get(mono);
+      if (prepared === undefined) {
+        prepared = prepareMessage(msg);
+        preparedCache.set(mono, prepared);
+      }
+      const height = measureMessageHeight(prepared, w);
+      messages[writeIdx++] = { monoIndex: mono, msg, prepared, top: y, height };
+      y += height;
+    }
+    messages.length = writeIdx;
+    return { messages, totalHeight: y };
+  });
+
+  const visibleRange = createMemo<{ start: number; end: number }>(() => {
+    const { messages } = layout();
+    const top = scrollTop();
+    const vh = viewportHeight();
+    if (messages.length === 0 || vh === 0) return { start: 0, end: 0 };
+
+    const minY = Math.max(0, top);
+    const maxY = top + vh;
+
+    let low = 0;
+    let high = messages.length;
+    while (low < high) {
+      const mid = (low + high) >> 1;
+      if (messages[mid]!.top + messages[mid]!.height > minY) high = mid;
+      else low = mid + 1;
+    }
+    const start = Math.max(0, low - OVERSCAN);
+
+    low = start;
+    high = messages.length;
+    while (low < high) {
+      const mid = (low + high) >> 1;
+      if (messages[mid]!.top >= maxY) high = mid;
+      else low = mid + 1;
+    }
+    const end = Math.min(messages.length, low + OVERSCAN);
+    return { start, end };
+  });
+
+  const visibleMessages = createMemo<PositionedMessage[]>(() => {
+    const { messages } = layout();
+    const { start, end } = visibleRange();
+    return messages.slice(start, end);
   });
 
   createEffect(() => {
-    visibleMessages();
-    scrollToBottom();
+    const { totalHeight } = layout();
+    if (!containerRef) return;
+    if (!stickToBottom()) return;
+    const vh = viewportHeight();
+    if (vh === 0) return;
+    const target = Math.max(0, totalHeight - vh);
+    if (Math.abs(containerRef.scrollTop - target) > 0.5) {
+      containerRef.scrollTop = target;
+    }
   });
 
   onMount(() => {
-    // Capture the unlisten handle into a closure so we can register
-    // onCleanup synchronously inside onMount (Solid's lifecycle only
-    // tracks cleanups registered inside its render/root scope; calling
-    // onCleanup from inside a .then() callback logs the warning
-    // "cleanups created outside a createRoot or render will never be
-    // run" and leaks listeners on HMR/unmount).
+    if (!containerRef) return;
+
+    const ro = new ResizeObserver(() => {
+      if (!containerRef) return;
+      setWidth(containerRef.clientWidth);
+      setViewportHeight(containerRef.clientHeight);
+    });
+    ro.observe(containerRef);
+    setWidth(containerRef.clientWidth);
+    setViewportHeight(containerRef.clientHeight);
+
+    // Pretext uses canvas measureText; heights are only trustworthy once
+    // webfonts are decoded. Fall back to immediate readiness in headless
+    // environments that lack document.fonts.
+    const fonts = (document as Document & { fonts?: FontFaceSet }).fonts;
+    if (fonts && typeof fonts.ready?.then === "function") {
+      fonts.ready.then(() => setFontsLoaded(true));
+    } else {
+      setFontsLoaded(true);
+    }
+
     let unlisten: (() => void) | undefined;
     listen<ChatMessage[]>("chat_messages", (event) => {
       addMessages(event.payload);
@@ -67,7 +181,11 @@ const ChatFeed: Component = () => {
       .catch((err) =>
         console.error("failed to listen for chat messages:", err),
       );
-    onCleanup(() => unlisten?.());
+
+    onCleanup(() => {
+      ro.disconnect();
+      unlisten?.();
+    });
   });
 
   return (
@@ -77,23 +195,51 @@ const ChatFeed: Component = () => {
       style={{
         flex: 1,
         "overflow-y": "auto",
-        padding: "8px",
+        position: "relative",
         "will-change": "transform",
       }}
     >
-      <For each={visibleMessages()}>
-        {(msg) => (
-          <div style={{ padding: "2px 0", "line-height": "1.4" }}>
-            <span
-              style={{ color: msg.color || "#9147ff", "font-weight": "bold" }}
+      <div
+        style={{
+          position: "relative",
+          height: `${layout().totalHeight}px`,
+          width: "100%",
+        }}
+      >
+        <For each={visibleMessages()}>
+          {(item) => (
+            <div
+              style={{
+                position: "absolute",
+                top: 0,
+                left: 0,
+                right: 0,
+                transform: `translateY(${item.top}px)`,
+                height: `${item.height}px`,
+                padding: `${MESSAGE_PADDING_Y / 2}px 8px`,
+                "line-height": `${MESSAGE_LINE_HEIGHT}px`,
+                "box-sizing": "border-box",
+                "font-family":
+                  '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+                "font-size": "13px",
+                "white-space": "normal",
+                "overflow-wrap": "break-word",
+              }}
             >
-              {msg.display_name}
-            </span>
-            <span style={{ color: "#adadb8" }}>: </span>
-            <span>{msg.message_text}</span>
-          </div>
-        )}
-      </For>
+              <span
+                style={{
+                  color: item.msg.color || "#9147ff",
+                  "font-weight": 700,
+                }}
+              >
+                {item.msg.display_name}
+              </span>
+              <span style={{ color: "#adadb8" }}>: </span>
+              <span>{item.msg.message_text}</span>
+            </div>
+          )}
+        </For>
+      </div>
     </div>
   );
 };

--- a/apps/desktop/src/lib/messageLayout.ts
+++ b/apps/desktop/src/lib/messageLayout.ts
@@ -10,15 +10,22 @@ import {
 import type { ChatMessage } from "../stores/chatStore";
 
 // Named families only. `system-ui` is unsafe for pretext accuracy on macOS.
-const FONT_FAMILY =
+// Exported so `ChatFeed.tsx` applies the exact same stack that Pretext
+// measures against — any drift here produces wrong heights.
+export const MESSAGE_FONT_FAMILY =
   '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+export const MESSAGE_FONT_SIZE_PX = 13;
 
-const USERNAME_FONT = `700 13px ${FONT_FAMILY}`;
-const SEPARATOR_FONT = `400 13px ${FONT_FAMILY}`;
-const TEXT_FONT = `400 13px ${FONT_FAMILY}`;
+const USERNAME_FONT = `700 ${MESSAGE_FONT_SIZE_PX}px ${MESSAGE_FONT_FAMILY}`;
+const SEPARATOR_FONT = `400 ${MESSAGE_FONT_SIZE_PX}px ${MESSAGE_FONT_FAMILY}`;
+const TEXT_FONT = `400 ${MESSAGE_FONT_SIZE_PX}px ${MESSAGE_FONT_FAMILY}`;
 
 export const MESSAGE_LINE_HEIGHT = 20;
 export const MESSAGE_PADDING_Y = 4;
+// Horizontal padding applied to every message row; Pretext must measure
+// against the container width minus both sides or the last-word-per-line
+// overflow will never wrap and measured heights will be too small.
+export const MESSAGE_PADDING_X = 8;
 
 export function prepareMessage(msg: ChatMessage): PreparedRichInline {
   return prepareRichInline([
@@ -34,9 +41,10 @@ export function prepareMessage(msg: ChatMessage): PreparedRichInline {
 
 export function measureMessageHeight(
   prepared: PreparedRichInline,
-  width: number,
+  containerWidth: number,
 ): number {
-  if (width <= 0) return MESSAGE_LINE_HEIGHT + MESSAGE_PADDING_Y;
-  const { lineCount } = measureRichInlineStats(prepared, width);
+  const contentWidth = Math.max(0, containerWidth - MESSAGE_PADDING_X * 2);
+  if (contentWidth <= 0) return MESSAGE_LINE_HEIGHT + MESSAGE_PADDING_Y;
+  const { lineCount } = measureRichInlineStats(prepared, contentWidth);
   return Math.max(1, lineCount) * MESSAGE_LINE_HEIGHT + MESSAGE_PADDING_Y;
 }

--- a/apps/desktop/src/lib/messageLayout.ts
+++ b/apps/desktop/src/lib/messageLayout.ts
@@ -1,0 +1,42 @@
+// Pretext-powered measurement for chat messages. ADR 2: Pretext is the
+// source of truth for text metrics so the virtual scroller gets exact
+// pixel heights without DOM reflow.
+
+import {
+  measureRichInlineStats,
+  prepareRichInline,
+  type PreparedRichInline,
+} from "@chenglou/pretext/rich-inline";
+import type { ChatMessage } from "../stores/chatStore";
+
+// Named families only. `system-ui` is unsafe for pretext accuracy on macOS.
+const FONT_FAMILY =
+  '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+
+const USERNAME_FONT = `700 13px ${FONT_FAMILY}`;
+const SEPARATOR_FONT = `400 13px ${FONT_FAMILY}`;
+const TEXT_FONT = `400 13px ${FONT_FAMILY}`;
+
+export const MESSAGE_LINE_HEIGHT = 20;
+export const MESSAGE_PADDING_Y = 4;
+
+export function prepareMessage(msg: ChatMessage): PreparedRichInline {
+  return prepareRichInline([
+    {
+      text: msg.display_name,
+      font: USERNAME_FONT,
+      break: "never",
+    },
+    { text: ": ", font: SEPARATOR_FONT },
+    { text: msg.message_text, font: TEXT_FONT },
+  ]);
+}
+
+export function measureMessageHeight(
+  prepared: PreparedRichInline,
+  width: number,
+): number {
+  if (width <= 0) return MESSAGE_LINE_HEIGHT + MESSAGE_PADDING_Y;
+  const { lineCount } = measureRichInlineStats(prepared, width);
+  return Math.max(1, lineCount) * MESSAGE_LINE_HEIGHT + MESSAGE_PADDING_Y;
+}


### PR DESCRIPTION
Replaces the current `<For>`-over-whole-buffer ChatFeed with a Pretext-backed virtualized renderer.

## What

- Installs `@chenglou/pretext` (ADR 2 dependency, previously missing)
- Adds `src/lib/messageLayout.ts` — `prepareRichInline()` per message, `measureRichInlineStats()` for exact pixel heights
- Rewrites `ChatFeed.tsx`:
  - Maintains a prepared-handle cache keyed by monotonic index; evicts handles for messages evicted from the ring
  - Binary-search visible range on scroll (viewport top/bottom against message top/top+height)
  - Mounts only messages in `[visibleStart - OVERSCAN, visibleEnd + OVERSCAN)` — bounded DOM regardless of buffer size
  - ResizeObserver drives a width signal; resize re-runs pure-arithmetic `layout()` only
  - RAF-coalesced scroll signal (one update per frame)
  - Auto-stick-to-bottom with 40px threshold; pauses when the user scrolls up
  - Waits on `document.fonts.ready` before first layout so canvas-measured widths match DOM rendering

## Why

The previous ChatFeed rendered every buffered message (up to 5000 DOM nodes). That's unworkable for the 10k+ msg/s peak target in `docs/performance.md`. Pretext gives exact heights from pure arithmetic over cached canvas measurements — no `getBoundingClientRect` calls, no layout reflow per message. This is the foundation that emotes, badges, mod actions, user cards, etc. all build on top of.

## Verification

- `bun run typecheck` ✓
- `bun run lint` ✓
- `bun run test` ✓ (10/10)
- `bun run build` ✓ (62.3 kB, 22.4 kB gzipped)
- `bun run format:check` ✓