### PR TITLE
feat(frontend): render inline emotes in chat messages

### DIFF
--- a/apps/desktop/src/components/ChatFeed.tsx
+++ b/apps/desktop/src/components/ChatFeed.tsx
@@ -14,7 +14,6 @@ import {
   onMount,
 } from "solid-js";
 import { listen } from "@tauri-apps/api/event";
-import type { PreparedRichInline } from "@chenglou/pretext/rich-inline";
 import {
   addMessages,
   getMessage,
@@ -29,22 +28,70 @@ import {
   MESSAGE_PADDING_Y,
   measureMessageHeight,
   prepareMessage,
+  type PreparedMessage,
 } from "../lib/messageLayout";
+import type { MessagePiece } from "../lib/emoteSpans";
 
 const OVERSCAN = 6;
 const STICK_THRESHOLD = 40;
 
+function renderPiece(piece: MessagePiece) {
+  if (piece.kind === "text") {
+    return <span>{piece.text}</span>;
+  }
+  const { primary, overlays } = piece;
+  return (
+    <span
+      style={{
+        display: "inline-block",
+        position: "relative",
+        width: `${primary.width}px`,
+        height: `${primary.height}px`,
+        "vertical-align": "middle",
+      }}
+    >
+      <img
+        src={primary.emote.url_1x}
+        alt={primary.emote.code}
+        title={primary.emote.code}
+        width={primary.width}
+        height={primary.height}
+        draggable={false}
+        style={{ display: "block" }}
+      />
+      <For each={overlays}>
+        {(overlay) => (
+          <img
+            src={overlay.emote.url_1x}
+            alt={overlay.emote.code}
+            title={overlay.emote.code}
+            width={overlay.width}
+            height={overlay.height}
+            draggable={false}
+            style={{
+              position: "absolute",
+              left: `${(primary.width - overlay.width) / 2}px`,
+              top: `${(primary.height - overlay.height) / 2}px`,
+              "pointer-events": "none",
+            }}
+          />
+        )}
+      </For>
+    </span>
+  );
+}
+
 interface PositionedMessage {
   monoIndex: number;
   msg: ChatMessage;
-  prepared: PreparedRichInline;
+  prepared: PreparedMessage;
   top: number;
   height: number;
 }
 
 const ChatFeed: Component = () => {
   let containerRef: HTMLDivElement | undefined;
-  const preparedCache = new Map<number, PreparedRichInline>();
+  const preparedCache = new Map<number, PreparedMessage>();
 
   const [width, setWidth] = createSignal(0);
   const [viewportHeight, setViewportHeight] = createSignal(0);
@@ -97,7 +144,7 @@ const ChatFeed: Component = () => {
         prepared = prepareMessage(msg);
         preparedCache.set(mono, prepared);
       }
-      const height = measureMessageHeight(prepared, w);
+      const height = measureMessageHeight(prepared.prepared, w);
       messages[writeIdx++] = { monoIndex: mono, msg, prepared, top: y, height };
       y += height;
     }
@@ -244,7 +291,9 @@ const ChatFeed: Component = () => {
                 {item.msg.display_name}
               </span>
               <span style={{ color: "#adadb8" }}>: </span>
-              <span>{item.msg.message_text}</span>
+              <For each={item.prepared.pieces}>
+                {(piece) => renderPiece(piece)}
+              </For>
             </div>
           )}
         </For>

