### PR TITLE
feat(host): lock-free emote index with aho-corasick scanner

### DIFF
--- a/apps/desktop/src-sidecar/internal/emotes/bttv.go
+++ b/apps/desktop/src-sidecar/internal/emotes/bttv.go
@@ -1,0 +1,112 @@
+package emotes
+
+import "context"
+
+const bttvDefaultBase = "https://api.betterttv.net/3"
+const bttvCDN = "https://cdn.betterttv.net"
+
+// BTTVClient fetches global and channel emotes from BetterTTV.
+//
+// Docs: BTTV does not publish an OpenAPI spec; endpoints are stable and
+// widely consumed by the community (Chatterino, FrankerFaceZ, Streamlink).
+// Channel lookup 404s for any Twitch user without a BTTV account.
+type BTTVClient struct {
+	HTTPClient Doer
+	BaseURL    string
+}
+
+// FetchGlobal returns BTTV's global emote set.
+func (c *BTTVClient) FetchGlobal(ctx context.Context) (EmoteSet, error) {
+	var raw []bttvEmote
+	if err := getJSON(ctx, c.client(), c.base()+"/cached/emotes/global", &raw); err != nil {
+		return EmoteSet{}, err
+	}
+	return EmoteSet{
+		Provider: ProviderBTTV,
+		Scope:    ScopeGlobal,
+		Emotes:   bttvToEmotes(raw),
+	}, nil
+}
+
+// FetchChannel returns BTTV's channel + shared emote sets for the given
+// Twitch broadcaster. Returns [ErrNotFound] for channels without a BTTV
+// integration; the channel and shared lists are merged.
+func (c *BTTVClient) FetchChannel(ctx context.Context, twitchUserID string) (EmoteSet, error) {
+	var raw bttvChannelResponse
+	if err := getJSON(ctx, c.client(), c.base()+"/cached/users/twitch/"+twitchUserID, &raw); err != nil {
+		return EmoteSet{}, err
+	}
+	merged := make([]bttvEmote, 0, len(raw.ChannelEmotes)+len(raw.SharedEmotes))
+	merged = append(merged, raw.ChannelEmotes...)
+	merged = append(merged, raw.SharedEmotes...)
+	return EmoteSet{
+		Provider:  ProviderBTTV,
+		Scope:     ScopeChannel,
+		ChannelID: twitchUserID,
+		Emotes:    bttvToEmotes(merged),
+	}, nil
+}
+
+func (c *BTTVClient) base() string {
+	if c.BaseURL != "" {
+		return c.BaseURL
+	}
+	return bttvDefaultBase
+}
+
+func (c *BTTVClient) client() Doer {
+	if c.HTTPClient != nil {
+		return c.HTTPClient
+	}
+	return defaultHTTPClient
+}
+
+type bttvEmote struct {
+	ID        string `json:"id"`
+	Code      string `json:"code"`
+	ImageType string `json:"imageType"`
+	Animated  bool   `json:"animated"`
+	Width     int    `json:"width"`
+	Height    int    `json:"height"`
+}
+
+type bttvChannelResponse struct {
+	ChannelEmotes []bttvEmote `json:"channelEmotes"`
+	SharedEmotes  []bttvEmote `json:"sharedEmotes"`
+}
+
+func bttvToEmotes(in []bttvEmote) []Emote {
+	out := make([]Emote, 0, len(in))
+	for _, e := range in {
+		if e.ID == "" || e.Code == "" {
+			continue
+		}
+		ext := e.ImageType
+		if ext == "" {
+			ext = "png"
+		}
+		// BTTV only derives animated from imageType=="gif" on legacy entries;
+		// trust the explicit flag when present but infer from ext as a
+		// fallback for older cached payloads that omit `animated`.
+		animated := e.Animated || ext == "gif"
+		out = append(out, Emote{
+			ID:       e.ID,
+			Code:     e.Code,
+			Provider: ProviderBTTV,
+			URL1x:    bttvURL(e.ID, "1x", ext),
+			URL2x:    bttvURL(e.ID, "2x", ext),
+			URL4x:    bttvURL(e.ID, "3x", ext),
+			Width:    e.Width,
+			Height:   e.Height,
+			Animated: animated,
+		})
+	}
+	return out
+}
+
+// bttvURL builds the CDN path for an emote at a given size variant.
+// BTTV exposes 1x/2x/3x; we slot 3x into URL4x since it is the largest
+// available.
+func bttvURL(id, size, ext string) string {
+	return bttvCDN + "/emote/" + id + "/" + size + "." + ext
+}

