### PR TITLE
feat(emotes): scan messages against emote index on drain

### DIFF
--- a/apps/desktop/src-tauri/benches/drain_throughput.rs
+++ b/apps/desktop/src-tauri/benches/drain_throughput.rs
@@ -19,6 +19,7 @@ use criterion::{
     black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput,
 };
 
+use prismoid_lib::emote_index::EmoteIndex;
 use prismoid_lib::ringbuf::RingBufReader;
 use prismoid_lib::{parse_batch, UnifiedMessage};
 
@@ -112,6 +113,7 @@ fn drain_only(c: &mut Criterion) {
 
 fn parse_only(c: &mut Criterion) {
     let mut group = c.benchmark_group("parse_only");
+    let idx = EmoteIndex::new();
     for &n in SWEEP_SIZES {
         let raw: Vec<Vec<u8>> = (0..n).map(|_| TWITCH_MESSAGE.to_vec()).collect();
         let mut batch: Vec<UnifiedMessage> = Vec::with_capacity(n as usize);
@@ -119,7 +121,7 @@ fn parse_only(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::from_parameter(n), &raw, |b, raw| {
             b.iter(|| {
                 batch.clear();
-                parse_batch(raw, &mut batch);
+                parse_batch(raw, &mut batch, &idx);
                 black_box(&batch);
             });
         });
@@ -129,6 +131,7 @@ fn parse_only(c: &mut Criterion) {
 
 fn drain_and_parse(c: &mut Criterion) {
     let mut group = c.benchmark_group("drain_and_parse");
+    let idx = EmoteIndex::new();
     for &n in SWEEP_SIZES {
         let mut batch: Vec<UnifiedMessage> = Vec::with_capacity(n as usize);
         group.throughput(Throughput::Elements(n as u64));
@@ -144,7 +147,7 @@ fn drain_and_parse(c: &mut Criterion) {
                 |reader| {
                     batch.clear();
                     let raw = reader.drain();
-                    parse_batch(&raw, &mut batch);
+                    parse_batch(&raw, &mut batch, &idx);
                     black_box(&batch);
                 },
                 BatchSize::SmallInput,

--- a/apps/desktop/src-tauri/src/emote_index.rs
+++ b/apps/desktop/src-tauri/src/emote_index.rs
@@ -124,7 +124,7 @@ impl EmoteBundle {
 /// Byte range of a matched emote code inside a message's `message_text`,
 /// plus the resolved emote metadata. `start..end` is a UTF-8 byte slice of
 /// the original text.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct EmoteSpan {
     pub start: u32,
     pub end: u32,

--- a/apps/desktop/src-tauri/src/host.rs
+++ b/apps/desktop/src-tauri/src/host.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use serde::Serialize;
 
-use crate::emote_index::EmoteBundle;
+use crate::emote_index::{EmoteBundle, EmoteIndex};
 use crate::message::{parse_twitch_envelope, UnifiedMessage};
 use crate::ringbuf::RawHandle;
 
@@ -41,15 +41,23 @@ pub struct TwitchCreds {
 /// The caller is responsible for clearing the scratch between drain ticks;
 /// this function only appends.
 ///
+/// Each successful parse is scanned against `emote_index` and the resulting
+/// spans are attached to the message. Scans are cheap when the index is
+/// empty (no automaton, early return) so passing a fresh index is fine in
+/// tests and during the gap before `emote_bundle` arrives.
+///
 /// Messages that fail to parse or that aren't chat notifications are dropped
 /// with a log. Each parse is wrapped in `catch_unwind` so a panicking parser
 /// cannot kill the drain loop (`docs/stability.md` §Rust Panic Handling).
-pub fn parse_batch(raw: &[Vec<u8>], batch: &mut Vec<UnifiedMessage>) {
+pub fn parse_batch(raw: &[Vec<u8>], batch: &mut Vec<UnifiedMessage>, emote_index: &EmoteIndex) {
     for payload in raw {
         let slice = payload.as_slice();
         let outcome = std::panic::catch_unwind(|| parse_twitch_envelope(slice));
         match outcome {
-            Ok(Ok(Some(msg))) => batch.push(msg),
+            Ok(Ok(Some(mut msg))) => {
+                emote_index.scan_into(&msg.message_text, &mut msg.emote_spans);
+                batch.push(msg);
+            }
             Ok(Ok(None)) => {}
             Ok(Err(e)) => {
                 tracing::warn!(error = %e, "parse failed, dropping message");
@@ -263,15 +271,18 @@ mod tests {
 
         let raw = vec![viewer, keepalive, junk];
         let mut batch = Vec::new();
-        parse_batch(&raw, &mut batch);
+        let idx = EmoteIndex::new();
+        parse_batch(&raw, &mut batch, &idx);
         assert_eq!(batch.len(), 1);
         assert_eq!(batch[0].message_text, "hi");
+        assert!(batch[0].emote_spans.is_empty());
     }
 
     #[test]
     fn parse_batch_empty_input() {
         let mut batch = Vec::new();
-        parse_batch(&[], &mut batch);
+        let idx = EmoteIndex::new();
+        parse_batch(&[], &mut batch, &idx);
         assert!(batch.is_empty());
     }
 
@@ -292,15 +303,55 @@ mod tests {
         }"##.to_vec();
 
         let mut batch = Vec::new();
+        let idx = EmoteIndex::new();
         // Pretend a previous tick left one item in the scratch.
-        parse_batch(std::slice::from_ref(&viewer), &mut batch);
+        parse_batch(std::slice::from_ref(&viewer), &mut batch, &idx);
         assert_eq!(batch.len(), 1);
         assert_eq!(batch[0].message_text, "second");
 
         // Second call appends, scratch is NOT cleared.
-        parse_batch(std::slice::from_ref(&viewer), &mut batch);
+        parse_batch(std::slice::from_ref(&viewer), &mut batch, &idx);
         assert_eq!(batch.len(), 2);
         assert_eq!(batch[1].message_text, "second");
+    }
+
+    #[test]
+    fn parse_batch_attaches_emote_spans_from_index() {
+        use crate::emote_index::{EmoteMeta, Provider};
+
+        let viewer = br##"{
+            "metadata": {"message_id":"m","message_type":"notification","message_timestamp":"2023-11-06T18:11:47.492Z"},
+            "payload": {
+                "subscription": {"type":"channel.chat.message"},
+                "event": {
+                    "chatter_user_id":"1","chatter_user_login":"u","chatter_user_name":"U",
+                    "message_id":"mid","message":{"text":"hello Kappa world"}
+                }
+            }
+        }"##.to_vec();
+
+        let idx = EmoteIndex::new();
+        idx.load([EmoteMeta {
+            id: "1".into(),
+            code: "Kappa".into(),
+            provider: Provider::Twitch,
+            url_1x: "https://t/1".into(),
+            url_2x: "".into(),
+            url_4x: "".into(),
+            width: 28,
+            height: 28,
+            animated: false,
+            zero_width: false,
+        }]);
+
+        let mut batch = Vec::new();
+        parse_batch(std::slice::from_ref(&viewer), &mut batch, &idx);
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch[0].emote_spans.len(), 1);
+        let span = &batch[0].emote_spans[0];
+        assert_eq!(span.start, 6);
+        assert_eq!(span.end, 11);
+        assert_eq!(span.emote.code.as_ref(), "Kappa");
     }
 
     #[cfg(windows)]

--- a/apps/desktop/src-tauri/src/message.rs
+++ b/apps/desktop/src-tauri/src/message.rs
@@ -3,6 +3,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::emote_index::EmoteSpan;
+
 #[derive(Debug, Clone, Serialize)]
 pub enum Platform {
     Twitch,
@@ -36,6 +38,11 @@ pub struct UnifiedMessage {
     pub is_broadcaster: bool,
     pub color: Option<String>,
     pub reply_to: Option<String>,
+    /// Emote matches inside [`message_text`](Self::message_text), populated
+    /// by [`crate::emote_index::EmoteIndex::scan_into`] after parsing.
+    /// Empty when no index is active or the message has no emotes.
+    #[serde(default)]
+    pub emote_spans: Vec<EmoteSpan>,
 }
 
 #[derive(Debug)]
@@ -197,6 +204,7 @@ pub fn parse_twitch_envelope(bytes: &[u8]) -> Result<Option<UnifiedMessage>, Par
         is_broadcaster,
         color: event.color,
         reply_to: event.reply.map(|r| r.parent_message_id),
+        emote_spans: Vec::new(),
     }))
 }
 

--- a/apps/desktop/src-tauri/src/message.rs
+++ b/apps/desktop/src-tauri/src/message.rs
@@ -41,7 +41,6 @@ pub struct UnifiedMessage {
     /// Emote matches inside [`message_text`](Self::message_text), populated
     /// by [`crate::emote_index::EmoteIndex::scan_into`] after parsing.
     /// Empty when no index is active or the message has no emotes.
-    #[serde(default)]
     pub emote_spans: Vec<EmoteSpan>,
 }
 

--- a/apps/desktop/src-tauri/src/sidecar_supervisor.rs
+++ b/apps/desktop/src-tauri/src/sidecar_supervisor.rs
@@ -304,20 +304,21 @@ async fn run_once<R: Runtime>(
     // strand the control protocol).
     let _child = child.release();
 
+    // EmoteIndex lives for the lifetime of this sidecar run; a fresh one is
+    // built on every respawn. Shared by the control-plane reader (which
+    // swaps in fresh bundles on `emote_bundle`) and the drain loop (which
+    // scans each parsed message against the current snapshot).
+    let emote_index: Arc<EmoteIndex> = Arc::new(EmoteIndex::new());
+
     let shutdown = Arc::new(AtomicBool::new(false));
     let drain_shutdown = shutdown.clone();
     let drain_app = app.clone();
+    let drain_index = emote_index.clone();
     let drain_handle = tauri::async_runtime::spawn_blocking(move || {
-        run_drain_loop(reader, drain_app, drain_shutdown);
+        run_drain_loop(reader, drain_app, drain_shutdown, drain_index);
     });
 
     emit_status(app, "running", attempt, None);
-
-    // EmoteIndex lives for the lifetime of this sidecar run; a fresh one is
-    // built on every respawn. Not yet consumed on the message hot path
-    // (follow-up) but held here so `emote_bundle` messages have a stable
-    // target while the frontend already receives the bundle for rendering.
-    let emote_index: Arc<EmoteIndex> = Arc::new(EmoteIndex::new());
 
     while let Some(event) = rx.recv().await {
         match event {
@@ -363,6 +364,7 @@ fn run_drain_loop<R: Runtime>(
     mut reader: RingBufReader,
     app: AppHandle<R>,
     shutdown: Arc<AtomicBool>,
+    emote_index: Arc<EmoteIndex>,
 ) {
     let timeout_ms: u32 = SIGNAL_WAIT_TIMEOUT
         .as_millis()
@@ -372,7 +374,7 @@ fn run_drain_loop<R: Runtime>(
 
     loop {
         if shutdown.load(Ordering::Acquire) {
-            drain_and_emit(&mut reader, &app, &mut batch);
+            drain_and_emit(&mut reader, &app, &mut batch, &emote_index);
             return;
         }
         match reader.wait_for_signal(timeout_ms) {
@@ -382,7 +384,7 @@ fn run_drain_loop<R: Runtime>(
                 return;
             }
         }
-        drain_and_emit(&mut reader, &app, &mut batch);
+        drain_and_emit(&mut reader, &app, &mut batch, &emote_index);
     }
 }
 
@@ -391,13 +393,14 @@ fn drain_and_emit<R: Runtime>(
     reader: &mut RingBufReader,
     app: &AppHandle<R>,
     batch: &mut Vec<UnifiedMessage>,
+    emote_index: &EmoteIndex,
 ) {
     let raw = reader.drain();
     if raw.is_empty() {
         return;
     }
     batch.clear();
-    parse_batch(&raw, batch);
+    parse_batch(&raw, batch, emote_index);
     if batch.is_empty() {
         return;
     }

--- a/apps/desktop/src/stores/chatStore.test.ts
+++ b/apps/desktop/src/stores/chatStore.test.ts
@@ -17,6 +17,7 @@ function makeMsg(id: string, text = `msg ${id}`): ChatMessage {
     is_broadcaster: false,
     color: null,
     reply_to: null,
+    emote_spans: [],
   };
 }
 

--- a/apps/desktop/src/stores/chatStore.ts
+++ b/apps/desktop/src/stores/chatStore.ts
@@ -4,6 +4,25 @@
 
 import { createSignal } from "solid-js";
 
+export interface EmoteMeta {
+  id: string;
+  code: string;
+  provider: "twitch" | "7tv" | "bttv" | "ffz";
+  url_1x: string;
+  url_2x: string;
+  url_4x: string;
+  width: number;
+  height: number;
+  animated: boolean;
+  zero_width: boolean;
+}
+
+export interface EmoteSpan {
+  start: number;
+  end: number;
+  emote: EmoteMeta;
+}
+
 export interface ChatMessage {
   id: string;
   platform: "Twitch" | "YouTube" | "Kick";
@@ -19,6 +38,7 @@ export interface ChatMessage {
   is_broadcaster: boolean;
   color: string | null;
   reply_to: string | null;
+  emote_spans: EmoteSpan[];
 }
 
 export interface Viewport {

--- a/apps/desktop/src/stores/chatStore.ts
+++ b/apps/desktop/src/stores/chatStore.ts
@@ -17,6 +17,17 @@ export interface EmoteMeta {
   zero_width: boolean;
 }
 
+/**
+ * One scanned emote occurrence inside `ChatMessage.message_text`.
+ *
+ * `start` and `end` are **UTF-8 byte offsets** as produced by the Rust
+ * scanner, not UTF-16 code-unit offsets. JavaScript string indexing
+ * (`String.prototype.slice`, `[]`, etc.) operates on UTF-16, so renderers
+ * that splice the message around emote spans must translate first. The
+ * straightforward way is to encode `message_text` once with `TextEncoder`
+ * and slice the resulting `Uint8Array`, decoding each segment with
+ * `TextDecoder`. For ASCII-only messages the two are equivalent.
+ */
 export interface EmoteSpan {
   start: number;
   end: number;


### PR DESCRIPTION
Stacked on #69. Do not merge until #69 lands (review that first; rebase here after).

Completes the emote delivery story: messages arriving from the ring buffer are now scanned against the per-run `EmoteIndex` and the matched spans ship to the frontend with each message.

## Rust
- `UnifiedMessage` gains `emote_spans: Vec<EmoteSpan>`, defaulting to empty.
- `EmoteSpan` now derives `Serialize` so it rides the `chat_messages` event.
- `parse_batch` takes `&EmoteIndex` and calls `scan_into` for every successfully parsed message. Scans no-op when the index is empty so the gap between sidecar spawn and first `emote_bundle` arrival is free.
- `sidecar_supervisor::run_once` builds the `Arc<EmoteIndex>` before spawning the drain task and threads a clone into `run_drain_loop`. The control-plane reader keeps its own reference and swaps in fresh bundles on `emote_bundle`; the drain loop sees the update on the next scan via `ArcSwap`.
- Criterion bench and all three existing `parse_batch` tests updated. New test verifies a realistic envelope + indexed emote produces the expected span offsets.

## Frontend
- `ChatMessage` gets `emote_spans`; `EmoteMeta` + `EmoteSpan` exposed from the store. Frontend rendering comes in a later PR.

## Verification
- `cargo test --lib` → 90/90
- `cargo clippy --all-targets --all-features -- -D warnings` → clean
- `pnpm test` → 10/10
- `tsc --noEmit` → clean