### PR TITLE
feat(emotes): wire channel-join bundle from sidecar to host

### DIFF
--- a/apps/desktop/src-sidecar/internal/emotes/fetcher.go
+++ b/apps/desktop/src-sidecar/internal/emotes/fetcher.go
@@ -2,6 +2,7 @@ package emotes
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"sync"
 )
@@ -13,18 +14,22 @@ import (
 // Any provider fetch that fails is reported in [Bundle.Errors] and the
 // corresponding field is left zero-valued. A failing provider never fails
 // the whole bundle — a dead BTTV CDN must not stop Twitch chat.
+//
+// The JSON shape is the on-the-wire contract for the `emote_bundle` control
+// message the sidecar emits to the Rust host; changes here must be mirrored
+// in `src-tauri/src/emote_index.rs` deserialization.
 type Bundle struct {
-	TwitchGlobalEmotes  EmoteSet
-	TwitchChannelEmotes EmoteSet
-	TwitchGlobalBadges  BadgeSet
-	TwitchChannelBadges BadgeSet
-	SevenTVGlobal       EmoteSet
-	SevenTVChannel      EmoteSet
-	BTTVGlobal          EmoteSet
-	BTTVChannel         EmoteSet
-	FFZGlobal           EmoteSet
-	FFZChannel          EmoteSet
-	Errors              []ProviderError
+	TwitchGlobalEmotes  EmoteSet        `json:"twitch_global_emotes"`
+	TwitchChannelEmotes EmoteSet        `json:"twitch_channel_emotes"`
+	TwitchGlobalBadges  BadgeSet        `json:"twitch_global_badges"`
+	TwitchChannelBadges BadgeSet        `json:"twitch_channel_badges"`
+	SevenTVGlobal       EmoteSet        `json:"seventv_global"`
+	SevenTVChannel      EmoteSet        `json:"seventv_channel"`
+	BTTVGlobal          EmoteSet        `json:"bttv_global"`
+	BTTVChannel         EmoteSet        `json:"bttv_channel"`
+	FFZGlobal           EmoteSet        `json:"ffz_global"`
+	FFZChannel          EmoteSet        `json:"ffz_channel"`
+	Errors              []ProviderError `json:"errors,omitempty"`
 }
 
 // ProviderError attributes a fetch failure to a specific provider and scope.
@@ -50,6 +55,21 @@ func (e *ProviderError) Unwrap() error {
 		return nil
 	}
 	return e.Err
+}
+
+// MarshalJSON renders the error string so the host can log it without
+// needing a Go error type on the Rust side. `error` is an interface and
+// marshals to `{}` by default.
+func (e ProviderError) MarshalJSON() ([]byte, error) {
+	var msg string
+	if e.Err != nil {
+		msg = e.Err.Error()
+	}
+	return json.Marshal(struct {
+		Provider Provider `json:"provider"`
+		Scope    Scope    `json:"scope"`
+		Error    string   `json:"error"`
+	}{e.Provider, e.Scope, msg})
 }
 
 // Fetcher is the aggregate client for a single channel join. Each sub-client

--- a/apps/desktop/src-sidecar/internal/sidecar/sidecar.go
+++ b/apps/desktop/src-sidecar/internal/sidecar/sidecar.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/ImpulseB23/Prismoid/sidecar/internal/control"
+	"github.com/ImpulseB23/Prismoid/sidecar/internal/emotes"
 	"github.com/ImpulseB23/Prismoid/sidecar/internal/ringbuf"
 	"github.com/ImpulseB23/Prismoid/sidecar/internal/twitch"
 )