--- a/apps/desktop/src-sidecar/internal/emotes/bttv_test.go
+++ b/apps/desktop/src-sidecar/internal/emotes/bttv_test.go
@@ -1,0 +1,80 @@
+package emotes
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBTTV_FetchGlobal(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cached/emotes/global" {
+			t.Fatalf("path: %s", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`[
+			{"id":"abc","code":"PogU","imageType":"gif","animated":true,"width":28,"height":28},
+			{"id":"def","code":"monkaS","imageType":"png","animated":false,"width":32,"height":32},
+			{"id":"","code":"skipMe"}
+		]`))
+	}))
+	defer srv.Close()
+
+	c := &BTTVClient{HTTPClient: srv.Client(), BaseURL: srv.URL}
+	set, err := c.FetchGlobal(context.Background())
+	if err != nil {
+		t.Fatalf("FetchGlobal: %v", err)
+	}
+	if len(set.Emotes) != 2 {
+		t.Fatalf("emotes = %d, want 2", len(set.Emotes))
+	}
+	pog := set.Emotes[0]
+	if pog.Code != "PogU" || !pog.Animated {
+		t.Errorf("pog: %+v", pog)
+	}
+	if pog.URL1x != "https://cdn.betterttv.net/emote/abc/1x.gif" {
+		t.Errorf("URL1x = %q", pog.URL1x)
+	}
+	if pog.URL4x != "https://cdn.betterttv.net/emote/abc/3x.gif" {
+		t.Errorf("URL4x = %q", pog.URL4x)
+	}
+}
+
+func TestBTTV_FetchChannel_MergesSharedAndChannel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cached/users/twitch/42" {
+			t.Fatalf("path: %s", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{
+			"channelEmotes":[{"id":"c1","code":"C1","imageType":"png"}],
+			"sharedEmotes":[{"id":"s1","code":"S1","imageType":"png"},{"id":"s2","code":"S2","imageType":"png"}]
+		}`))
+	}))
+	defer srv.Close()
+
+	c := &BTTVClient{HTTPClient: srv.Client(), BaseURL: srv.URL}
+	set, err := c.FetchChannel(context.Background(), "42")
+	if err != nil {
+		t.Fatalf("FetchChannel: %v", err)
+	}
+	if set.ChannelID != "42" || set.Scope != ScopeChannel {
+		t.Errorf("bad set: %+v", set)
+	}
+	if len(set.Emotes) != 3 {
+		t.Fatalf("emotes = %d, want 3", len(set.Emotes))
+	}
+}
+
+func TestBTTV_FetchChannel_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := &BTTVClient{HTTPClient: srv.Client(), BaseURL: srv.URL}
+	_, err := c.FetchChannel(context.Background(), "0")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}

--- a/apps/desktop/src-sidecar/internal/emotes/fetcher.go
+++ b/apps/desktop/src-sidecar/internal/emotes/fetcher.go
@@ -1,0 +1,183 @@
+package emotes
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+// Bundle is the full set of emote and badge catalogs relevant to a single
+// Twitch channel. Global entries are shared across channels; the host's
+// emote index stores them once and joins per-channel sets on top.
+//
+// Any provider fetch that fails is reported in [Bundle.Errors] and the
+// corresponding field is left zero-valued. A failing provider never fails
+// the whole bundle — a dead BTTV CDN must not stop Twitch chat.
+type Bundle struct {
+	TwitchGlobalEmotes  EmoteSet
+	TwitchChannelEmotes EmoteSet
+	TwitchGlobalBadges  BadgeSet
+	TwitchChannelBadges BadgeSet
+	SevenTVGlobal       EmoteSet
+	SevenTVChannel      EmoteSet
+	BTTVGlobal          EmoteSet
+	BTTVChannel         EmoteSet
+	FFZGlobal           EmoteSet
+	FFZChannel          EmoteSet
+	Errors              []ProviderError
+}
+
+// ProviderError attributes a fetch failure to a specific provider and scope.
+type ProviderError struct {
+	Provider Provider
+	Scope    Scope
+	Err      error
+}
+
+func (e *ProviderError) Error() string {
+	return string(e.Provider) + " " + string(e.Scope) + ": " + e.Err.Error()
+}
+
+func (e *ProviderError) Unwrap() error { return e.Err }
+
+// Fetcher is the aggregate client for a single channel join. Each sub-client
+// is optional: a nil client skips that provider entirely. The [TwitchClient]
+// in particular may be nil when the user is unauthenticated; global and
+// channel Twitch sets will simply be absent in that case.
+type Fetcher struct {
+	Twitch  *TwitchClient
+	SevenTV *SevenTVClient
+	BTTV    *BTTVClient
+	FFZ     *FFZClient
+}
+
+// Fetch dispatches all enabled provider requests in parallel and returns a
+// [Bundle]. [ErrNotFound] from a channel-scoped fetch is absorbed (treated
+// as "no channel set configured") rather than recorded as an error.
+func (f *Fetcher) Fetch(ctx context.Context, broadcasterID string) Bundle {
+	var b Bundle
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	record := func(p Provider, s Scope, err error) {
+		if err == nil || errors.Is(err, ErrNotFound) {
+			return
+		}
+		mu.Lock()
+		b.Errors = append(b.Errors, ProviderError{Provider: p, Scope: s, Err: err})
+		mu.Unlock()
+	}
+
+	launch := func(fn func()) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			fn()
+		}()
+	}
+
+	if f.Twitch != nil {
+		launch(func() {
+			set, err := f.Twitch.FetchGlobalEmotes(ctx)
+			record(ProviderTwitch, ScopeGlobal, err)
+			if err == nil {
+				mu.Lock()
+				b.TwitchGlobalEmotes = set
+				mu.Unlock()
+			}
+		})
+		launch(func() {
+			set, err := f.Twitch.FetchChannelEmotes(ctx, broadcasterID)
+			record(ProviderTwitch, ScopeChannel, err)
+			if err == nil {
+				mu.Lock()
+				b.TwitchChannelEmotes = set
+				mu.Unlock()
+			}
+		})
+		launch(func() {
+			set, err := f.Twitch.FetchGlobalBadges(ctx)
+			record(ProviderTwitch, ScopeGlobal, err)
+			if err == nil {
+				mu.Lock()
+				b.TwitchGlobalBadges = set
+				mu.Unlock()
+			}
+		})
+		launch(func() {
+			set, err := f.Twitch.FetchChannelBadges(ctx, broadcasterID)
+			record(ProviderTwitch, ScopeChannel, err)
+			if err == nil {
+				mu.Lock()
+				b.TwitchChannelBadges = set
+				mu.Unlock()
+			}
+		})
+	}
+
+	if f.SevenTV != nil {
+		launch(func() {
+			set, err := f.SevenTV.FetchGlobal(ctx)
+			record(Provider7TV, ScopeGlobal, err)
+			if err == nil {
+				mu.Lock()
+				b.SevenTVGlobal = set
+				mu.Unlock()
+			}
+		})
+		launch(func() {
+			set, err := f.SevenTV.FetchChannel(ctx, broadcasterID)
+			record(Provider7TV, ScopeChannel, err)
+			if err == nil {
+				mu.Lock()
+				b.SevenTVChannel = set
+				mu.Unlock()
+			}
+		})
+	}
+
+	if f.BTTV != nil {
+		launch(func() {
+			set, err := f.BTTV.FetchGlobal(ctx)
+			record(ProviderBTTV, ScopeGlobal, err)
+			if err == nil {
+				mu.Lock()
+				b.BTTVGlobal = set
+				mu.Unlock()
+			}
+		})
+		launch(func() {
+			set, err := f.BTTV.FetchChannel(ctx, broadcasterID)
+			record(ProviderBTTV, ScopeChannel, err)
+			if err == nil {
+				mu.Lock()
+				b.BTTVChannel = set
+				mu.Unlock()
+			}
+		})
+	}
+
+	if f.FFZ != nil {
+		launch(func() {
+			set, err := f.FFZ.FetchGlobal(ctx)
+			record(ProviderFFZ, ScopeGlobal, err)
+			if err == nil {
+				mu.Lock()
+				b.FFZGlobal = set
+				mu.Unlock()
+			}
+		})
+		launch(func() {
+			set, err := f.FFZ.FetchChannel(ctx, broadcasterID)
+			record(ProviderFFZ, ScopeChannel, err)
+			if err == nil {
+				mu.Lock()
+				b.FFZChannel = set
+				mu.Unlock()
+			}
+		})
+	}
+
+	wg.Wait()
+	return b
+}

--- a/apps/desktop/src-sidecar/internal/emotes/fetcher.go
+++ b/apps/desktop/src-sidecar/internal/emotes/fetcher.go
@@ -35,10 +35,22 @@ type ProviderError struct {
 }
 
 func (e *ProviderError) Error() string {
-	return string(e.Provider) + " " + string(e.Scope) + ": " + e.Err.Error()
+	if e == nil {
+		return "<nil>"
+	}
+	msg := string(e.Provider) + " " + string(e.Scope) + ": "
+	if e.Err == nil {
+		return msg + "<nil>"
+	}
+	return msg + e.Err.Error()
 }
 
-func (e *ProviderError) Unwrap() error { return e.Err }
+func (e *ProviderError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
 
 // Fetcher is the aggregate client for a single channel join. Each sub-client
 // is optional: a nil client skips that provider entirely. The [TwitchClient]
@@ -60,7 +72,13 @@ func (f *Fetcher) Fetch(ctx context.Context, broadcasterID string) Bundle {
 	var wg sync.WaitGroup
 
 	record := func(p Provider, s Scope, err error) {
-		if err == nil || errors.Is(err, ErrNotFound) {
+		if err == nil {
+			return
+		}
+		// Channel-scoped 404s mean the broadcaster simply hasn't linked the
+		// provider (no 7TV account, no FFZ room). A global 404 indicates an
+		// outage or API change and must surface.
+		if s == ScopeChannel && errors.Is(err, ErrNotFound) {
 			return
 		}
 		mu.Lock()

--- a/apps/desktop/src-sidecar/internal/emotes/fetcher_test.go
+++ b/apps/desktop/src-sidecar/internal/emotes/fetcher_test.go
@@ -1,0 +1,113 @@
+package emotes
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+// newBundleServer serves stub responses for every endpoint hit by a Fetcher
+// against a single channel. Paths that don't match return 500 so the test
+// notices unexpected requests.
+func newBundleServer(t *testing.T, callCount *int32) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(callCount, 1)
+		switch {
+		case r.URL.Path == "/helix/chat/emotes/global":
+			fmt.Fprint(w, twitchGlobalEmotesBody)
+		case r.URL.Path == "/helix/chat/emotes":
+			fmt.Fprint(w, `{"data":[],"template":""}`)
+		case r.URL.Path == "/helix/chat/badges/global":
+			fmt.Fprint(w, `{"data":[{"set_id":"moderator","versions":[{"id":"1","image_url_1x":"https://u/1"}]}]}`)
+		case r.URL.Path == "/helix/chat/badges":
+			fmt.Fprint(w, `{"data":[]}`)
+		case r.URL.Path == "/7tv/emote-sets/global":
+			fmt.Fprint(w, sevenTVSampleSet)
+		case r.URL.Path == "/7tv/users/twitch/42":
+			w.WriteHeader(http.StatusNotFound)
+		case r.URL.Path == "/bttv/cached/emotes/global":
+			fmt.Fprint(w, `[{"id":"a","code":"G","imageType":"png"}]`)
+		case r.URL.Path == "/bttv/cached/users/twitch/42":
+			fmt.Fprint(w, `{"channelEmotes":[{"id":"c","code":"C","imageType":"png"}],"sharedEmotes":[]}`)
+		case r.URL.Path == "/ffz/set/global":
+			fmt.Fprint(w, `{"default_sets":[1],"sets":{"1":{"emoticons":[{"id":1,"name":"G","urls":{"1":"//cdn/x"}}]}}}`)
+		case r.URL.Path == "/ffz/room/id/42":
+			fmt.Fprint(w, `{"sets":{"2":{"emoticons":[{"id":2,"name":"C","urls":{"1":"//cdn/y"}}]}}}`)
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+}
+
+func TestFetcher_AllProviders(t *testing.T) {
+	var calls int32
+	srv := newBundleServer(t, &calls)
+	defer srv.Close()
+
+	f := &Fetcher{
+		Twitch:  &TwitchClient{HTTPClient: srv.Client(), BaseURL: srv.URL + "/helix", ClientID: "cid", AccessToken: "tok"},
+		SevenTV: &SevenTVClient{HTTPClient: srv.Client(), BaseURL: srv.URL + "/7tv"},
+		BTTV:    &BTTVClient{HTTPClient: srv.Client(), BaseURL: srv.URL + "/bttv"},
+		FFZ:     &FFZClient{HTTPClient: srv.Client(), BaseURL: srv.URL + "/ffz"},
+	}
+
+	b := f.Fetch(context.Background(), "42")
+
+	// 4 Twitch + 2 SevenTV + 2 BTTV + 2 FFZ = 10 requests.
+	if got := atomic.LoadInt32(&calls); got != 10 {
+		t.Errorf("requests = %d, want 10", got)
+	}
+	// SevenTV channel is 404 — absorbed as "not configured", not an error.
+	if len(b.Errors) != 0 {
+		t.Errorf("errors: %+v", b.Errors)
+	}
+	if len(b.TwitchGlobalEmotes.Emotes) == 0 {
+		t.Error("twitch global emotes empty")
+	}
+	if b.TwitchGlobalBadges.Badges[0].Set != "moderator" {
+		t.Errorf("twitch badge: %+v", b.TwitchGlobalBadges)
+	}
+	if len(b.SevenTVChannel.Emotes) != 0 {
+		t.Errorf("seventv channel should be empty on 404, got %+v", b.SevenTVChannel)
+	}
+	if b.BTTVChannel.Emotes[0].Code != "C" {
+		t.Errorf("bttv channel: %+v", b.BTTVChannel)
+	}
+	if b.FFZChannel.Emotes[0].Code != "C" {
+		t.Errorf("ffz channel: %+v", b.FFZChannel)
+	}
+}
+
+func TestFetcher_NilProvidersSkipped(t *testing.T) {
+	f := &Fetcher{}
+	b := f.Fetch(context.Background(), "42")
+	if len(b.Errors) != 0 {
+		t.Errorf("errors: %+v", b.Errors)
+	}
+	if len(b.TwitchGlobalEmotes.Emotes) != 0 || len(b.BTTVGlobal.Emotes) != 0 {
+		t.Error("nothing should be fetched when all clients are nil")
+	}
+}
+
+func TestFetcher_RecordsProviderErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	f := &Fetcher{BTTV: &BTTVClient{HTTPClient: srv.Client(), BaseURL: srv.URL}}
+	b := f.Fetch(context.Background(), "42")
+	if len(b.Errors) != 2 {
+		t.Fatalf("errors = %d, want 2 (global + channel both 502)", len(b.Errors))
+	}
+	for _, e := range b.Errors {
+		if e.Provider != ProviderBTTV {
+			t.Errorf("provider = %s", e.Provider)
+		}
+	}
+}

--- a/apps/desktop/src-sidecar/internal/emotes/fetcher_test.go
+++ b/apps/desktop/src-sidecar/internal/emotes/fetcher_test.go
@@ -16,30 +16,36 @@ func newBundleServer(t *testing.T, callCount *int32) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(callCount, 1)
-		switch {
-		case r.URL.Path == "/helix/chat/emotes/global":
-			fmt.Fprint(w, twitchGlobalEmotesBody)
-		case r.URL.Path == "/helix/chat/emotes":
-			fmt.Fprint(w, `{"data":[],"template":""}`)
-		case r.URL.Path == "/helix/chat/badges/global":
-			fmt.Fprint(w, `{"data":[{"set_id":"moderator","versions":[{"id":"1","image_url_1x":"https://u/1"}]}]}`)
-		case r.URL.Path == "/helix/chat/badges":
-			fmt.Fprint(w, `{"data":[]}`)
-		case r.URL.Path == "/7tv/emote-sets/global":
-			fmt.Fprint(w, sevenTVSampleSet)
-		case r.URL.Path == "/7tv/users/twitch/42":
+		var body string
+		switch r.URL.Path {
+		case "/helix/chat/emotes/global":
+			body = twitchGlobalEmotesBody
+		case "/helix/chat/emotes":
+			body = `{"data":[],"template":""}`
+		case "/helix/chat/badges/global":
+			body = `{"data":[{"set_id":"moderator","versions":[{"id":"1","image_url_1x":"https://u/1"}]}]}`
+		case "/helix/chat/badges":
+			body = `{"data":[]}`
+		case "/7tv/emote-sets/global":
+			body = sevenTVSampleSet
+		case "/7tv/users/twitch/42":
 			w.WriteHeader(http.StatusNotFound)
-		case r.URL.Path == "/bttv/cached/emotes/global":
-			fmt.Fprint(w, `[{"id":"a","code":"G","imageType":"png"}]`)
-		case r.URL.Path == "/bttv/cached/users/twitch/42":
-			fmt.Fprint(w, `{"channelEmotes":[{"id":"c","code":"C","imageType":"png"}],"sharedEmotes":[]}`)
-		case r.URL.Path == "/ffz/set/global":
-			fmt.Fprint(w, `{"default_sets":[1],"sets":{"1":{"emoticons":[{"id":1,"name":"G","urls":{"1":"//cdn/x"}}]}}}`)
-		case r.URL.Path == "/ffz/room/id/42":
-			fmt.Fprint(w, `{"sets":{"2":{"emoticons":[{"id":2,"name":"C","urls":{"1":"//cdn/y"}}]}}}`)
+			return
+		case "/bttv/cached/emotes/global":
+			body = `[{"id":"a","code":"G","imageType":"png"}]`
+		case "/bttv/cached/users/twitch/42":
+			body = `{"channelEmotes":[{"id":"c","code":"C","imageType":"png"}],"sharedEmotes":[]}`
+		case "/ffz/set/global":
+			body = `{"default_sets":[1],"sets":{"1":{"emoticons":[{"id":1,"name":"G","urls":{"1":"//cdn/x"}}]}}}`
+		case "/ffz/room/id/42":
+			body = `{"room":{"set":2},"sets":{"2":{"emoticons":[{"id":2,"name":"C","urls":{"1":"//cdn/y"}}]}}}`
 		default:
 			t.Errorf("unexpected path: %s", r.URL.Path)
 			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		if _, err := fmt.Fprint(w, body); err != nil {
+			t.Errorf("write response: %v", err)
 		}
 	}))
 }

--- a/apps/desktop/src-sidecar/internal/emotes/ffz.go
+++ b/apps/desktop/src-sidecar/internal/emotes/ffz.go
@@ -1,0 +1,133 @@
+package emotes
+
+import (
+	"context"
+	"strconv"
+)
+
+const ffzDefaultBase = "https://api.frankerfacez.com/v1"
+
+// FFZClient fetches global and channel emotes from FrankerFaceZ.
+//
+// Docs: https://api.frankerfacez.com/docs/. Global and per-room responses
+// both expose `sets[setID].emoticons[]`; the top-level `default_sets` /
+// `room.set` tell us which sets are actually active for the lookup.
+type FFZClient struct {
+	HTTPClient Doer
+	BaseURL    string
+}
+
+// FetchGlobal returns the merged default global FFZ sets.
+func (c *FFZClient) FetchGlobal(ctx context.Context) (EmoteSet, error) {
+	var raw ffzGlobalResponse
+	if err := getJSON(ctx, c.client(), c.base()+"/set/global", &raw); err != nil {
+		return EmoteSet{}, err
+	}
+	emotes := make([]Emote, 0, 128)
+	for _, setID := range raw.DefaultSets {
+		key := strconv.Itoa(setID)
+		if set, ok := raw.Sets[key]; ok {
+			emotes = append(emotes, ffzConvertSet(set)...)
+		}
+	}
+	return EmoteSet{
+		Provider: ProviderFFZ,
+		Scope:    ScopeGlobal,
+		Emotes:   emotes,
+	}, nil
+}
+
+// FetchChannel returns the FFZ set configured for the Twitch broadcaster.
+// Returns [ErrNotFound] when the channel has no FFZ room registered.
+func (c *FFZClient) FetchChannel(ctx context.Context, twitchUserID string) (EmoteSet, error) {
+	var raw ffzRoomResponse
+	if err := getJSON(ctx, c.client(), c.base()+"/room/id/"+twitchUserID, &raw); err != nil {
+		return EmoteSet{}, err
+	}
+	emotes := make([]Emote, 0, 64)
+	for _, set := range raw.Sets {
+		emotes = append(emotes, ffzConvertSet(set)...)
+	}
+	return EmoteSet{
+		Provider:  ProviderFFZ,
+		Scope:     ScopeChannel,
+		ChannelID: twitchUserID,
+		Emotes:    emotes,
+	}, nil
+}
+
+func (c *FFZClient) base() string {
+	if c.BaseURL != "" {
+		return c.BaseURL
+	}
+	return ffzDefaultBase
+}
+
+func (c *FFZClient) client() Doer {
+	if c.HTTPClient != nil {
+		return c.HTTPClient
+	}
+	return defaultHTTPClient
+}
+
+type ffzGlobalResponse struct {
+	DefaultSets []int             `json:"default_sets"`
+	Sets        map[string]ffzSet `json:"sets"`
+}
+
+type ffzRoomResponse struct {
+	Sets map[string]ffzSet `json:"sets"`
+}
+
+type ffzSet struct {
+	Emoticons []ffzEmote `json:"emoticons"`
+}
+
+type ffzEmote struct {
+	ID       int               `json:"id"`
+	Name     string            `json:"name"`
+	Width    int               `json:"width"`
+	Height   int               `json:"height"`
+	URLs     map[string]string `json:"urls"`
+	Animated map[string]string `json:"animated"`
+}
+
+func ffzConvertSet(s ffzSet) []Emote {
+	out := make([]Emote, 0, len(s.Emoticons))
+	for _, e := range s.Emoticons {
+		urls := e.URLs
+		animated := false
+		if len(e.Animated) > 0 {
+			urls = e.Animated
+			animated = true
+		}
+		u1 := normalizeFFZURL(urls["1"])
+		if u1 == "" {
+			continue
+		}
+		out = append(out, Emote{
+			ID:       strconv.Itoa(e.ID),
+			Code:     e.Name,
+			Provider: ProviderFFZ,
+			URL1x:    u1,
+			URL2x:    normalizeFFZURL(urls["2"]),
+			URL4x:    normalizeFFZURL(urls["4"]),
+			Width:    e.Width,
+			Height:   e.Height,
+			Animated: animated,
+		})
+	}
+	return out
+}
+
+// normalizeFFZURL upgrades FFZ's protocol-relative URLs to https. Empty
+// input yields an empty string so callers can skip absent size variants.
+func normalizeFFZURL(u string) string {
+	if u == "" {
+		return ""
+	}
+	if len(u) >= 2 && u[:2] == "//" {
+		return "https:" + u
+	}
+	return u
+}

--- a/apps/desktop/src-sidecar/internal/emotes/ffz.go
+++ b/apps/desktop/src-sidecar/internal/emotes/ffz.go
@@ -39,13 +39,18 @@ func (c *FFZClient) FetchGlobal(ctx context.Context) (EmoteSet, error) {
 
 // FetchChannel returns the FFZ set configured for the Twitch broadcaster.
 // Returns [ErrNotFound] when the channel has no FFZ room registered.
+//
+// FFZ's room response can include multiple sets in `sets` (historical data,
+// unpublished drafts). Only the set identified by `room.set` is considered
+// active by FFZ's own client and Chatterino, so that is all we convert.
 func (c *FFZClient) FetchChannel(ctx context.Context, twitchUserID string) (EmoteSet, error) {
 	var raw ffzRoomResponse
 	if err := getJSON(ctx, c.client(), c.base()+"/room/id/"+twitchUserID, &raw); err != nil {
 		return EmoteSet{}, err
 	}
 	emotes := make([]Emote, 0, 64)
-	for _, set := range raw.Sets {
+	activeKey := strconv.Itoa(raw.Room.Set)
+	if set, ok := raw.Sets[activeKey]; ok {
 		emotes = append(emotes, ffzConvertSet(set)...)
 	}
 	return EmoteSet{
@@ -76,7 +81,14 @@ type ffzGlobalResponse struct {
 }
 
 type ffzRoomResponse struct {
+	Room ffzRoom           `json:"room"`
 	Sets map[string]ffzSet `json:"sets"`
+}
+
+// ffzRoom.Set is the ID of the active channel set. FFZ sometimes returns
+// additional draft sets inside `sets` that the client should ignore.
+type ffzRoom struct {
+	Set int `json:"set"`
 }
 
 type ffzSet struct {

--- a/apps/desktop/src-sidecar/internal/emotes/ffz_test.go
+++ b/apps/desktop/src-sidecar/internal/emotes/ffz_test.go
@@ -1,0 +1,96 @@
+package emotes
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFFZ_FetchGlobal(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/set/global" {
+			t.Fatalf("path: %s", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{
+			"default_sets":[3,4330],
+			"sets":{
+				"3":{"emoticons":[
+					{"id":28138,"name":"LilZ","width":22,"height":30,
+					 "urls":{"1":"//cdn.frankerfacez.com/emote/28138/1","2":"//cdn.frankerfacez.com/emote/28138/2","4":"//cdn.frankerfacez.com/emote/28138/4"}}
+				]},
+				"4330":{"emoticons":[
+					{"id":9,"name":"ZrehplaR","width":16,"height":16,
+					 "urls":{"1":"//cdn.frankerfacez.com/emote/9/1"},
+					 "animated":{"1":"//cdn.frankerfacez.com/emote/9/animated/1"}}
+				]},
+				"99":{"emoticons":[{"id":1,"name":"Skip","urls":{}}]}
+			}
+		}`))
+	}))
+	defer srv.Close()
+
+	c := &FFZClient{HTTPClient: srv.Client(), BaseURL: srv.URL}
+	set, err := c.FetchGlobal(context.Background())
+	if err != nil {
+		t.Fatalf("FetchGlobal: %v", err)
+	}
+	// Set 99 is not in default_sets, so it must not appear.
+	if len(set.Emotes) != 2 {
+		t.Fatalf("emotes = %d, want 2", len(set.Emotes))
+	}
+	var lilz, zreh *Emote
+	for i := range set.Emotes {
+		switch set.Emotes[i].Code {
+		case "LilZ":
+			lilz = &set.Emotes[i]
+		case "ZrehplaR":
+			zreh = &set.Emotes[i]
+		}
+	}
+	if lilz == nil || zreh == nil {
+		t.Fatalf("missing emote: %+v", set.Emotes)
+	}
+	if lilz.URL1x != "https://cdn.frankerfacez.com/emote/28138/1" {
+		t.Errorf("lilz URL1x: %q", lilz.URL1x)
+	}
+	if lilz.Animated {
+		t.Error("lilz should not be animated")
+	}
+	if !zreh.Animated || zreh.URL1x != "https://cdn.frankerfacez.com/emote/9/animated/1" {
+		t.Errorf("zreh: %+v", zreh)
+	}
+}
+
+func TestFFZ_FetchChannel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/room/id/77" {
+			t.Fatalf("path: %s", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"sets":{"500":{"emoticons":[{"id":1,"name":"ChanEmote","urls":{"1":"//cdn/x"}}]}}}`))
+	}))
+	defer srv.Close()
+
+	c := &FFZClient{HTTPClient: srv.Client(), BaseURL: srv.URL}
+	set, err := c.FetchChannel(context.Background(), "77")
+	if err != nil {
+		t.Fatalf("FetchChannel: %v", err)
+	}
+	if set.ChannelID != "77" || len(set.Emotes) != 1 || set.Emotes[0].Code != "ChanEmote" {
+		t.Errorf("unexpected: %+v", set)
+	}
+}
+
+func TestFFZ_FetchChannel_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := &FFZClient{HTTPClient: srv.Client(), BaseURL: srv.URL}
+	_, err := c.FetchChannel(context.Background(), "0")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}

--- a/apps/desktop/src-sidecar/internal/emotes/ffz_test.go
+++ b/apps/desktop/src-sidecar/internal/emotes/ffz_test.go
@@ -68,7 +68,13 @@ func TestFFZ_FetchChannel(t *testing.T) {
 		if r.URL.Path != "/room/id/77" {
 			t.Fatalf("path: %s", r.URL.Path)
 		}
-		_, _ = w.Write([]byte(`{"sets":{"500":{"emoticons":[{"id":1,"name":"ChanEmote","urls":{"1":"//cdn/x"}}]}}}`))
+		_, _ = w.Write([]byte(`{
+			"room":{"set":500},
+			"sets":{
+				"500":{"emoticons":[{"id":1,"name":"ChanEmote","urls":{"1":"//cdn/x"}}]},
+				"999":{"emoticons":[{"id":2,"name":"DraftEmote","urls":{"1":"//cdn/y"}}]}
+			}
+		}`))
 	}))
 	defer srv.Close()
 
@@ -78,7 +84,7 @@ func TestFFZ_FetchChannel(t *testing.T) {
 		t.Fatalf("FetchChannel: %v", err)
 	}
 	if set.ChannelID != "77" || len(set.Emotes) != 1 || set.Emotes[0].Code != "ChanEmote" {
-		t.Errorf("unexpected: %+v", set)
+		t.Errorf("unexpected (should only return the active set, not drafts): %+v", set)
 	}
 }
 

--- a/apps/desktop/src-sidecar/internal/emotes/http.go
+++ b/apps/desktop/src-sidecar/internal/emotes/http.go
@@ -1,0 +1,59 @@
+package emotes
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// defaultHTTPClient is used when a provider is constructed without an explicit
+// Doer. The 15s timeout covers 7TV/BTTV/FFZ p99 latencies from observed runs
+// while still failing fast enough not to stall the channel-join flow.
+var defaultHTTPClient = &http.Client{Timeout: 15 * time.Second}
+
+// Doer is the subset of *http.Client the providers use. Tests swap in a
+// transport-backed client.
+type Doer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// ErrNotFound is returned when a channel has no set configured on the
+// provider (e.g. 7TV 404 for users without a linked emote set). Callers
+// treat it as "use global only", not an error to surface.
+var ErrNotFound = errors.New("emotes: not found")
+
+func getJSON(ctx context.Context, client Doer, url string, dst any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request %s: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return ErrNotFound
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("GET %s: status %d: %s", url, resp.StatusCode, string(body))
+	}
+
+	if dst == nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(dst); err != nil {
+		return fmt.Errorf("decode %s: %w", url, err)
+	}
+	return nil
+}

--- a/apps/desktop/src-sidecar/internal/emotes/seventv.go
+++ b/apps/desktop/src-sidecar/internal/emotes/seventv.go
@@ -1,0 +1,156 @@
+package emotes
+
+import (
+	"context"
+	"fmt"
+)
+
+// SevenTV endpoints. Override in tests via [SevenTVClient.BaseURL].
+const sevenTVDefaultBase = "https://7tv.io/v3"
+
+// SevenTVClient fetches emote sets from 7TV.
+//
+// Docs: https://7tv.io/docs/api/v3. Channels are addressed by the Twitch
+// numeric user ID; 7TV resolves it to its own internal user and emote set.
+type SevenTVClient struct {
+	HTTPClient Doer
+	BaseURL    string
+}
+
+// FetchGlobal returns the 7TV global emote set.
+func (c *SevenTVClient) FetchGlobal(ctx context.Context) (EmoteSet, error) {
+	var raw sevenTVEmoteSet
+	if err := getJSON(ctx, c.client(), c.base()+"/emote-sets/global", &raw); err != nil {
+		return EmoteSet{}, err
+	}
+	return EmoteSet{
+		Provider: Provider7TV,
+		Scope:    ScopeGlobal,
+		Emotes:   raw.toEmotes(),
+	}, nil
+}
+
+// FetchChannel returns the 7TV set attached to the given Twitch broadcaster.
+// Returns [ErrNotFound] if the channel has no 7TV account linked.
+func (c *SevenTVClient) FetchChannel(ctx context.Context, twitchUserID string) (EmoteSet, error) {
+	var user sevenTVUser
+	if err := getJSON(ctx, c.client(), c.base()+"/users/twitch/"+twitchUserID, &user); err != nil {
+		return EmoteSet{}, err
+	}
+	return EmoteSet{
+		Provider:  Provider7TV,
+		Scope:     ScopeChannel,
+		ChannelID: twitchUserID,
+		Emotes:    user.EmoteSet.toEmotes(),
+	}, nil
+}
+
+func (c *SevenTVClient) base() string {
+	if c.BaseURL != "" {
+		return c.BaseURL
+	}
+	return sevenTVDefaultBase
+}
+
+func (c *SevenTVClient) client() Doer {
+	if c.HTTPClient != nil {
+		return c.HTTPClient
+	}
+	return defaultHTTPClient
+}
+
+// sevenTVEmoteSet matches the JSON shape of `/emote-sets/{id}`.
+type sevenTVEmoteSet struct {
+	Emotes []sevenTVEmote `json:"emotes"`
+}
+
+type sevenTVUser struct {
+	EmoteSet sevenTVEmoteSet `json:"emote_set"`
+}
+
+// sevenTVEmote is an entry inside an emote set's `emotes` array. The name
+// at this level can override `data.name` (user-customized alias); we prefer
+// the outer name to match what the chat text would contain.
+type sevenTVEmote struct {
+	ID   string           `json:"id"`
+	Name string           `json:"name"`
+	Data sevenTVEmoteData `json:"data"`
+}
+
+type sevenTVEmoteData struct {
+	Animated bool        `json:"animated"`
+	Flags    int         `json:"flags"`
+	Host     sevenTVHost `json:"host"`
+}
+
+type sevenTVHost struct {
+	URL   string            `json:"url"`
+	Files []sevenTVHostFile `json:"files"`
+}
+
+type sevenTVHostFile struct {
+	Name   string `json:"name"`
+	Width  int    `json:"width"`
+	Height int    `json:"height"`
+	Format string `json:"format"`
+}
+
+// sevenTVFlagZeroWidth is the bit set on overlay emotes (cvMask etc.).
+// 7TV source of truth: https://github.com/SevenTV/API/blob/main/data/model/emote.model.go
+const sevenTVFlagZeroWidth = 1 << 8
+
+func (s sevenTVEmoteSet) toEmotes() []Emote {
+	out := make([]Emote, 0, len(s.Emotes))
+	for _, e := range s.Emotes {
+		u1, u2, u4, w, h := pickSevenTVFiles(e.Data.Host)
+		if u1 == "" {
+			continue
+		}
+		out = append(out, Emote{
+			ID:        e.ID,
+			Code:      e.Name,
+			Provider:  Provider7TV,
+			URL1x:     u1,
+			URL2x:     u2,
+			URL4x:     u4,
+			Width:     w,
+			Height:    h,
+			Animated:  e.Data.Animated,
+			ZeroWidth: e.Data.Flags&sevenTVFlagZeroWidth != 0,
+		})
+	}
+	return out
+}
+
+// pickSevenTVFiles selects the webp variants for 1x/2x/4x from the provider's
+// file list. Width/height come from the 1x entry. Returns empty URL1x when
+// the host has no usable files (malformed response).
+func pickSevenTVFiles(h sevenTVHost) (u1, u2, u4 string, w, hpx int) {
+	for _, f := range h.Files {
+		if f.Format != "WEBP" {
+			continue
+		}
+		switch f.Name {
+		case "1x.webp":
+			u1 = joinHost(h.URL, f.Name)
+			w, hpx = f.Width, f.Height
+		case "2x.webp":
+			u2 = joinHost(h.URL, f.Name)
+		case "4x.webp":
+			u4 = joinHost(h.URL, f.Name)
+		}
+	}
+	return
+}
+
+// joinHost builds a full URL from 7TV's protocol-relative host (`//cdn.7tv.app/...`)
+// plus a file name.
+func joinHost(host, name string) string {
+	if host == "" || name == "" {
+		return ""
+	}
+	if len(host) >= 2 && host[:2] == "//" {
+		return "https:" + host + "/" + name
+	}
+	return fmt.Sprintf("%s/%s", host, name)
+}