--- a/apps/desktop/src/lib/emoteSpans.test.ts
+++ b/apps/desktop/src/lib/emoteSpans.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from "vitest";
+import { splitMessage, sizeEmote } from "./emoteSpans";
+import type { EmoteMeta, EmoteSpan } from "../stores/chatStore";
+
+function emote(overrides: Partial<EmoteMeta> = {}): EmoteMeta {
+  return {
+    id: "e1",
+    code: "Kappa",
+    provider: "twitch",
+    url_1x: "https://example/1x",
+    url_2x: "https://example/2x",
+    url_4x: "https://example/4x",
+    width: 28,
+    height: 28,
+    animated: false,
+    zero_width: false,
+    ...overrides,
+  };
+}
+
+function span(
+  start: number,
+  end: number,
+  meta: Partial<EmoteMeta> = {},
+): EmoteSpan {
+  return { start, end, emote: emote(meta) };
+}
+
+const OPTS = { maxHeight: 20 };
+
+describe("splitMessage", () => {
+  it("returns a single text piece when there are no spans", () => {
+    expect(splitMessage("hello world", [], OPTS)).toEqual([
+      { kind: "text", text: "hello world" },
+    ]);
+  });
+
+  it("returns no pieces for empty input with no spans", () => {
+    expect(splitMessage("", [], OPTS)).toEqual([]);
+  });
+
+  it("interleaves text and emotes in order", () => {
+    // "hi Kappa bye": Kappa at bytes 3..8
+    const pieces = splitMessage(
+      "hi Kappa bye",
+      [span(3, 8, { code: "Kappa" })],
+      OPTS,
+    );
+    expect(pieces).toHaveLength(3);
+    expect(pieces[0]).toEqual({ kind: "text", text: "hi " });
+    expect(pieces[1]!.kind).toBe("emote");
+    expect(pieces[2]).toEqual({ kind: "text", text: " bye" });
+  });
+
+  it("handles emote at start of message", () => {
+    const pieces = splitMessage("Kappa hi", [span(0, 5)], OPTS);
+    expect(pieces).toHaveLength(2);
+    expect(pieces[0]!.kind).toBe("emote");
+    expect(pieces[1]).toEqual({ kind: "text", text: " hi" });
+  });
+
+  it("handles emote at end of message", () => {
+    const pieces = splitMessage("hi Kappa", [span(3, 8)], OPTS);
+    expect(pieces).toHaveLength(2);
+    expect(pieces[0]).toEqual({ kind: "text", text: "hi " });
+    expect(pieces[1]!.kind).toBe("emote");
+  });
+
+  it("handles back-to-back emotes", () => {
+    // "AB" where A and B are separate emote codes at bytes 0..1 and 1..2
+    const pieces = splitMessage(
+      "AB",
+      [span(0, 1, { code: "A" }), span(1, 2, { code: "B" })],
+      OPTS,
+    );
+    expect(pieces).toHaveLength(2);
+    expect(pieces[0]!.kind).toBe("emote");
+    expect(pieces[1]!.kind).toBe("emote");
+  });
+
+  it("uses UTF-8 byte offsets, not UTF-16 indices", () => {
+    // "é" is 2 bytes in UTF-8 but 1 code unit in UTF-16. Message: "é Kappa"
+    // Bytes: [0xC3, 0xA9, 0x20, 'K', 'a', 'p', 'p', 'a'] — Kappa at 3..8.
+    const text = "é Kappa";
+    const pieces = splitMessage(text, [span(3, 8)], OPTS);
+    expect(pieces).toHaveLength(2);
+    expect(pieces[0]).toEqual({ kind: "text", text: "é " });
+    expect(pieces[1]!.kind).toBe("emote");
+  });
+
+  it("stacks zero-width overlays on the preceding emote", () => {
+    const pieces = splitMessage(
+      "A B",
+      [span(0, 1, { code: "A" }), span(2, 3, { code: "B", zero_width: true })],
+      OPTS,
+    );
+    expect(pieces).toHaveLength(2);
+    expect(pieces[0]!.kind).toBe("emote");
+    if (pieces[0]!.kind === "emote") {
+      expect(pieces[0]!.overlays).toHaveLength(1);
+      expect(pieces[0]!.overlays[0]!.emote.code).toBe("B");
+    }
+    expect(pieces[1]).toEqual({ kind: "text", text: " " });
+  });
+
+  it("renders orphan zero-width emote as inline when no prior emote exists", () => {
+    const pieces = splitMessage(
+      "hi X",
+      [span(3, 4, { code: "X", zero_width: true })],
+      OPTS,
+    );
+    expect(pieces).toHaveLength(2);
+    expect(pieces[0]).toEqual({ kind: "text", text: "hi " });
+    expect(pieces[1]!.kind).toBe("emote");
+  });
+
+  it("skips malformed spans without corrupting later output", () => {
+    // Second span overlaps first; first is valid.
+    const pieces = splitMessage(
+      "hi Kappa bye",
+      [span(3, 8), span(5, 10)],
+      OPTS,
+    );
+    expect(pieces).toHaveLength(3);
+    expect(pieces[0]).toEqual({ kind: "text", text: "hi " });
+    expect(pieces[1]!.kind).toBe("emote");
+    expect(pieces[2]).toEqual({ kind: "text", text: " bye" });
+  });
+
+  it("sorts out-of-order spans before splitting", () => {
+    const pieces = splitMessage(
+      "AB",
+      [span(1, 2, { code: "B" }), span(0, 1, { code: "A" })],
+      OPTS,
+    );
+    expect(pieces).toHaveLength(2);
+    if (pieces[0]!.kind === "emote")
+      expect(pieces[0]!.primary.emote.code).toBe("A");
+    if (pieces[1]!.kind === "emote")
+      expect(pieces[1]!.primary.emote.code).toBe("B");
+  });
+});
+
+describe("sizeEmote", () => {
+  it("scales down to fit maxHeight while preserving aspect ratio", () => {
+    const sized = sizeEmote(emote({ width: 56, height: 56 }), {
+      maxHeight: 20,
+    });
+    expect(sized.height).toBe(20);
+    expect(sized.width).toBe(20);
+  });
+
+  it("leaves emotes smaller than maxHeight at native size", () => {
+    const sized = sizeEmote(emote({ width: 18, height: 18 }), {
+      maxHeight: 20,
+    });
+    expect(sized.height).toBe(18);
+    expect(sized.width).toBe(18);
+  });
+
+  it("preserves non-square aspect ratio", () => {
+    const sized = sizeEmote(emote({ width: 80, height: 40 }), {
+      maxHeight: 20,
+    });
+    expect(sized.height).toBe(20);
+    expect(sized.width).toBe(40);
+  });
+
+  it("falls back to 28x28 for zero-sized emotes", () => {
+    const sized = sizeEmote(emote({ width: 0, height: 0 }), { maxHeight: 20 });
+    expect(sized.width).toBeGreaterThan(0);
+    expect(sized.height).toBeGreaterThan(0);
+  });
+});