@@ -374,6 +375,12 @@ func HandleDeleteMessage(cmd control.Command, logger zerolog.Logger) {
 // HandleTwitchConnect spawns a Twitch EventSub client for the broadcaster in
 // cmd if there isn't already one running. The client writes envelope bytes to
 // `out`, which the writer goroutine drains into the ring buffer.
+//
+// A parallel goroutine fetches the channel's emote and badge bundle (Helix +
+// 7TV + BTTV + FFZ) and emits it as a single `emote_bundle` control message.
+// Fetches share the client's cancel context, so twitch_disconnect also
+// cancels an in-flight bundle fetch. Failures per provider are captured in
+// [emotes.Bundle.Errors] rather than blocking the chat connection.
 func HandleTwitchConnect(ctx context.Context, cmd control.Command, clients map[string]context.CancelFunc, out chan<- []byte, notify twitch.Notify, logger zerolog.Logger) {
 	if _, exists := clients[cmd.BroadcasterID]; exists {
 		logger.Warn().Str("broadcaster", cmd.BroadcasterID).Msg("already connected, ignoring")
@@ -403,7 +410,78 @@ func HandleTwitchConnect(ctx context.Context, cmd control.Command, clients map[s
 		}
 	}()
 
+	go emoteFetchFn(clientCtx, cmd, notify, logger)
+
 	logger.Info().Str("broadcaster", cmd.BroadcasterID).Msg("twitch client started")
+}
+
+// emoteFetchFn is the goroutine entry point for fetching an emote bundle on
+// twitch_connect. Package-level so tests can stub it to a no-op without
+// spinning up httptest servers for all four providers.
+var emoteFetchFn = FetchAndNotifyEmotes
+
+// FetchAndNotifyEmotes builds a [emotes.Fetcher] from the connect command's
+// credentials, fetches the channel's full emote/badge bundle, and emits it
+// to the host as an `emote_bundle` control message. Extracted so tests can
+// drive it directly without spinning up the full command loop.
+//
+// An empty BroadcasterID is treated as "nothing to fetch" and the function
+// returns without emitting. A cancelled context (twitch_disconnect or parent
+// shutdown mid-fetch) short-circuits the emit alike.
+func FetchAndNotifyEmotes(ctx context.Context, cmd control.Command, notify twitch.Notify, logger zerolog.Logger) {
+	if cmd.BroadcasterID == "" {
+		return
+	}
+	fetchAndEmit(ctx, buildFetcher(cmd), cmd.BroadcasterID, notify, logger)
+}
+
+// fetchAndEmit is the test-friendly core of [FetchAndNotifyEmotes]: given an
+// already-constructed fetcher, run the fetch and emit the bundle.
+func fetchAndEmit(ctx context.Context, f *emotes.Fetcher, broadcasterID string, notify twitch.Notify, logger zerolog.Logger) {
+	bundle := f.Fetch(ctx, broadcasterID)
+	if ctx.Err() != nil {
+		return
+	}
+	for _, pe := range bundle.Errors {
+		logger.Warn().
+			Str("broadcaster", broadcasterID).
+			Str("provider", string(pe.Provider)).
+			Str("scope", string(pe.Scope)).
+			Err(pe.Err).
+			Msg("emote provider fetch failed")
+	}
+	notify("emote_bundle", bundle)
+	logger.Info().
+		Str("broadcaster", broadcasterID).
+		Int("twitch_global", len(bundle.TwitchGlobalEmotes.Emotes)).
+		Int("twitch_channel", len(bundle.TwitchChannelEmotes.Emotes)).
+		Int("seventv_global", len(bundle.SevenTVGlobal.Emotes)).
+		Int("seventv_channel", len(bundle.SevenTVChannel.Emotes)).
+		Int("bttv_global", len(bundle.BTTVGlobal.Emotes)).
+		Int("bttv_channel", len(bundle.BTTVChannel.Emotes)).
+		Int("ffz_global", len(bundle.FFZGlobal.Emotes)).
+		Int("ffz_channel", len(bundle.FFZChannel.Emotes)).
+		Int("errors", len(bundle.Errors)).
+		Msg("emote bundle ready")
+}
+
+// buildFetcher constructs an [emotes.Fetcher] from a twitch_connect command.
+// Twitch Helix lookups require a client ID and bearer token; without them
+// the first-party sub-client is left nil and the fetcher skips those
+// endpoints entirely (third-party providers still run).
+func buildFetcher(cmd control.Command) *emotes.Fetcher {
+	f := &emotes.Fetcher{
+		SevenTV: &emotes.SevenTVClient{},
+		BTTV:    &emotes.BTTVClient{},
+		FFZ:     &emotes.FFZClient{},
+	}
+	if cmd.ClientID != "" && cmd.Token != "" {
+		f.Twitch = &emotes.TwitchClient{
+			ClientID:    cmd.ClientID,
+			AccessToken: cmd.Token,
+		}
+	}
+	return f
 }
 
 // HandleTwitchDisconnect cancels and removes a previously-connected client.

--- a/apps/desktop/src-sidecar/internal/sidecar/sidecar_test.go
+++ b/apps/desktop/src-sidecar/internal/sidecar/sidecar_test.go
@@ -5,6 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -15,7 +18,9 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/ImpulseB23/Prismoid/sidecar/internal/control"
+	"github.com/ImpulseB23/Prismoid/sidecar/internal/emotes"
 	"github.com/ImpulseB23/Prismoid/sidecar/internal/ringbuf"
+	"github.com/ImpulseB23/Prismoid/sidecar/internal/twitch"
 )
 
 const (
@@ -164,6 +169,9 @@ func TestRunWriter_SkipsSignalOnFullRing(t *testing.T) {
 }
 
 func TestHandleTwitchConnect_AddsClient(t *testing.T) {
+	restore := stubEmoteFetcher(t)
+	defer restore()
+
 	clients := make(map[string]context.CancelFunc)
 	out := make(chan []byte, 1)
 	cmd := control.Command{
@@ -185,6 +193,9 @@ func TestHandleTwitchConnect_AddsClient(t *testing.T) {
 }
 
 func TestHandleTwitchConnect_RejectsDuplicate(t *testing.T) {
+	restore := stubEmoteFetcher(t)
+	defer restore()
+
 	clients := make(map[string]context.CancelFunc)
 	out := make(chan []byte, 1)
 
@@ -227,6 +238,9 @@ func TestHandleTwitchDisconnect_NoOpForUnknown(t *testing.T) {
 }
 
 func TestDispatchCommand_RoutesConnect(t *testing.T) {
+	restore := stubEmoteFetcher(t)
+	defer restore()
+
 	clients := make(map[string]context.CancelFunc)
 	out := make(chan []byte, 1)
 	cmd := control.Command{Cmd: "twitch_connect", BroadcasterID: "b1"}
@@ -379,6 +393,9 @@ func TestHandleDeleteMessage_MissingMessageIDIgnored(t *testing.T) {
 }
 
 func TestRunCommandLoop_DispatchesCommands(t *testing.T) {
+	restore := stubEmoteFetcher(t)
+	defer restore()
+
 	// Pre-load the scanner with one twitch_connect, then close stdin so
 	// scanCommands exits cleanly. The loop itself stops when ctx is cancelled.
 	stdin := strings.NewReader(`{"cmd":"twitch_connect","broadcaster_id":"b1"}` + "\n")
@@ -704,5 +721,192 @@ func TestRunWithIO_HappyPath(t *testing.T) {
 
 	if !strings.Contains(stdout.String(), `"type":"heartbeat"`) {
 		t.Errorf("expected at least one heartbeat in stdout, got: %s", stdout.String())
+	}
+}
+
+// stubEmoteFetcher replaces emoteFetchFn with a no-op for the duration of a
+// test so HandleTwitchConnect doesn't kick off real HTTP fetches against
+// 7tv.io / betterttv.net / frankerfacez.com during unit tests.
+func stubEmoteFetcher(t *testing.T) func() {
+	t.Helper()
+	orig := emoteFetchFn
+	emoteFetchFn = func(context.Context, control.Command, twitch.Notify, zerolog.Logger) {}
+	return func() { emoteFetchFn = orig }
+}
+
+func TestBuildFetcher_WithTwitchCredsPopulatesHelixClient(t *testing.T) {
+	f := buildFetcher(control.Command{
+		Cmd:           "twitch_connect",
+		BroadcasterID: "b1",
+		ClientID:      "cid",
+		Token:         "tok",
+	})
+	if f.Twitch == nil {
+		t.Fatal("expected Twitch client to be set when cid+token are present")
+	}
+	if f.Twitch.ClientID != "cid" || f.Twitch.AccessToken != "tok" {
+		t.Errorf("twitch client credentials not wired: %+v", f.Twitch)
+	}
+	if f.SevenTV == nil || f.BTTV == nil || f.FFZ == nil {
+		t.Error("third-party clients must always be set")
+	}
+}
+
+func TestBuildFetcher_WithoutTwitchCredsSkipsHelix(t *testing.T) {
+	// Missing either ClientID or Token must leave the Twitch client nil so
+	// Fetcher.Fetch skips Helix entirely instead of 401-ing every request.
+	cases := []control.Command{
+		{BroadcasterID: "b1"},
+		{BroadcasterID: "b1", ClientID: "cid"},
+		{BroadcasterID: "b1", Token: "tok"},
+	}
+	for i, cmd := range cases {
+		f := buildFetcher(cmd)
+		if f.Twitch != nil {
+			t.Errorf("case %d: expected nil Twitch client, got %+v", i, f.Twitch)
+		}
+	}
+}
+
+func TestFetchAndNotifyEmotes_EmptyBroadcasterDoesNotEmit(t *testing.T) {
+	var called atomic.Bool
+	notify := func(string, any) { called.Store(true) }
+
+	FetchAndNotifyEmotes(context.Background(), control.Command{}, notify, zerolog.Nop())
+
+	if called.Load() {
+		t.Fatal("expected no emit when BroadcasterID is empty")
+	}
+}
+
+func TestFetchAndNotifyEmotes_EmitsBundleOverControlPlane(t *testing.T) {
+	// Spin up an httptest server that plays all four provider endpoints: the
+	// integration checks that a real fetcher reaches our channel handler and
+	// the resulting Bundle is emitted as a single `emote_bundle` message.
+	sevenTVGlobal := `{"id":"g","emotes":[{"id":"7tv1","name":"PepegaAim","data":{"id":"7tv1","name":"PepegaAim","host":{"url":"//cdn.7tv.app/emote/7tv1","files":[{"name":"1x.webp","width":32,"height":32,"format":"WEBP"}]}}}]}`
+	sevenTVUser := `{"emote_set":{"id":"u","emotes":[]}}`
+	bttvGlobal := `[{"id":"bttv1","code":"monkaS","imageType":"png"}]`
+	bttvChannel := `{"channelEmotes":[],"sharedEmotes":[]}`
+	ffzGlobal := `{"default_sets":[3],"sets":{"3":{"emoticons":[{"id":1,"name":"ZrehplaR","urls":{"1":"//cdn.frankerfacez.com/1.png"}}]}}}`
+	ffzRoom := `{"room":{"set":500},"sets":{"500":{"emoticons":[]}}}`
+	twitchGlobalEmotes := `{"data":[],"template":""}`
+	twitchChannelEmotes := `{"data":[],"template":""}`
+	twitchGlobalBadges := `{"data":[]}`
+	twitchChannelBadges := `{"data":[]}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/emote-sets/global"):
+			_, _ = io.WriteString(w, sevenTVGlobal)
+		case strings.Contains(r.URL.Path, "/users/twitch/"):
+			_, _ = io.WriteString(w, sevenTVUser)
+		case strings.HasSuffix(r.URL.Path, "/cached/emotes/global"):
+			_, _ = io.WriteString(w, bttvGlobal)
+		case strings.Contains(r.URL.Path, "/cached/users/twitch/"):
+			_, _ = io.WriteString(w, bttvChannel)
+		case strings.HasSuffix(r.URL.Path, "/set/global"):
+			_, _ = io.WriteString(w, ffzGlobal)
+		case strings.Contains(r.URL.Path, "/room/id/"):
+			_, _ = io.WriteString(w, ffzRoom)
+		case strings.HasSuffix(r.URL.Path, "/chat/emotes/global"):
+			_, _ = io.WriteString(w, twitchGlobalEmotes)
+		case strings.HasPrefix(r.URL.Path, "/chat/emotes"):
+			_, _ = io.WriteString(w, twitchChannelEmotes)
+		case strings.HasSuffix(r.URL.Path, "/chat/badges/global"):
+			_, _ = io.WriteString(w, twitchGlobalBadges)
+		case strings.HasPrefix(r.URL.Path, "/chat/badges"):
+			_, _ = io.WriteString(w, twitchChannelBadges)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	f := &emotes.Fetcher{
+		Twitch:  &emotes.TwitchClient{BaseURL: srv.URL, ClientID: "cid", AccessToken: "tok"},
+		SevenTV: &emotes.SevenTVClient{BaseURL: srv.URL},
+		BTTV:    &emotes.BTTVClient{BaseURL: srv.URL},
+		FFZ:     &emotes.FFZClient{BaseURL: srv.URL},
+	}
+
+	var gotType string
+	var gotPayload any
+	notify := func(mt string, p any) { gotType = mt; gotPayload = p }
+
+	fetchAndEmit(context.Background(), f, "b1", notify, zerolog.Nop())
+
+	if gotType != "emote_bundle" {
+		t.Fatalf("expected type=emote_bundle, got %q", gotType)
+	}
+	bundle, ok := gotPayload.(emotes.Bundle)
+	if !ok {
+		t.Fatalf("expected emotes.Bundle payload, got %T", gotPayload)
+	}
+	if len(bundle.SevenTVGlobal.Emotes) == 0 {
+		t.Error("expected 7TV global emotes")
+	}
+	if len(bundle.BTTVGlobal.Emotes) == 0 {
+		t.Error("expected BTTV global emotes")
+	}
+	if len(bundle.FFZGlobal.Emotes) == 0 {
+		t.Error("expected FFZ global emotes")
+	}
+
+	// JSON round-trip has to succeed: this is the on-the-wire contract.
+	raw, err := json.Marshal(control.Message{Type: gotType, Payload: bundle})
+	if err != nil {
+		t.Fatalf("bundle message failed to marshal: %v", err)
+	}
+	if !strings.Contains(string(raw), `"type":"emote_bundle"`) {
+		t.Errorf("marshalled message missing type: %s", raw)
+	}
+	if !strings.Contains(string(raw), `"seventv_global"`) {
+		t.Errorf("marshalled bundle missing seventv_global field: %s", raw)
+	}
+}
+
+func TestFetchAndNotifyEmotes_CancelledContextSuppressesEmit(t *testing.T) {
+	// Use a server that blocks until the context is cancelled; confirm no
+	// emit fires when the context is already done by the time Fetch returns.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	f := &emotes.Fetcher{
+		SevenTV: &emotes.SevenTVClient{BaseURL: srv.URL},
+		BTTV:    &emotes.BTTVClient{BaseURL: srv.URL},
+		FFZ:     &emotes.FFZClient{BaseURL: srv.URL},
+	}
+
+	var called atomic.Bool
+	notify := func(string, any) { called.Store(true) }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	fetchAndEmit(ctx, f, "b1", notify, zerolog.Nop())
+
+	if called.Load() {
+		t.Fatal("expected no emit when context is cancelled before fetch returns")
+	}
+}
+
+func TestProviderError_JSONIncludesErrorString(t *testing.T) {
+	pe := emotes.ProviderError{
+		Provider: emotes.ProviderBTTV,
+		Scope:    emotes.ScopeGlobal,
+		Err:      errors.New("network down"),
+	}
+	raw, err := json.Marshal(pe)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(raw)
+	if !strings.Contains(got, `"provider":"bttv"`) ||
+		!strings.Contains(got, `"scope":"global"`) ||
+		!strings.Contains(got, `"error":"network down"`) {
+		t.Errorf("unexpected JSON: %s", got)
 	}
 }

--- a/apps/desktop/src-tauri/src/emote_index.rs
+++ b/apps/desktop/src-tauri/src/emote_index.rs
@@ -54,26 +54,61 @@ pub struct EmoteMeta {
     pub zero_width: bool,
 }
 
-/// One provider+scope slice of an [`EmoteBundle`]. Mirrors
-/// `sidecar/internal/emotes.EmoteSet`.
+/// One provider+scope slice of an [`EmoteBundle`]. Mirrors the
+/// payload-bearing field of `sidecar/internal/emotes.EmoteSet`. The Go
+/// type also carries `provider`, `scope`, and `channel_id` for debugging
+/// — those are intentionally dropped here because the bundle field name
+/// itself (`seventv_global`, `twitch_channel_emotes`, …) already encodes
+/// the provider+scope pair, and the channel ID lives on the parent join
+/// command. Adding extra `#[serde]` attributes would be needed to ignore
+/// them; serde's default behaviour already does so silently.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct EmoteSet {
     #[serde(default)]
     pub emotes: Vec<EmoteMeta>,
 }
 
-/// The full per-channel emote catalog as delivered by the sidecar in a
-/// single `emote_bundle` control message. Only the emote fields are
-/// consumed by [`EmoteIndex::load_bundle`]; badges are carried through for
-/// the frontend but do not participate in text scanning. Unknown fields
-/// (badges, errors) are ignored here and deserialized separately where
-/// needed.
+/// A single chat badge as delivered by the sidecar in a [`BadgeSet`].
+/// Carried through the bundle untouched so the frontend can render badge
+/// images; not consumed by the host scanner.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Badge {
+    pub set: Box<str>,
+    pub version: Box<str>,
+    #[serde(default)]
+    pub title: Box<str>,
+    #[serde(rename = "url_1x")]
+    pub url_1x: Box<str>,
+    #[serde(rename = "url_2x", default)]
+    pub url_2x: Box<str>,
+    #[serde(rename = "url_4x", default)]
+    pub url_4x: Box<str>,
+}
+
+/// Provider+scope slice of badges. Mirrors
+/// `sidecar/internal/emotes.BadgeSet`'s payload field; see [`EmoteSet`]
+/// for why the metadata fields are omitted.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct BadgeSet {
+    #[serde(default)]
+    pub badges: Vec<Badge>,
+}
+
+/// The full per-channel emote and badge catalog as delivered by the sidecar
+/// in a single `emote_bundle` control message. The four emote sets feed
+/// [`EmoteIndex::load_bundle`]; the two badge sets and the error list pass
+/// through the bundle unchanged so the frontend can render badges and
+/// surface partial-failure state without a second round trip.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct EmoteBundle {
     #[serde(default)]
     pub twitch_global_emotes: EmoteSet,
     #[serde(default)]
     pub twitch_channel_emotes: EmoteSet,
+    #[serde(default)]
+    pub twitch_global_badges: BadgeSet,
+    #[serde(default)]
+    pub twitch_channel_badges: BadgeSet,
     #[serde(default)]
     pub seventv_global: EmoteSet,
     #[serde(default)]
@@ -86,6 +121,11 @@ pub struct EmoteBundle {
     pub ffz_global: EmoteSet,
     #[serde(default)]
     pub ffz_channel: EmoteSet,
+    /// Per-provider fetch failures from the sidecar, rendered as opaque
+    /// JSON values. Each entry has the shape
+    /// `{"provider": "...", "scope": "...", "error": "..."}`.
+    #[serde(default)]
+    pub errors: Vec<serde_json::Value>,
 }
 
 impl EmoteBundle {
@@ -558,5 +598,42 @@ mod tests {
         let idx = EmoteIndex::new();
         idx.load_bundle(EmoteBundle::default());
         assert!(idx.is_empty());
+    }
+
+    #[test]
+    fn bundle_round_trips_badges_and_errors() {
+        let wire = serde_json::json!({
+            "twitch_global_emotes": {"emotes": []},
+            "twitch_channel_emotes": {"emotes": []},
+            "twitch_global_badges": {"badges": [
+                {"set": "moderator", "version": "1", "url_1x": "https://cdn/mod/1x", "url_2x": "https://cdn/mod/2x"}
+            ]},
+            "twitch_channel_badges": {"badges": []},
+            "seventv_global": {"emotes": []},
+            "seventv_channel": {"emotes": []},
+            "bttv_global": {"emotes": []},
+            "bttv_channel": {"emotes": []},
+            "ffz_global": {"emotes": []},
+            "ffz_channel": {"emotes": []},
+            "errors": [{"provider": "bttv", "scope": "channel", "error": "boom"}]
+        });
+        let bundle: EmoteBundle = serde_json::from_value(wire).unwrap();
+        assert_eq!(bundle.twitch_global_badges.badges.len(), 1);
+        assert_eq!(
+            bundle.twitch_global_badges.badges[0].set.as_ref(),
+            "moderator"
+        );
+        assert_eq!(
+            bundle.twitch_global_badges.badges[0].url_2x.as_ref(),
+            "https://cdn/mod/2x"
+        );
+        assert_eq!(bundle.errors.len(), 1);
+
+        let reserialized = serde_json::to_value(&bundle).unwrap();
+        assert_eq!(
+            reserialized["twitch_global_badges"]["badges"][0]["url_1x"],
+            "https://cdn/mod/1x"
+        );
+        assert_eq!(reserialized["errors"][0]["error"], "boom");
     }
 }

--- a/apps/desktop/src-tauri/src/emote_index.rs
+++ b/apps/desktop/src-tauri/src/emote_index.rs
@@ -31,7 +31,7 @@ pub enum Provider {
 /// Normalized metadata for a single emote. Fields match the Go side
 /// (`sidecar/internal/emotes.Emote`) so the sidecar can write these directly
 /// over the control plane.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EmoteMeta {
     pub id: Box<str>,
     /// Emote code (what users type). Stored as `Arc<str>` so the index can
@@ -52,6 +52,73 @@ pub struct EmoteMeta {
     pub animated: bool,
     #[serde(default)]
     pub zero_width: bool,
+}
+
+/// One provider+scope slice of an [`EmoteBundle`]. Mirrors
+/// `sidecar/internal/emotes.EmoteSet`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct EmoteSet {
+    #[serde(default)]
+    pub emotes: Vec<EmoteMeta>,
+}
+
+/// The full per-channel emote catalog as delivered by the sidecar in a
+/// single `emote_bundle` control message. Only the emote fields are
+/// consumed by [`EmoteIndex::load_bundle`]; badges are carried through for
+/// the frontend but do not participate in text scanning. Unknown fields
+/// (badges, errors) are ignored here and deserialized separately where
+/// needed.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct EmoteBundle {
+    #[serde(default)]
+    pub twitch_global_emotes: EmoteSet,
+    #[serde(default)]
+    pub twitch_channel_emotes: EmoteSet,
+    #[serde(default)]
+    pub seventv_global: EmoteSet,
+    #[serde(default)]
+    pub seventv_channel: EmoteSet,
+    #[serde(default)]
+    pub bttv_global: EmoteSet,
+    #[serde(default)]
+    pub bttv_channel: EmoteSet,
+    #[serde(default)]
+    pub ffz_global: EmoteSet,
+    #[serde(default)]
+    pub ffz_channel: EmoteSet,
+}
+
+impl EmoteBundle {
+    /// Iterates every emote in the order [`EmoteIndex::load_bundle`] uses
+    /// to resolve duplicate codes: global first, then channel, with
+    /// third-party providers overriding Twitch within each scope. The
+    /// Chatterino convention, and the expected one for users coming from
+    /// other Twitch chat clients.
+    fn iter_in_precedence_order(self) -> impl Iterator<Item = EmoteMeta> {
+        self.twitch_global_emotes
+            .emotes
+            .into_iter()
+            .chain(self.bttv_global.emotes)
+            .chain(self.ffz_global.emotes)
+            .chain(self.seventv_global.emotes)
+            .chain(self.twitch_channel_emotes.emotes)
+            .chain(self.bttv_channel.emotes)
+            .chain(self.ffz_channel.emotes)
+            .chain(self.seventv_channel.emotes)
+    }
+
+    /// Total emote count across all eight sets. Exposed for logging + the
+    /// frontend status UI, not used on the hot path.
+    pub fn total_emotes(&self) -> usize {
+        self.twitch_global_emotes.emotes.len()
+            + self.twitch_channel_emotes.emotes.len()
+            + self.seventv_global.emotes.len()
+            + self.seventv_channel.emotes.len()
+            + self.bttv_global.emotes.len()
+            + self.bttv_channel.emotes.len()
+            + self.ffz_global.emotes.len()
+            + self.ffz_channel.emotes.len()
+    }
 }
 
 /// Byte range of a matched emote code inside a message's `message_text`,
@@ -147,6 +214,15 @@ impl EmoteIndex {
             patterns,
             ac,
         }));
+    }
+
+    /// Replace the current snapshot with one built from an [`EmoteBundle`]
+    /// delivered by the sidecar. Equivalent to calling [`load`](Self::load)
+    /// with the bundle's emotes in the documented precedence order so
+    /// channel-scoped emotes and third-party providers win over Twitch
+    /// globals.
+    pub fn load_bundle(&self, bundle: EmoteBundle) {
+        self.load(bundle.iter_in_precedence_order());
     }
 
     /// Look up an emote by its exact code. Case-sensitive — Twitch and
@@ -408,5 +484,79 @@ mod tests {
         assert_eq!(got.provider, Provider::SevenTv);
         assert!(got.animated && got.zero_width);
         assert_eq!(got.width, 32);
+    }
+
+    #[test]
+    fn bundle_deserializes_from_sidecar_json() {
+        // Matches the on-wire shape emitted by sidecar FetchAndNotifyEmotes.
+        // Extra fields (badges, errors) are tolerated via serde's default
+        // "ignore unknown" behaviour.
+        let raw = r#"{
+            "twitch_global_emotes": {"provider":"twitch","scope":"global","emotes":[
+                {"id":"1","code":"Kappa","provider":"twitch","url_1x":"https://t/1"}
+            ]},
+            "twitch_channel_emotes": {"provider":"twitch","scope":"channel","emotes":[]},
+            "twitch_global_badges": {"scope":"global","badges":[]},
+            "twitch_channel_badges": {"scope":"channel","badges":[]},
+            "seventv_global": {"provider":"7tv","scope":"global","emotes":[
+                {"id":"2","code":"PepegaAim","provider":"7tv","url_1x":"https://s/2"}
+            ]},
+            "seventv_channel": {"provider":"7tv","scope":"channel","emotes":[]},
+            "bttv_global": {"provider":"bttv","scope":"global","emotes":[]},
+            "bttv_channel": {"provider":"bttv","scope":"channel","emotes":[]},
+            "ffz_global": {"provider":"ffz","scope":"global","emotes":[]},
+            "ffz_channel": {"provider":"ffz","scope":"channel","emotes":[]},
+            "errors": []
+        }"#;
+        let b: EmoteBundle = serde_json::from_str(raw).unwrap();
+        assert_eq!(b.total_emotes(), 2);
+        assert_eq!(b.twitch_global_emotes.emotes[0].code.as_ref(), "Kappa");
+        assert_eq!(b.seventv_global.emotes[0].provider, Provider::SevenTv);
+    }
+
+    #[test]
+    fn load_bundle_channel_overrides_global() {
+        let idx = EmoteIndex::new();
+        let mut bundle = EmoteBundle::default();
+        bundle
+            .twitch_global_emotes
+            .emotes
+            .push(meta("Kappa", Provider::Twitch));
+        bundle
+            .seventv_channel
+            .emotes
+            .push(meta("Kappa", Provider::SevenTv));
+
+        idx.load_bundle(bundle);
+
+        // Channel-scoped 7TV overrides the global Twitch emote with the same code.
+        let hit = idx.lookup("Kappa").unwrap();
+        assert_eq!(hit.provider, Provider::SevenTv);
+    }
+
+    #[test]
+    fn load_bundle_third_party_overrides_twitch_in_same_scope() {
+        let idx = EmoteIndex::new();
+        let mut bundle = EmoteBundle::default();
+        bundle
+            .twitch_global_emotes
+            .emotes
+            .push(meta("PogChamp", Provider::Twitch));
+        bundle
+            .seventv_global
+            .emotes
+            .push(meta("PogChamp", Provider::SevenTv));
+
+        idx.load_bundle(bundle);
+
+        let hit = idx.lookup("PogChamp").unwrap();
+        assert_eq!(hit.provider, Provider::SevenTv);
+    }
+
+    #[test]
+    fn load_bundle_empty_is_safe() {
+        let idx = EmoteIndex::new();
+        idx.load_bundle(EmoteBundle::default());
+        assert!(idx.is_empty());
     }
 }