--- a/apps/desktop/src-sidecar/internal/emotes/seventv_test.go
+++ b/apps/desktop/src-sidecar/internal/emotes/seventv_test.go
@@ -1,0 +1,107 @@
+package emotes
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const sevenTVSampleSet = `{
+  "emotes": [
+    {
+      "id": "60ae958e229664e8667aea38",
+      "name": "PepegaAim",
+      "data": {
+        "animated": true,
+        "flags": 256,
+        "host": {
+          "url": "//cdn.7tv.app/emote/60ae958e229664e8667aea38",
+          "files": [
+            {"name": "1x.webp", "width": 32, "height": 32, "format": "WEBP"},
+            {"name": "2x.webp", "width": 64, "height": 64, "format": "WEBP"},
+            {"name": "4x.webp", "width": 128, "height": 128, "format": "WEBP"},
+            {"name": "1x.avif", "width": 32, "height": 32, "format": "AVIF"}
+          ]
+        }
+      }
+    },
+    {
+      "id": "bad",
+      "name": "Broken",
+      "data": {"host": {"url": "//cdn.7tv.app/emote/bad", "files": []}}
+    }
+  ]
+}`
+
+func TestSevenTV_FetchGlobal(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/emote-sets/global" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(sevenTVSampleSet))
+	}))
+	defer srv.Close()
+
+	c := &SevenTVClient{HTTPClient: srv.Client(), BaseURL: srv.URL}
+	set, err := c.FetchGlobal(context.Background())
+	if err != nil {
+		t.Fatalf("FetchGlobal: %v", err)
+	}
+	if set.Provider != Provider7TV || set.Scope != ScopeGlobal {
+		t.Errorf("wrong provider/scope: %+v", set)
+	}
+	if len(set.Emotes) != 1 {
+		t.Fatalf("emotes = %d, want 1 (broken entry filtered)", len(set.Emotes))
+	}
+	e := set.Emotes[0]
+	if e.Code != "PepegaAim" || !e.Animated || !e.ZeroWidth {
+		t.Errorf("unexpected emote: %+v", e)
+	}
+	if e.URL1x != "https://cdn.7tv.app/emote/60ae958e229664e8667aea38/1x.webp" {
+		t.Errorf("URL1x = %q", e.URL1x)
+	}
+	if e.URL4x == "" {
+		t.Error("URL4x missing")
+	}
+	if e.Width != 32 || e.Height != 32 {
+		t.Errorf("dims = %dx%d, want 32x32", e.Width, e.Height)
+	}
+}
+
+func TestSevenTV_FetchChannel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/users/twitch/12345" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"emote_set":` + sevenTVSampleSet + `}`))
+	}))
+	defer srv.Close()
+
+	c := &SevenTVClient{HTTPClient: srv.Client(), BaseURL: srv.URL}
+	set, err := c.FetchChannel(context.Background(), "12345")
+	if err != nil {
+		t.Fatalf("FetchChannel: %v", err)
+	}
+	if set.Scope != ScopeChannel || set.ChannelID != "12345" {
+		t.Errorf("wrong scope/channel: %+v", set)
+	}
+	if len(set.Emotes) != 1 {
+		t.Errorf("emotes = %d, want 1", len(set.Emotes))
+	}
+}
+
+func TestSevenTV_FetchChannel_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := &SevenTVClient{HTTPClient: srv.Client(), BaseURL: srv.URL}
+	_, err := c.FetchChannel(context.Background(), "999")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}