--- a/apps/desktop/src/lib/emoteSpans.ts
+++ b/apps/desktop/src/lib/emoteSpans.ts
@@ -1,0 +1,118 @@
+// Splits a message into ordered text + emote pieces for both Pretext
+// measurement and DOM rendering. EmoteSpan offsets from the Rust scanner
+// are UTF-8 byte indices (see EmoteSpan docs in stores/chatStore.ts), so
+// splicing with plain JS string operations is wrong for any non-ASCII
+// text. We encode once and slice the byte array.
+
+import type { EmoteMeta, EmoteSpan } from "../stores/chatStore";
+
+export interface EmoteRenderInfo {
+  emote: EmoteMeta;
+  width: number;
+  height: number;
+}
+
+export type MessagePiece =
+  | { kind: "text"; text: string }
+  | {
+      kind: "emote";
+      primary: EmoteRenderInfo;
+      // Zero-width overlays stack on top of `primary` at the same x-origin.
+      // They contribute no horizontal width to line layout.
+      overlays: EmoteRenderInfo[];
+    };
+
+export interface SizeEmoteOptions {
+  // Upper bound on rendered height. Emotes are scaled down proportionally
+  // to this bound so chat line geometry stays predictable. Pass the
+  // message line-height.
+  maxHeight: number;
+}
+
+const FALLBACK_DIM = 28;
+
+export function sizeEmote(
+  emote: EmoteMeta,
+  opts: SizeEmoteOptions,
+): EmoteRenderInfo {
+  const rawH = emote.height > 0 ? emote.height : FALLBACK_DIM;
+  const rawW = emote.width > 0 ? emote.width : FALLBACK_DIM;
+  const scale = rawH > opts.maxHeight ? opts.maxHeight / rawH : 1;
+  return {
+    emote,
+    width: Math.max(1, Math.round(rawW * scale)),
+    height: Math.max(1, Math.round(rawH * scale)),
+  };
+}
+
+export function splitMessage(
+  text: string,
+  spans: EmoteSpan[],
+  opts: SizeEmoteOptions,
+): MessagePiece[] {
+  if (spans.length === 0) {
+    return text.length === 0 ? [] : [{ kind: "text", text }];
+  }
+
+  // Sort defensively; the scanner should already produce sorted spans but
+  // a stray unsorted input here would corrupt every downstream slice.
+  const sorted = [...spans].sort((a, b) => a.start - b.start);
+
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+  const bytes = encoder.encode(text);
+
+  const pieces: MessagePiece[] = [];
+  let cursor = 0;
+
+  for (const span of sorted) {
+    if (
+      span.start < cursor ||
+      span.end < span.start ||
+      span.end > bytes.length
+    ) {
+      // Malformed span; skip it rather than produce misaligned output.
+      continue;
+    }
+
+    const sized = sizeEmote(span.emote, opts);
+
+    if (span.emote.zero_width) {
+      const prev = pieces.length > 0 ? pieces[pieces.length - 1] : undefined;
+      if (prev && prev.kind === "emote") {
+        // Flush any literal text between the previous emote and this one
+        // before swallowing the zero-width span's code from the message.
+        if (span.start > cursor) {
+          pieces.push({
+            kind: "text",
+            text: decoder.decode(bytes.subarray(cursor, span.start)),
+          });
+        }
+        prev.overlays.push(sized);
+        cursor = span.end;
+        continue;
+      }
+      // Orphan zero-width emote (no primary to stack on). Fall through and
+      // render it as a normal inline emote.
+    }
+
+    if (span.start > cursor) {
+      pieces.push({
+        kind: "text",
+        text: decoder.decode(bytes.subarray(cursor, span.start)),
+      });
+    }
+
+    pieces.push({ kind: "emote", primary: sized, overlays: [] });
+    cursor = span.end;
+  }
+
+  if (cursor < bytes.length) {
+    pieces.push({
+      kind: "text",
+      text: decoder.decode(bytes.subarray(cursor)),
+    });
+  }
+
+  return pieces;
+}

