### PR TITLE
chore(ci): use prebuilt cargo-llvm-cov and cargo-audit binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,9 @@ jobs:
       - name: Clippy
         run: cargo clippy -- -D warnings
 
-      - name: Install cargo-llvm-cov
-        run: cargo install cargo-llvm-cov --quiet
+      - uses: taiki-e/install-action@5939f3337e40968c39aa70f5ecb1417a92fb25a0 # v2.75.15
+        with:
+          tool: cargo-llvm-cov,cargo-audit
 
       - name: Test with coverage
         run: cargo llvm-cov --all-features --workspace --lcov --output-path coverage-rust.lcov
@@ -104,9 +105,7 @@ jobs:
           flags: rust
 
       - name: Audit
-        run: |
-          cargo install cargo-audit --quiet
-          cargo audit
+        run: cargo audit
 
   go:
     name: Go


### PR DESCRIPTION
Rust CI is taking ~16 minutes. The job breakdown on #69:

| Step | Duration |
|---|---|
| rust-cache restore | 2s |
| Clippy | 2:45 |
| `cargo install cargo-llvm-cov` | **1:45** |
| Test with coverage | 4:03 |
| `cargo install cargo-audit` + audit | **5:48** |

`swatinem/rust-cache` caches `target/` and `~/.cargo/registry`, but not `~/.cargo/bin`, so both tools were being compiled from source on every run. That's ~7 minutes of pure wasted build time.

Swap to `taiki-e/install-action`, which pulls prebuilt binaries from the tools' GitHub Releases in a few seconds each. Pinned to `v2.75.15` by SHA to match the repo's existing action pinning style.

Expected total Rust CI time after this: ~9 minutes instead of ~16.