--- a/apps/desktop/src-sidecar/internal/emotes/twitch.go
+++ b/apps/desktop/src-sidecar/internal/emotes/twitch.go
@@ -1,0 +1,221 @@
+package emotes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const twitchHelixDefaultBase = "https://api.twitch.tv/helix"
+
+// TwitchClient fetches first-party emotes and chat badges from the Helix API.
+//
+// Kept intentionally separate from `internal/twitch.HelixClient`: the emotes
+// package must not import the twitch package (the twitch package already
+// pulls in EventSub/websocket dependencies, and these endpoints only need a
+// plain Client-Id + Bearer pair).
+type TwitchClient struct {
+	HTTPClient  Doer
+	BaseURL     string
+	ClientID    string
+	AccessToken string
+}
+
+// FetchGlobalEmotes returns Twitch's global emote set (Kappa, PogChamp,
+// KEKW, …).
+func (c *TwitchClient) FetchGlobalEmotes(ctx context.Context) (EmoteSet, error) {
+	var raw twitchEmoteResponse
+	if err := c.get(ctx, "/chat/emotes/global", &raw); err != nil {
+		return EmoteSet{}, err
+	}
+	return EmoteSet{
+		Provider: ProviderTwitch,
+		Scope:    ScopeGlobal,
+		Emotes:   twitchEmotesFromResponse(raw),
+	}, nil
+}
+
+// FetchChannelEmotes returns the broadcaster's subscriber + bits + follower
+// emote set. Empty (no error) when the channel has no custom emotes.
+func (c *TwitchClient) FetchChannelEmotes(ctx context.Context, broadcasterID string) (EmoteSet, error) {
+	q := url.Values{"broadcaster_id": []string{broadcasterID}}
+	var raw twitchEmoteResponse
+	if err := c.get(ctx, "/chat/emotes?"+q.Encode(), &raw); err != nil {
+		return EmoteSet{}, err
+	}
+	return EmoteSet{
+		Provider:  ProviderTwitch,
+		Scope:     ScopeChannel,
+		ChannelID: broadcasterID,
+		Emotes:    twitchEmotesFromResponse(raw),
+	}, nil
+}
+
+// FetchGlobalBadges returns the global chat badge set (subscriber base,
+// moderator, verified, …). Per-channel subscriber-tier badges are returned
+// from [FetchChannelBadges].
+func (c *TwitchClient) FetchGlobalBadges(ctx context.Context) (BadgeSet, error) {
+	var raw twitchBadgeResponse
+	if err := c.get(ctx, "/chat/badges/global", &raw); err != nil {
+		return BadgeSet{}, err
+	}
+	return BadgeSet{
+		Scope:  ScopeGlobal,
+		Badges: twitchBadgesFromResponse(raw),
+	}, nil
+}
+
+// FetchChannelBadges returns per-channel badge overrides (custom subscriber
+// tier art, bit tier art).
+func (c *TwitchClient) FetchChannelBadges(ctx context.Context, broadcasterID string) (BadgeSet, error) {
+	q := url.Values{"broadcaster_id": []string{broadcasterID}}
+	var raw twitchBadgeResponse
+	if err := c.get(ctx, "/chat/badges?"+q.Encode(), &raw); err != nil {
+		return BadgeSet{}, err
+	}
+	return BadgeSet{
+		Scope:     ScopeChannel,
+		ChannelID: broadcasterID,
+		Badges:    twitchBadgesFromResponse(raw),
+	}, nil
+}
+
+func (c *TwitchClient) get(ctx context.Context, path string, dst any) error {
+	base := c.BaseURL
+	if base == "" {
+		base = twitchHelixDefaultBase
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+path, nil)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Client-Id", c.ClientID)
+	req.Header.Set("Authorization", "Bearer "+c.AccessToken)
+	req.Header.Set("Accept", "application/json")
+
+	client := c.HTTPClient
+	if client == nil {
+		client = defaultHTTPClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request %s: %w", path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("GET %s: status %d: %s", path, resp.StatusCode, string(body))
+	}
+	if dst == nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(dst)
+}
+
+type twitchEmoteResponse struct {
+	Data     []twitchEmote `json:"data"`
+	Template string        `json:"template"`
+}
+
+type twitchEmote struct {
+	ID        string   `json:"id"`
+	Name      string   `json:"name"`
+	Format    []string `json:"format"`
+	Scale     []string `json:"scale"`
+	ThemeMode []string `json:"theme_mode"`
+}
+
+type twitchBadgeResponse struct {
+	Data []twitchBadgeSet `json:"data"`
+}
+
+type twitchBadgeSet struct {
+	SetID    string           `json:"set_id"`
+	Versions []twitchBadgeVer `json:"versions"`
+}
+
+type twitchBadgeVer struct {
+	ID    string `json:"id"`
+	URL1x string `json:"image_url_1x"`
+	URL2x string `json:"image_url_2x"`
+	URL4x string `json:"image_url_4x"`
+	Title string `json:"title"`
+}
+
+func twitchEmotesFromResponse(r twitchEmoteResponse) []Emote {
+	out := make([]Emote, 0, len(r.Data))
+	for _, e := range r.Data {
+		format := "static"
+		animated := false
+		for _, f := range e.Format {
+			if f == "animated" {
+				format = "animated"
+				animated = true
+				break
+			}
+		}
+		mode := "dark"
+		for _, m := range e.ThemeMode {
+			if m == "dark" {
+				mode = "dark"
+				break
+			}
+			mode = m
+		}
+		em := Emote{
+			ID:       e.ID,
+			Code:     e.Name,
+			Provider: ProviderTwitch,
+			URL1x:    twitchEmoteURL(r.Template, e.ID, format, mode, "1.0"),
+			URL2x:    twitchEmoteURL(r.Template, e.ID, format, mode, "2.0"),
+			URL4x:    twitchEmoteURL(r.Template, e.ID, format, mode, "3.0"),
+			Animated: animated,
+		}
+		if em.URL1x == "" {
+			continue
+		}
+		out = append(out, em)
+	}
+	return out
+}
+
+// twitchEmoteURL expands the API's `template` field. Falls back to a hard-coded
+// path if the response omits it (older cached responses sometimes do).
+func twitchEmoteURL(template, id, format, theme, scale string) string {
+	if template == "" {
+		template = "https://static-cdn.jtvnw.net/emoticons/v2/{{id}}/{{format}}/{{theme_mode}}/{{scale}}"
+	}
+	r := strings.NewReplacer(
+		"{{id}}", id,
+		"{{format}}", format,
+		"{{theme_mode}}", theme,
+		"{{scale}}", scale,
+	)
+	return r.Replace(template)
+}
+
+func twitchBadgesFromResponse(r twitchBadgeResponse) []Badge {
+	out := make([]Badge, 0, len(r.Data)*2)
+	for _, set := range r.Data {
+		for _, v := range set.Versions {
+			if v.URL1x == "" {
+				continue
+			}
+			out = append(out, Badge{
+				Set:     set.SetID,
+				Version: v.ID,
+				Title:   v.Title,
+				URL1x:   v.URL1x,
+				URL2x:   v.URL2x,
+				URL4x:   v.URL4x,
+			})
+		}
+	}
+	return out
+}