--- a/apps/desktop/src/lib/messageLayout.ts
+++ b/apps/desktop/src/lib/messageLayout.ts
@@ -6,8 +6,11 @@ import {
   measureRichInlineStats,
   prepareRichInline,
   type PreparedRichInline,
+  type RichInlineItem,
 } from "@chenglou/pretext/rich-inline";
+import { measureNaturalWidth, prepareWithSegments } from "@chenglou/pretext";
 import type { ChatMessage } from "../stores/chatStore";
+import { splitMessage, type MessagePiece } from "./emoteSpans";
 
 // Named families only. `system-ui` is unsafe for pretext accuracy on macOS.
 // Exported so `ChatFeed.tsx` applies the exact same stack that Pretext
@@ -27,16 +30,51 @@ export const MESSAGE_PADDING_Y = 4;
 // overflow will never wrap and measured heights will be too small.
 export const MESSAGE_PADDING_X = 8;
 
-export function prepareMessage(msg: ChatMessage): PreparedRichInline {
-  return prepareRichInline([
-    {
-      text: msg.display_name,
-      font: USERNAME_FONT,
-      break: "never",
-    },
+// NBSP is not collapsed by Pretext's boundary-whitespace rules, so it
+// survives as a measurable placeholder. Each emote becomes an atomic
+// (`break: "never"`) item whose total width equals the NBSP natural
+// width plus `extraWidth`, sized to match the rendered <img>.
+const EMOTE_PLACEHOLDER = "\u00A0";
+
+const placeholderWidthCache = new Map<string, number>();
+function placeholderWidth(font: string): number {
+  const cached = placeholderWidthCache.get(font);
+  if (cached !== undefined) return cached;
+  const w = measureNaturalWidth(prepareWithSegments(EMOTE_PLACEHOLDER, font));
+  placeholderWidthCache.set(font, w);
+  return w;
+}
+
+export interface PreparedMessage {
+  prepared: PreparedRichInline;
+  pieces: MessagePiece[];
+}
+
+export function prepareMessage(msg: ChatMessage): PreparedMessage {
+  const pieces = splitMessage(msg.message_text, msg.emote_spans, {
+    maxHeight: MESSAGE_LINE_HEIGHT,
+  });
+
+  const items: RichInlineItem[] = [
+    { text: msg.display_name, font: USERNAME_FONT, break: "never" },
     { text: ": ", font: SEPARATOR_FONT },
-    { text: msg.message_text, font: TEXT_FONT },
-  ]);
+  ];
+
+  const placeholder = placeholderWidth(TEXT_FONT);
+  for (const piece of pieces) {
+    if (piece.kind === "text") {
+      items.push({ text: piece.text, font: TEXT_FONT });
+    } else {
+      items.push({
+        text: EMOTE_PLACEHOLDER,
+        font: TEXT_FONT,
+        break: "never",
+        extraWidth: Math.max(0, piece.primary.width - placeholder),
+      });
+    }
+  }
+
+  return { prepared: prepareRichInline(items), pieces };
 }
 
 export function measureMessageHeight(


### PR DESCRIPTION
Closes the loop on the emote pipeline: chat messages now display emote images inline instead of raw codes.

- new `splitMessage` util in `src/lib/emoteSpans.ts` that walks `emote_spans` using UTF-8 byte offsets (per the documented contract on `EmoteSpan`) and emits ordered text + emote pieces
- `prepareMessage` now returns `{prepared, pieces}` and represents each emote as an atomic `break: 'never'` rich-inline item with `extraWidth` sized to the rendered image so Pretext's line-count stays exact
- `ChatFeed` renders text pieces as spans and emote pieces as `<img>`. zero-width 7TV-style emotes stack as absolutely positioned overlays on the preceding primary emote and contribute no inline width
- emotes are scaled down proportionally to the 20px line-height to keep line geometry predictable

tests cover: plain text passthrough, emotes at start/middle/end, back-to-back emotes, utf-8 vs utf-16 offset handling, zero-width stacking, orphan zero-width fallback, malformed span rejection, unsorted-input sorting, and `sizeEmote` aspect-ratio math.