--- a/apps/desktop/src-tauri/src/host.rs
+++ b/apps/desktop/src-tauri/src/host.rs
@@ -162,8 +162,9 @@ pub enum SidecarEvent {
     /// variant is currently just a structured marker for future watchdogs.
     Heartbeat,
     /// `{"type":"emote_bundle","payload":Bundle}`. Built on channel-join,
-    /// consumed by the host to rebuild its emote index.
-    EmoteBundle(EmoteBundle),
+    /// consumed by the host to rebuild its emote index. Boxed because the
+    /// bundle is much larger than the other variants.
+    EmoteBundle(Box<EmoteBundle>),
     /// A well-formed `{type, payload}` message the host does not yet
     /// recognize. The inner string is the type tag.
     Other(String),
@@ -200,7 +201,7 @@ pub fn parse_sidecar_event(bytes: &[u8]) -> SidecarEvent {
         "emote_bundle" => {
             let payload = env.payload.unwrap_or(serde_json::Value::Null);
             match serde_json::from_value::<EmoteBundle>(payload) {
-                Ok(b) => SidecarEvent::EmoteBundle(b),
+                Ok(b) => SidecarEvent::EmoteBundle(Box::new(b)),
                 Err(e) => {
                     tracing::warn!(error = %e, "emote_bundle payload decode failed");
                     SidecarEvent::Invalid

--- a/apps/desktop/src-tauri/src/host.rs
+++ b/apps/desktop/src-tauri/src/host.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 
 use serde::Serialize;
 
+use crate::emote_index::EmoteBundle;
 use crate::message::{parse_twitch_envelope, UnifiedMessage};
 use crate::ringbuf::RawHandle;
 
@@ -152,6 +153,65 @@ pub fn unmark_handle_inheritable(_handle: RawHandle) -> std::io::Result<()> {
     Ok(())
 }
 
+/// Parsed variant of a single line the sidecar emits on stdout. Unknown or
+/// malformed lines are surfaced as explicit variants so the caller can log
+/// them consistently rather than swallowing.
+pub enum SidecarEvent {
+    /// `{"type":"heartbeat","payload":{...}}`. The supervisor tracks
+    /// liveness via child-process exit rather than heartbeat gaps so this
+    /// variant is currently just a structured marker for future watchdogs.
+    Heartbeat,
+    /// `{"type":"emote_bundle","payload":Bundle}`. Built on channel-join,
+    /// consumed by the host to rebuild its emote index.
+    EmoteBundle(EmoteBundle),
+    /// A well-formed `{type, payload}` message the host does not yet
+    /// recognize. The inner string is the type tag.
+    Other(String),
+    /// Line was not valid JSON or lacked the `{type, payload}` shape.
+    Invalid,
+}
+
+/// Parses one line of sidecar stdout into a [`SidecarEvent`]. The sidecar
+/// writes one JSON object per line via `json.Encoder.Encode`, so `bytes`
+/// should be the full line without the trailing newline. Leading/trailing
+/// whitespace is tolerated.
+pub fn parse_sidecar_event(bytes: &[u8]) -> SidecarEvent {
+    #[derive(serde::Deserialize)]
+    struct Envelope {
+        #[serde(rename = "type", default)]
+        msg_type: String,
+        #[serde(default)]
+        payload: Option<serde_json::Value>,
+    }
+
+    let trimmed = bytes
+        .iter()
+        .position(|b| !b.is_ascii_whitespace())
+        .map(|i| &bytes[i..])
+        .unwrap_or(&[]);
+    if trimmed.is_empty() {
+        return SidecarEvent::Invalid;
+    }
+    let Ok(env) = serde_json::from_slice::<Envelope>(trimmed) else {
+        return SidecarEvent::Invalid;
+    };
+    match env.msg_type.as_str() {
+        "heartbeat" => SidecarEvent::Heartbeat,
+        "emote_bundle" => {
+            let payload = env.payload.unwrap_or(serde_json::Value::Null);
+            match serde_json::from_value::<EmoteBundle>(payload) {
+                Ok(b) => SidecarEvent::EmoteBundle(b),
+                Err(e) => {
+                    tracing::warn!(error = %e, "emote_bundle payload decode failed");
+                    SidecarEvent::Invalid
+                }
+            }
+        }
+        "" => SidecarEvent::Invalid,
+        other => SidecarEvent::Other(other.to_owned()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -253,5 +313,66 @@ mod tests {
 
         mark_handle_inheritable(handle).expect("mark should succeed");
         unmark_handle_inheritable(handle).expect("unmark should succeed");
+    }
+
+    #[test]
+    fn parse_sidecar_event_recognizes_heartbeat() {
+        let line = br#"{"type":"heartbeat","payload":{"ts_ms":123,"counter":4}}"#;
+        assert!(matches!(parse_sidecar_event(line), SidecarEvent::Heartbeat));
+    }
+
+    #[test]
+    fn parse_sidecar_event_decodes_emote_bundle() {
+        let line = br#"{"type":"emote_bundle","payload":{
+            "twitch_global_emotes":{"provider":"twitch","scope":"global","emotes":[
+                {"id":"1","code":"Kappa","provider":"twitch","url_1x":"https://t/1"}
+            ]},
+            "twitch_channel_emotes":{"provider":"twitch","scope":"channel","emotes":[]},
+            "twitch_global_badges":{"scope":"global","badges":[]},
+            "twitch_channel_badges":{"scope":"channel","badges":[]},
+            "seventv_global":{"provider":"7tv","scope":"global","emotes":[]},
+            "seventv_channel":{"provider":"7tv","scope":"channel","emotes":[]},
+            "bttv_global":{"provider":"bttv","scope":"global","emotes":[]},
+            "bttv_channel":{"provider":"bttv","scope":"channel","emotes":[]},
+            "ffz_global":{"provider":"ffz","scope":"global","emotes":[]},
+            "ffz_channel":{"provider":"ffz","scope":"channel","emotes":[]}
+        }}"#;
+        match parse_sidecar_event(line) {
+            SidecarEvent::EmoteBundle(b) => {
+                assert_eq!(b.total_emotes(), 1);
+                assert_eq!(b.twitch_global_emotes.emotes[0].code.as_ref(), "Kappa");
+            }
+            _ => panic!("expected EmoteBundle variant"),
+        }
+    }
+
+    #[test]
+    fn parse_sidecar_event_handles_unknown_type() {
+        let line = br#"{"type":"future_thing","payload":{"x":1}}"#;
+        match parse_sidecar_event(line) {
+            SidecarEvent::Other(t) => assert_eq!(t, "future_thing"),
+            _ => panic!("expected Other variant"),
+        }
+    }
+
+    #[test]
+    fn parse_sidecar_event_rejects_non_json() {
+        assert!(matches!(
+            parse_sidecar_event(b"plain text log line"),
+            SidecarEvent::Invalid
+        ));
+        assert!(matches!(
+            parse_sidecar_event(b"   \t  "),
+            SidecarEvent::Invalid
+        ));
+        assert!(matches!(parse_sidecar_event(b""), SidecarEvent::Invalid));
+    }
+
+    #[test]
+    fn parse_sidecar_event_rejects_malformed_emote_bundle_payload() {
+        // Type tag is right but payload shape is wrong. Return Invalid so the
+        // caller logs it, rather than silently dropping it as Other.
+        let line = br#"{"type":"emote_bundle","payload":{"twitch_global_emotes":"oops"}}"#;
+        assert!(matches!(parse_sidecar_event(line), SidecarEvent::Invalid));
     }
 }

--- a/apps/desktop/src-tauri/src/sidecar_supervisor.rs
+++ b/apps/desktop/src-tauri/src/sidecar_supervisor.rs
@@ -406,9 +406,14 @@ fn drain_and_emit<R: Runtime>(
     }
 }
 
-/// Processes one or more lines of sidecar stdout. Tauri's shell plugin may
-/// coalesce multiple JSON lines into a single [`CommandEvent::Stdout`], so
-/// we split on newlines and parse each piece independently.
+/// Processes one line of sidecar stdout. Tauri's shell plugin (in
+/// non-raw mode, which is our default) emits one [`CommandEvent::Stdout`]
+/// per `\n`-terminated line written by the child, with the trailing
+/// newline stripped, so a partial line never reaches us. The split-on-`\n`
+/// here is defensive: if the plugin ever changes that contract or the
+/// sidecar buffers multiple JSON objects per write, each object still
+/// parses independently. Empty pieces (trailing newline, blank lines) are
+/// skipped.
 #[cfg(windows)]
 fn handle_sidecar_stdout<R: Runtime>(
     bytes: &[u8],
@@ -433,11 +438,14 @@ fn handle_sidecar_stdout<R: Runtime>(
 }
 
 /// Swaps a fresh [`EmoteBundle`] into the supervisor's [`EmoteIndex`] and
-/// forwards a clone to the frontend for emote URL rendering. The index
-/// swap uses [`EmoteIndex::load_bundle`] (lock-free for readers).
+/// forwards a clone to the frontend. The frontend gets the full bundle
+/// (emotes + badges + per-provider errors) so it can render emote and
+/// badge images and surface partial-failure state without a second round
+/// trip; only the emote sets feed [`EmoteIndex::load_bundle`], which is
+/// lock-free for readers.
 #[cfg(windows)]
 fn apply_emote_bundle<R: Runtime>(
-    bundle: EmoteBundle,
+    bundle: Box<EmoteBundle>,
     app: &AppHandle<R>,
     emote_index: &Arc<EmoteIndex>,
 ) {
@@ -445,10 +453,10 @@ fn apply_emote_bundle<R: Runtime>(
     // Frontend needs the full bundle to render URLs; cloning is cheap
     // compared to the network fetch that produced it and happens at most
     // once per channel join.
-    if let Err(e) = app.emit("emote_bundle", &bundle) {
+    if let Err(e) = app.emit("emote_bundle", bundle.as_ref()) {
         tracing::error!(error = %e, "failed to emit emote_bundle");
     }
-    emote_index.load_bundle(bundle);
+    emote_index.load_bundle(*bundle);
     tracing::info!(total_emotes = total, "emote index rebuilt");
 }
 

--- a/apps/desktop/src-tauri/src/sidecar_supervisor.rs
+++ b/apps/desktop/src-tauri/src/sidecar_supervisor.rs
@@ -32,9 +32,12 @@ use tauri_plugin_shell::{
 };
 
 #[cfg(windows)]
+use crate::emote_index::{EmoteBundle, EmoteIndex};
+#[cfg(windows)]
 use crate::host::{
     build_bootstrap_line, build_twitch_connect_line, mark_handle_inheritable, parse_batch,
-    unmark_handle_inheritable, TwitchCreds, SIDECAR_BINARY, SIGNAL_WAIT_TIMEOUT,
+    parse_sidecar_event, unmark_handle_inheritable, SidecarEvent, TwitchCreds, SIDECAR_BINARY,
+    SIGNAL_WAIT_TIMEOUT,
 };
 #[cfg(windows)]
 use crate::message::UnifiedMessage;
@@ -310,10 +313,16 @@ async fn run_once<R: Runtime>(
 
     emit_status(app, "running", attempt, None);
 
+    // EmoteIndex lives for the lifetime of this sidecar run; a fresh one is
+    // built on every respawn. Not yet consumed on the message hot path
+    // (follow-up) but held here so `emote_bundle` messages have a stable
+    // target while the frontend already receives the bundle for rendering.
+    let emote_index: Arc<EmoteIndex> = Arc::new(EmoteIndex::new());
+
     while let Some(event) = rx.recv().await {
         match event {
             CommandEvent::Stdout(bytes) => {
-                tracing::debug!(line = %String::from_utf8_lossy(&bytes), "sidecar stdout");
+                handle_sidecar_stdout(&bytes, app, &emote_index);
             }
             CommandEvent::Stderr(bytes) => {
                 tracing::debug!(line = %String::from_utf8_lossy(&bytes), "sidecar stderr");
@@ -395,6 +404,52 @@ fn drain_and_emit<R: Runtime>(
     if let Err(e) = app.emit("chat_messages", &*batch) {
         tracing::error!(error = %e, "failed to emit chat_messages");
     }
+}
+
+/// Processes one or more lines of sidecar stdout. Tauri's shell plugin may
+/// coalesce multiple JSON lines into a single [`CommandEvent::Stdout`], so
+/// we split on newlines and parse each piece independently.
+#[cfg(windows)]
+fn handle_sidecar_stdout<R: Runtime>(
+    bytes: &[u8],
+    app: &AppHandle<R>,
+    emote_index: &Arc<EmoteIndex>,
+) {
+    for line in bytes.split(|b| *b == b'\n') {
+        if line.is_empty() {
+            continue;
+        }
+        match parse_sidecar_event(line) {
+            SidecarEvent::Heartbeat => {}
+            SidecarEvent::EmoteBundle(bundle) => apply_emote_bundle(bundle, app, emote_index),
+            SidecarEvent::Other(t) => {
+                tracing::debug!(msg_type = %t, "unhandled sidecar control message");
+            }
+            SidecarEvent::Invalid => {
+                tracing::debug!(line = %String::from_utf8_lossy(line), "sidecar stdout (non-control)");
+            }
+        }
+    }
+}
+
+/// Swaps a fresh [`EmoteBundle`] into the supervisor's [`EmoteIndex`] and
+/// forwards a clone to the frontend for emote URL rendering. The index
+/// swap uses [`EmoteIndex::load_bundle`] (lock-free for readers).
+#[cfg(windows)]
+fn apply_emote_bundle<R: Runtime>(
+    bundle: EmoteBundle,
+    app: &AppHandle<R>,
+    emote_index: &Arc<EmoteIndex>,
+) {
+    let total = bundle.total_emotes();
+    // Frontend needs the full bundle to render URLs; cloning is cheap
+    // compared to the network fetch that produced it and happens at most
+    // once per channel join.
+    if let Err(e) = app.emit("emote_bundle", &bundle) {
+        tracing::error!(error = %e, "failed to emit emote_bundle");
+    }
+    emote_index.load_bundle(bundle);
+    tracing::info!(total_emotes = total, "emote index rebuilt");
 }
 
 fn emit_status<R: Runtime>(


### PR DESCRIPTION
Bridges the emote fetch path (PR #67) and the emote index (PR #68) end to end.

## Go sidecar
- `Bundle` and `ProviderError` get explicit JSON tags / `MarshalJSON` so the wire shape is stable and matches the Rust deserializer.
- `HandleTwitchConnect` now spawns `FetchAndNotifyEmotes` in the background using the client's cancel context, fetches global + channel emotes across Twitch / 7TV / BTTV / FFZ, and writes a single `emote_bundle` control message when done.
- Package-level `emoteFetchFn` seam keeps existing unit tests offline; new tests cover `buildFetcher` credential paths, empty-broadcaster skip, happy path over `httptest`, cancelled context suppression, and `ProviderError` JSON shape.

## Rust host
- `EmoteBundle` / `EmoteSet` mirror the Go wire format with `#[serde(default)]` on every set so partial bundles (one provider failed) still deserialize.
- `EmoteIndex::load_bundle` consumes a bundle in Chatterino precedence order (channel > global, 7TV > FFZ > BTTV > Twitch within scope) via the existing "later wins" `load`.
- `parse_sidecar_event` classifies stdout lines into `Heartbeat` / `EmoteBundle` / `Other` / `Invalid`.
- `sidecar_supervisor::run_once` now owns a per-run `Arc<EmoteIndex>`, splits stdout on newlines, rebuilds the index on `emote_bundle`, and forwards the bundle to the frontend via a new `emote_bundle` Tauri event.

## Not in this PR
Threading the `EmoteIndex` through `parse_batch` to populate `emote_spans` on `UnifiedMessage` is a follow-up. The index is built and held, but the drain loop is unchanged so the hot path stays untouched until that PR.

## Verification
- `cargo test --lib` → 89/89
- `cargo clippy --all-targets --all-features -- -D warnings` → clean
- `go test ./...` → clean