--- a/apps/desktop/src-sidecar/internal/emotes/twitch.go
+++ b/apps/desktop/src-sidecar/internal/emotes/twitch.go
@@ -115,7 +115,10 @@ func (c *TwitchClient) get(ctx context.Context, path string, dst any) error {
 		_, _ = io.Copy(io.Discard, resp.Body)
 		return nil
 	}
-	return json.NewDecoder(resp.Body).Decode(dst)
+	if err := json.NewDecoder(resp.Body).Decode(dst); err != nil {
+		return fmt.Errorf("decode %s: %w", path, err)
+	}
+	return nil
 }
 
 type twitchEmoteResponse struct {

--- a/apps/desktop/src-sidecar/internal/emotes/twitch_test.go
+++ b/apps/desktop/src-sidecar/internal/emotes/twitch_test.go
@@ -1,0 +1,136 @@
+package emotes
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const twitchGlobalEmotesBody = `{
+  "data": [
+    {"id":"25","name":"Kappa","format":["static"],"scale":["1.0","2.0","3.0"],"theme_mode":["light","dark"]},
+    {"id":"88","name":"AnimTest","format":["static","animated"],"scale":["1.0","2.0","3.0"],"theme_mode":["dark"]}
+  ],
+  "template":"https://static-cdn.jtvnw.net/emoticons/v2/{{id}}/{{format}}/{{theme_mode}}/{{scale}}"
+}`
+
+func TestTwitch_FetchGlobalEmotes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/emotes/global" {
+			t.Fatalf("path: %s", r.URL.Path)
+		}
+		if r.Header.Get("Client-Id") != "cid" || r.Header.Get("Authorization") != "Bearer tok" {
+			t.Fatalf("missing auth headers: %v", r.Header)
+		}
+		_, _ = w.Write([]byte(twitchGlobalEmotesBody))
+	}))
+	defer srv.Close()
+
+	c := &TwitchClient{HTTPClient: srv.Client(), BaseURL: srv.URL, ClientID: "cid", AccessToken: "tok"}
+	set, err := c.FetchGlobalEmotes(context.Background())
+	if err != nil {
+		t.Fatalf("FetchGlobalEmotes: %v", err)
+	}
+	if len(set.Emotes) != 2 {
+		t.Fatalf("emotes = %d, want 2", len(set.Emotes))
+	}
+	kappa := set.Emotes[0]
+	if kappa.Code != "Kappa" {
+		t.Fatalf("first = %q", kappa.Code)
+	}
+	if !strings.Contains(kappa.URL1x, "/25/static/dark/1.0") {
+		t.Errorf("kappa URL1x = %q", kappa.URL1x)
+	}
+	anim := set.Emotes[1]
+	if !anim.Animated || !strings.Contains(anim.URL1x, "/88/animated/dark/1.0") {
+		t.Errorf("anim: %+v", anim)
+	}
+}
+
+func TestTwitch_FetchChannelEmotes_BroadcasterQuery(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/emotes" {
+			t.Fatalf("path: %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("broadcaster_id") != "123" {
+			t.Fatalf("broadcaster_id: %q", r.URL.Query().Get("broadcaster_id"))
+		}
+		_, _ = w.Write([]byte(`{"data":[],"template":""}`))
+	}))
+	defer srv.Close()
+
+	c := &TwitchClient{HTTPClient: srv.Client(), BaseURL: srv.URL, ClientID: "cid", AccessToken: "tok"}
+	set, err := c.FetchChannelEmotes(context.Background(), "123")
+	if err != nil {
+		t.Fatalf("FetchChannelEmotes: %v", err)
+	}
+	if set.ChannelID != "123" || set.Scope != ScopeChannel {
+		t.Errorf("bad set: %+v", set)
+	}
+}
+
+func TestTwitch_FetchGlobalBadges(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/badges/global" {
+			t.Fatalf("path: %s", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"data":[
+			{"set_id":"moderator","versions":[
+				{"id":"1","image_url_1x":"https://u/1","image_url_2x":"https://u/2","image_url_4x":"https://u/4","title":"Moderator"}
+			]},
+			{"set_id":"broken","versions":[{"id":"1","image_url_1x":""}]}
+		]}`))
+	}))
+	defer srv.Close()
+
+	c := &TwitchClient{HTTPClient: srv.Client(), BaseURL: srv.URL, ClientID: "cid", AccessToken: "tok"}
+	set, err := c.FetchGlobalBadges(context.Background())
+	if err != nil {
+		t.Fatalf("FetchGlobalBadges: %v", err)
+	}
+	if len(set.Badges) != 1 {
+		t.Fatalf("badges = %d, want 1", len(set.Badges))
+	}
+	b := set.Badges[0]
+	if b.Set != "moderator" || b.Version != "1" || b.URL4x != "https://u/4" {
+		t.Errorf("badge: %+v", b)
+	}
+}
+
+func TestTwitch_FetchChannelBadges(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("broadcaster_id") != "555" {
+			t.Fatalf("missing broadcaster_id")
+		}
+		_, _ = w.Write([]byte(`{"data":[{"set_id":"subscriber","versions":[{"id":"3000","image_url_1x":"https://s/1","title":"3-Year"}]}]}`))
+	}))
+	defer srv.Close()
+
+	c := &TwitchClient{HTTPClient: srv.Client(), BaseURL: srv.URL, ClientID: "cid", AccessToken: "tok"}
+	set, err := c.FetchChannelBadges(context.Background(), "555")
+	if err != nil {
+		t.Fatalf("FetchChannelBadges: %v", err)
+	}
+	if set.ChannelID != "555" || len(set.Badges) != 1 || set.Badges[0].Version != "3000" {
+		t.Errorf("unexpected: %+v", set)
+	}
+}
+
+func TestTwitch_ErrorStatusIsSurfaced(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"error":"Bad Gateway","status":502}`))
+	}))
+	defer srv.Close()
+
+	c := &TwitchClient{HTTPClient: srv.Client(), BaseURL: srv.URL, ClientID: "cid", AccessToken: "tok"}
+	_, err := c.FetchGlobalEmotes(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "502") {
+		t.Errorf("err = %v", err)
+	}
+}

--- a/apps/desktop/src-sidecar/internal/emotes/types.go
+++ b/apps/desktop/src-sidecar/internal/emotes/types.go
@@ -1,0 +1,73 @@
+// Package emotes fetches third-party and first-party emote and badge
+// catalogs (7TV, BTTV, FFZ, Twitch) and normalizes them into a common shape
+// the Rust host can index with aho-corasick.
+//
+// Network I/O only. No parsing of chat messages, no caching — the host owns
+// the index and the SQLite image cache (ADR 13).
+package emotes
+
+// Provider identifies which service an [Emote] or [Badge] originated from.
+type Provider string
+
+const (
+	ProviderTwitch Provider = "twitch"
+	Provider7TV    Provider = "7tv"
+	ProviderBTTV   Provider = "bttv"
+	ProviderFFZ    Provider = "ffz"
+)
+
+// Scope distinguishes global emote sets (available in every channel) from
+// channel-specific sets (subscriber emotes, the channel's 7TV set, etc.).
+type Scope string
+
+const (
+	ScopeGlobal  Scope = "global"
+	ScopeChannel Scope = "channel"
+)
+
+// Emote is the normalized cross-provider shape fed into the Rust emote index.
+// Width/Height are 0 when the provider does not report them; the renderer
+// falls back to the first-frame decode size in that case.
+type Emote struct {
+	ID       string   `json:"id"`
+	Code     string   `json:"code"`
+	Provider Provider `json:"provider"`
+	URL1x    string   `json:"url_1x"`
+	URL2x    string   `json:"url_2x,omitempty"`
+	URL4x    string   `json:"url_4x,omitempty"`
+	Width    int      `json:"width,omitempty"`
+	Height   int      `json:"height,omitempty"`
+	Animated bool     `json:"animated,omitempty"`
+	// ZeroWidth is the 7TV/BTTV "overlay" flag. True for emotes like
+	// `cvMask`, `RainTime` that render on top of the previous emote.
+	ZeroWidth bool `json:"zero_width,omitempty"`
+}
+
+// EmoteSet groups emotes by provider and scope. Channel sets carry the
+// Twitch broadcaster ID they apply to.
+type EmoteSet struct {
+	Provider  Provider `json:"provider"`
+	Scope     Scope    `json:"scope"`
+	ChannelID string   `json:"channel_id,omitempty"`
+	Emotes    []Emote  `json:"emotes"`
+}
+
+// Badge is a chat badge (subscriber, moderator, verified, etc.).
+type Badge struct {
+	// Set is the badge category: "subscriber", "moderator", "broadcaster"…
+	Set string `json:"set"`
+	// Version is the per-set variant: "0", "1", "12" for subscriber tiers,
+	// "1" for most single-variant badges.
+	Version string `json:"version"`
+	Title   string `json:"title,omitempty"`
+	URL1x   string `json:"url_1x"`
+	URL2x   string `json:"url_2x,omitempty"`
+	URL4x   string `json:"url_4x,omitempty"`
+}
+
+// BadgeSet groups badges by scope (global or per-channel).
+type BadgeSet struct {
+	Scope     Scope   `json:"scope"`
+	ChannelID string  `json:"channel_id,omitempty"`
+	Badges    []Badge `json:"badges"`
+}

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -91,6 +91,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ascii-canvas"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3644,12 +3653,15 @@ dependencies = [
 name = "prismoid"
 version = "0.0.1"
 dependencies = [
+ "aho-corasick",
+ "arc-swap",
  "chrono",
  "criterion",
  "dotenvy",
  "httpmock",
  "keyring",
  "reqwest",
+ "rustc-hash",
  "serde",
  "serde_json",
  "tauri",
@@ -5203,10 +5215,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5707,7 +5719,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -4209,9 +4209,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -30,6 +30,9 @@ thiserror = "1"
 tokio = { version = "1", features = ["macros", "time"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+aho-corasick = "1.1"
+arc-swap = "1.7"
+rustc-hash = "2.1"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/apps/desktop/src-tauri/src/emote_index.rs
+++ b/apps/desktop/src-tauri/src/emote_index.rs
@@ -1,0 +1,362 @@
+//! Channel-scoped emote index (ADR 13).
+//!
+//! Frontend-agnostic, lock-free-on-read catalog of emote metadata plus an
+//! aho-corasick automaton over emote codes. The host swaps a whole new
+//! snapshot whenever emotes change (channel join, 7TV set reload); readers
+//! on the message hot path take an [`arc_swap::Guard`] and scan without
+//! blocking.
+//!
+//! Not responsible for fetching catalogs (that's `sidecar/internal/emotes`)
+//! or for caching emote image bytes (that's the SQLite cache, follow-up).
+
+use std::sync::Arc;
+
+use aho_corasick::{AhoCorasick, AhoCorasickBuilder, MatchKind};
+use arc_swap::ArcSwap;
+use rustc_hash::FxHashMap;
+use serde::{Deserialize, Serialize};
+
+/// Emote provider. Mirrors `sidecar/internal/emotes.Provider` with a `u8`
+/// tag so callers can pack it into message payloads cheaply.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Provider {
+    Twitch,
+    #[serde(rename = "7tv")]
+    SevenTv,
+    Bttv,
+    Ffz,
+}
+
+/// Normalized metadata for a single emote. Fields match the Go side
+/// (`sidecar/internal/emotes.Emote`) so the sidecar can write these directly
+/// over the control plane.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct EmoteMeta {
+    pub id: Box<str>,
+    pub code: Box<str>,
+    pub provider: Provider,
+    #[serde(rename = "url_1x")]
+    pub url_1x: Box<str>,
+    #[serde(rename = "url_2x", default)]
+    pub url_2x: Box<str>,
+    #[serde(rename = "url_4x", default)]
+    pub url_4x: Box<str>,
+    #[serde(default)]
+    pub width: u16,
+    #[serde(default)]
+    pub height: u16,
+    #[serde(default)]
+    pub animated: bool,
+    #[serde(default)]
+    pub zero_width: bool,
+}
+
+/// Byte range of a matched emote code inside a message's `message_text`,
+/// plus the resolved emote metadata. `start..end` is a UTF-8 byte slice of
+/// the original text.
+#[derive(Debug, Clone)]
+pub struct EmoteSpan {
+    pub start: u32,
+    pub end: u32,
+    pub emote: Arc<EmoteMeta>,
+}
+
+/// Immutable snapshot of the index. Built once by [`EmoteIndex::load`] and
+/// pointed at by the atomic swap; readers keep the snapshot alive for the
+/// duration of their scan regardless of subsequent rebuilds.
+struct Snapshot {
+    by_code: FxHashMap<Box<str>, Arc<EmoteMeta>>,
+    /// aho-corasick pattern i resolves to `patterns[i]`. Kept parallel so
+    /// the automaton output carries zero per-match metadata.
+    patterns: Vec<Arc<EmoteMeta>>,
+    /// `None` when there are zero emotes — `AhoCorasickBuilder::build` errors
+    /// on empty inputs and we never want to allocate one in that case.
+    ac: Option<AhoCorasick>,
+}
+
+impl Snapshot {
+    fn empty() -> Self {
+        Self {
+            by_code: FxHashMap::default(),
+            patterns: Vec::new(),
+            ac: None,
+        }
+    }
+}
+
+/// Lock-free emote index. Cheap to clone via [`Arc`]; one instance per
+/// active channel.
+pub struct EmoteIndex {
+    inner: ArcSwap<Snapshot>,
+}
+
+impl EmoteIndex {
+    pub fn new() -> Self {
+        Self {
+            inner: ArcSwap::from_pointee(Snapshot::empty()),
+        }
+    }
+
+    /// Replace the current snapshot with one built from `emotes`. Duplicate
+    /// codes are resolved by "later wins" — callers that care about
+    /// precedence (channel > global, or 7TV > BTTV > FFZ) pass entries in
+    /// ascending priority order so the highest-priority source overwrites.
+    pub fn load<I: IntoIterator<Item = EmoteMeta>>(&self, emotes: I) {
+        let mut by_code: FxHashMap<Box<str>, Arc<EmoteMeta>> = FxHashMap::default();
+        for e in emotes {
+            let code = e.code.clone();
+            by_code.insert(code, Arc::new(e));
+        }
+
+        let mut patterns: Vec<Arc<EmoteMeta>> = Vec::with_capacity(by_code.len());
+        let mut needles: Vec<&str> = Vec::with_capacity(by_code.len());
+        for e in by_code.values() {
+            patterns.push(Arc::clone(e));
+            needles.push(&e.code);
+        }
+
+        // LeftmostLongest matches Chatterino's resolution: when multiple
+        // codes share a prefix (`Kappa` / `KappaHD`), the longer code wins
+        // at the same starting offset.
+        let ac = if needles.is_empty() {
+            None
+        } else {
+            Some(
+                AhoCorasickBuilder::new()
+                    .match_kind(MatchKind::LeftmostLongest)
+                    .build(&needles)
+                    .expect("aho-corasick build with non-empty inputs cannot fail"),
+            )
+        };
+
+        self.inner.store(Arc::new(Snapshot {
+            by_code,
+            patterns,
+            ac,
+        }));
+    }
+
+    /// Look up an emote by its exact code. Case-sensitive — Twitch and
+    /// third-party providers treat codes as case-sensitive identifiers.
+    pub fn lookup(&self, code: &str) -> Option<Arc<EmoteMeta>> {
+        self.inner.load().by_code.get(code).cloned()
+    }
+
+    /// Current number of indexed emotes. Snapshot-consistent.
+    pub fn len(&self) -> usize {
+        self.inner.load().by_code.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Scan `text` for emote matches and append them to `out`. The caller
+    /// owns the buffer so the message hot path can reuse a scratch `Vec`
+    /// across parses and avoid per-message allocation.
+    ///
+    /// Matches are emitted left-to-right and only when the match is bounded
+    /// by ASCII whitespace or the ends of `text` — this mirrors how Twitch
+    /// chat tokenizes, and prevents `Kappa` inside `KappaPride` (if only
+    /// `Kappa` is indexed) from matching as a substring.
+    pub fn scan_into(&self, text: &str, out: &mut Vec<EmoteSpan>) {
+        let snap = self.inner.load();
+        let Some(ac) = snap.ac.as_ref() else {
+            return;
+        };
+        let bytes = text.as_bytes();
+        for m in ac.find_iter(text) {
+            let start = m.start();
+            let end = m.end();
+            if !is_token_boundary(bytes, start, end) {
+                continue;
+            }
+            let emote = Arc::clone(&snap.patterns[m.pattern().as_usize()]);
+            out.push(EmoteSpan {
+                start: start as u32,
+                end: end as u32,
+                emote,
+            });
+        }
+    }
+}
+
+impl Default for EmoteIndex {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Returns true when `start..end` is surrounded by ASCII whitespace or sits
+/// at a string boundary. Emote codes never contain spaces, so whitespace is
+/// the only valid delimiter across Twitch, 7TV, BTTV, and FFZ.
+fn is_token_boundary(bytes: &[u8], start: usize, end: usize) -> bool {
+    let left_ok = start == 0 || bytes[start - 1] == b' ';
+    let right_ok = end == bytes.len() || bytes[end] == b' ';
+    left_ok && right_ok
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn meta(code: &str, provider: Provider) -> EmoteMeta {
+        EmoteMeta {
+            id: code.into(),
+            code: code.into(),
+            provider,
+            url_1x: format!("https://cdn/{code}/1x").into(),
+            url_2x: "".into(),
+            url_4x: "".into(),
+            width: 28,
+            height: 28,
+            animated: false,
+            zero_width: false,
+        }
+    }
+
+    #[test]
+    fn empty_index_scans_cleanly() {
+        let idx = EmoteIndex::new();
+        let mut out = Vec::new();
+        idx.scan_into("Kappa PogChamp", &mut out);
+        assert!(out.is_empty());
+        assert_eq!(idx.len(), 0);
+        assert!(idx.is_empty());
+    }
+
+    #[test]
+    fn exact_and_tokenized_match() {
+        let idx = EmoteIndex::new();
+        idx.load([
+            meta("Kappa", Provider::Twitch),
+            meta("PogChamp", Provider::Twitch),
+        ]);
+
+        let mut out = Vec::new();
+        idx.scan_into("hello Kappa and PogChamp world", &mut out);
+        assert_eq!(out.len(), 2);
+        assert_eq!(
+            &"hello Kappa and PogChamp world"[out[0].start as usize..out[0].end as usize],
+            "Kappa"
+        );
+        assert_eq!(
+            &"hello Kappa and PogChamp world"[out[1].start as usize..out[1].end as usize],
+            "PogChamp"
+        );
+    }
+
+    #[test]
+    fn substring_does_not_match() {
+        let idx = EmoteIndex::new();
+        idx.load([meta("Kappa", Provider::Twitch)]);
+
+        let mut out = Vec::new();
+        idx.scan_into("xKappax", &mut out);
+        assert!(out.is_empty(), "substring should not match: {out:?}");
+
+        idx.scan_into("Kappa!", &mut out);
+        assert!(out.is_empty(), "punctuation-adjacent must not match");
+    }
+
+    #[test]
+    fn longest_match_wins_on_overlap() {
+        let idx = EmoteIndex::new();
+        idx.load([
+            meta("Kappa", Provider::Twitch),
+            meta("KappaHD", Provider::Twitch),
+        ]);
+
+        let mut out = Vec::new();
+        idx.scan_into("KappaHD rules", &mut out);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].emote.code.as_ref(), "KappaHD");
+    }
+
+    #[test]
+    fn later_load_overwrites_earlier_by_code() {
+        let idx = EmoteIndex::new();
+        idx.load([
+            meta("PogU", Provider::Bttv),
+            meta("PogU", Provider::SevenTv),
+        ]);
+        let hit = idx.lookup("PogU").unwrap();
+        assert_eq!(hit.provider, Provider::SevenTv);
+    }
+
+    #[test]
+    fn reload_swaps_cleanly() {
+        let idx = EmoteIndex::new();
+        idx.load([meta("Kappa", Provider::Twitch)]);
+        assert!(idx.lookup("Kappa").is_some());
+
+        idx.load([meta("Pepega", Provider::SevenTv)]);
+        assert!(idx.lookup("Kappa").is_none());
+        assert!(idx.lookup("Pepega").is_some());
+        assert_eq!(idx.len(), 1);
+    }
+
+    #[test]
+    fn scan_is_case_sensitive() {
+        let idx = EmoteIndex::new();
+        idx.load([meta("Kappa", Provider::Twitch)]);
+
+        let mut out = Vec::new();
+        idx.scan_into("kappa KAPPA Kappa", &mut out);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].start, 12);
+    }
+
+    #[test]
+    fn scan_preserves_order() {
+        let idx = EmoteIndex::new();
+        idx.load([
+            meta("A", Provider::Twitch),
+            meta("BB", Provider::Twitch),
+            meta("CCC", Provider::Twitch),
+        ]);
+
+        let mut out = Vec::new();
+        idx.scan_into("CCC A BB A", &mut out);
+        let codes: Vec<&str> = out.iter().map(|s| s.emote.code.as_ref()).collect();
+        assert_eq!(codes, ["CCC", "A", "BB", "A"]);
+    }
+
+    #[test]
+    fn scan_reuses_buffer() {
+        let idx = EmoteIndex::new();
+        idx.load([meta("Kappa", Provider::Twitch)]);
+
+        let mut out = Vec::with_capacity(4);
+        let cap_before = out.capacity();
+        idx.scan_into("Kappa Kappa Kappa", &mut out);
+        assert_eq!(out.len(), 3);
+        out.clear();
+        idx.scan_into("Kappa", &mut out);
+        assert_eq!(out.len(), 1);
+        assert!(out.capacity() >= cap_before);
+    }
+
+    #[test]
+    fn meta_deserializes_from_sidecar_json() {
+        // Matches the shape sidecar/internal/emotes writes.
+        let raw = r#"{
+            "id": "60a",
+            "code": "PepegaAim",
+            "provider": "7tv",
+            "url_1x": "https://cdn.7tv.app/emote/60a/1x.webp",
+            "url_2x": "https://cdn.7tv.app/emote/60a/2x.webp",
+            "url_4x": "https://cdn.7tv.app/emote/60a/4x.webp",
+            "width": 32,
+            "height": 32,
+            "animated": true,
+            "zero_width": true
+        }"#;
+        let got: EmoteMeta = serde_json::from_str(raw).unwrap();
+        assert_eq!(got.code.as_ref(), "PepegaAim");
+        assert_eq!(got.provider, Provider::SevenTv);
+        assert!(got.animated && got.zero_width);
+        assert_eq!(got.width, 32);
+    }
+}

--- a/apps/desktop/src-tauri/src/emote_index.rs
+++ b/apps/desktop/src-tauri/src/emote_index.rs
@@ -15,9 +15,9 @@ use aho_corasick::{AhoCorasick, AhoCorasickBuilder, MatchKind};
 use arc_swap::ArcSwap;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 
-/// Emote provider. Mirrors `sidecar/internal/emotes.Provider` with a `u8`
-/// tag so callers can pack it into message payloads cheaply.
+/// Emote provider. Mirrors `sidecar/internal/emotes.Provider`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Provider {
@@ -34,7 +34,9 @@ pub enum Provider {
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct EmoteMeta {
     pub id: Box<str>,
-    pub code: Box<str>,
+    /// Emote code (what users type). Stored as `Arc<str>` so the index can
+    /// share a single allocation between the lookup map key and the meta.
+    pub code: Arc<str>,
     pub provider: Provider,
     #[serde(rename = "url_1x")]
     pub url_1x: Box<str>,
@@ -66,12 +68,12 @@ pub struct EmoteSpan {
 /// pointed at by the atomic swap; readers keep the snapshot alive for the
 /// duration of their scan regardless of subsequent rebuilds.
 struct Snapshot {
-    by_code: FxHashMap<Box<str>, Arc<EmoteMeta>>,
+    by_code: FxHashMap<Arc<str>, Arc<EmoteMeta>>,
     /// aho-corasick pattern i resolves to `patterns[i]`. Kept parallel so
     /// the automaton output carries zero per-match metadata.
     patterns: Vec<Arc<EmoteMeta>>,
-    /// `None` when there are zero emotes — `AhoCorasickBuilder::build` errors
-    /// on empty inputs and we never want to allocate one in that case.
+    /// `None` when there are zero emotes, or when the builder rejected the
+    /// input (all codes filtered out as invalid).
     ac: Option<AhoCorasick>,
 }
 
@@ -85,8 +87,8 @@ impl Snapshot {
     }
 }
 
-/// Lock-free emote index. Cheap to clone via [`Arc`]; one instance per
-/// active channel.
+/// Lock-free emote index. Wrap in [`Arc<EmoteIndex>`] when callers need
+/// cheap shared ownership; typically one instance per active channel.
 pub struct EmoteIndex {
     inner: ArcSwap<Snapshot>,
 }
@@ -102,10 +104,16 @@ impl EmoteIndex {
     /// codes are resolved by "later wins" — callers that care about
     /// precedence (channel > global, or 7TV > BTTV > FFZ) pass entries in
     /// ascending priority order so the highest-priority source overwrites.
+    ///
+    /// Emotes with empty codes are dropped (aho-corasick rejects them and
+    /// they would never match anyway).
     pub fn load<I: IntoIterator<Item = EmoteMeta>>(&self, emotes: I) {
-        let mut by_code: FxHashMap<Box<str>, Arc<EmoteMeta>> = FxHashMap::default();
+        let mut by_code: FxHashMap<Arc<str>, Arc<EmoteMeta>> = FxHashMap::default();
         for e in emotes {
-            let code = e.code.clone();
+            if e.code.is_empty() {
+                continue;
+            }
+            let code = Arc::clone(&e.code);
             by_code.insert(code, Arc::new(e));
         }
 
@@ -122,12 +130,16 @@ impl EmoteIndex {
         let ac = if needles.is_empty() {
             None
         } else {
-            Some(
-                AhoCorasickBuilder::new()
-                    .match_kind(MatchKind::LeftmostLongest)
-                    .build(&needles)
-                    .expect("aho-corasick build with non-empty inputs cannot fail"),
-            )
+            match AhoCorasickBuilder::new()
+                .match_kind(MatchKind::LeftmostLongest)
+                .build(&needles)
+            {
+                Ok(ac) => Some(ac),
+                Err(err) => {
+                    warn!(error = %err, count = needles.len(), "emote_index: aho-corasick build failed; scans will no-op until next reload");
+                    None
+                }
+            }
         };
 
         self.inner.store(Arc::new(Snapshot {
@@ -160,7 +172,14 @@ impl EmoteIndex {
     /// by ASCII whitespace or the ends of `text` — this mirrors how Twitch
     /// chat tokenizes, and prevents `Kappa` inside `KappaPride` (if only
     /// `Kappa` is indexed) from matching as a substring.
+    ///
+    /// Texts longer than `u32::MAX` bytes are not scanned; chat messages
+    /// are capped far below that in practice, so this only guards against
+    /// corrupt input.
     pub fn scan_into(&self, text: &str, out: &mut Vec<EmoteSpan>) {
+        if text.len() > u32::MAX as usize {
+            return;
+        }
         let snap = self.inner.load();
         let Some(ac) = snap.ac.as_ref() else {
             return;
@@ -188,12 +207,13 @@ impl Default for EmoteIndex {
     }
 }
 
-/// Returns true when `start..end` is surrounded by ASCII whitespace or sits
-/// at a string boundary. Emote codes never contain spaces, so whitespace is
-/// the only valid delimiter across Twitch, 7TV, BTTV, and FFZ.
+/// Returns true when `start..end` is surrounded by ASCII whitespace (space,
+/// tab, newline, carriage return, form feed) or sits at a string boundary.
+/// Emote codes never contain whitespace, so whitespace is the only valid
+/// delimiter across Twitch, 7TV, BTTV, and FFZ.
 fn is_token_boundary(bytes: &[u8], start: usize, end: usize) -> bool {
-    let left_ok = start == 0 || bytes[start - 1] == b' ';
-    let right_ok = end == bytes.len() || bytes[end] == b' ';
+    let left_ok = start == 0 || bytes[start - 1].is_ascii_whitespace();
+    let right_ok = end == bytes.len() || bytes[end].is_ascii_whitespace();
     left_ok && right_ok
 }
 
@@ -336,6 +356,36 @@ mod tests {
         idx.scan_into("Kappa", &mut out);
         assert_eq!(out.len(), 1);
         assert!(out.capacity() >= cap_before);
+    }
+
+    #[test]
+    fn tab_and_newline_are_boundaries() {
+        let idx = EmoteIndex::new();
+        idx.load([meta("Kappa", Provider::Twitch)]);
+
+        let mut out = Vec::new();
+        idx.scan_into("hi\tKappa\nbye", &mut out);
+        assert_eq!(out.len(), 1, "tab+newline should delimit emotes");
+        assert_eq!(out[0].start, 3);
+        assert_eq!(out[0].end, 8);
+    }
+
+    #[test]
+    fn empty_code_is_dropped() {
+        let idx = EmoteIndex::new();
+        idx.load([meta("", Provider::Twitch), meta("Kappa", Provider::Twitch)]);
+        assert_eq!(idx.len(), 1);
+        assert!(idx.lookup("Kappa").is_some());
+    }
+
+    #[test]
+    fn only_empty_codes_leaves_index_usable() {
+        let idx = EmoteIndex::new();
+        idx.load([meta("", Provider::Twitch)]);
+        assert!(idx.is_empty());
+        let mut out = Vec::new();
+        idx.scan_into("hello world", &mut out);
+        assert!(out.is_empty());
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -4,6 +4,8 @@ pub mod ringbuf;
 mod sidecar_supervisor;
 pub mod twitch_auth;
 
+pub mod emote_index;
+
 // Re-exports for the bench harness. Gated so the public crate surface
 // does not grow with bench-only plumbing in release builds.
 #[cfg(any(test, feature = "__bench"))]


### PR DESCRIPTION
Channel-scoped emote metadata catalog + aho-corasick matcher. Data structure only, no hot-path integration yet.

## What

- New module `src/emote_index.rs`
- `EmoteIndex` wraps `ArcSwap<Snapshot>` so message-hot-path readers never block and writers swap a whole new snapshot per reload
- `EmoteMeta` deserializes directly from the shape `sidecar/internal/emotes` produces (verified by test)
- `scan_into(&str, &mut Vec<EmoteSpan>)` takes a caller-owned buffer so per-message scanning is zero-alloc after warmup
- Token-boundary check enforces whitespace-delimited matches (no `Kappa` inside `xKappax`)
- `MatchKind::LeftmostLongest` resolves overlapping prefixes (Chatterino parity: `KappaHD` beats `Kappa`)
- Duplicate-code resolution: later-wins, so callers can push global → channel and have channel overwrite

## Deps added

- `aho-corasick = "1.1"` (DFA matcher, already listed in docs/adr.md)
- `arc-swap = "1.7"` (lock-free snapshot swap)
- `rustc-hash = "2.1"` (FxHashMap — cheaper hash than std for short string keys)

## Why

Per ADR 13 / docs/caching.md: Rust owns the hot-path emote lookup. Scanning 10k+ msg/s with a DFA over ~5k emotes is the only approach that keeps per-message cost predictable. Next branch wires this into `message.rs` so `UnifiedMessage` carries a span list before it hits the ring buffer.

## Verification

- `cargo test --all-targets` ✓ (77/77; 10 new tests in `emote_index::tests`)
- `cargo clippy --all-targets -- -D warnings` ✓
- `cargo fmt` clean
- Lefthook pre-commit + pre-push green