### PR TITLE
feat(host): respawn sidecar on heartbeat timeout

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -37,7 +37,7 @@ rustc-hash = "2.1"
 [dev-dependencies]
 criterion = "0.5"
 httpmock = "0.7"
-tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time"] }
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time", "test-util"] }
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.61", features = [

--- a/apps/desktop/src-tauri/src/sidecar_supervisor.rs
+++ b/apps/desktop/src-tauri/src/sidecar_supervisor.rs
@@ -56,6 +56,11 @@ pub struct SupervisorConfig {
     /// termination. Without this the ladder would only ever ratchet up,
     /// even if the sidecar was stable for hours between crashes.
     pub healthy_threshold: Duration,
+    /// Maximum gap between heartbeats from the sidecar before the
+    /// supervisor declares the child unhealthy and force-kills it to
+    /// trigger a respawn. `docs/stability.md` §Sidecar Health specifies
+    /// 3 missed heartbeats at a 1 s interval, so the default is 3 s.
+    pub heartbeat_timeout: Duration,
 }
 
 impl Default for SupervisorConfig {
@@ -64,6 +69,7 @@ impl Default for SupervisorConfig {
             initial_backoff: Duration::from_millis(250),
             max_backoff: Duration::from_secs(30),
             healthy_threshold: Duration::from_secs(60),
+            heartbeat_timeout: Duration::from_secs(3),
         }
     }
 }
@@ -165,7 +171,7 @@ async fn supervise<R: Runtime>(app: AppHandle<R>, cfg: SupervisorConfig) {
         };
 
         let started = Instant::now();
-        match run_once(&app, attempt, Some(&creds)).await {
+        match run_once(&app, &cfg, attempt, Some(&creds)).await {
             Ok(()) => tracing::info!(attempt, "sidecar iteration ended"),
             Err(e) => tracing::error!(error = %e, attempt, "sidecar iteration failed"),
         }
@@ -236,6 +242,7 @@ impl Drop for ChildGuard {
 #[cfg(windows)]
 async fn run_once<R: Runtime>(
     app: &AppHandle<R>,
+    cfg: &SupervisorConfig,
     attempt: u32,
     creds: Option<&TwitchCreds>,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -298,11 +305,12 @@ async fn run_once<R: Runtime>(
     }
 
     // Disarm the kill-on-drop: the CommandEvent stream now owns the
-    // child's lifecycle. Hold the released CommandChild in `_child` for
+    // child's lifecycle. Hold the released CommandChild in `child` for
     // the rest of the function so its stdin stays open for the duration
     // of the session (dropping it mid-session would close stdin and
-    // strand the control protocol).
-    let _child = child.release();
+    // strand the control protocol). It also lets us force-kill on a
+    // heartbeat timeout without waiting for Tauri's Drop path.
+    let child = child.release();
 
     // EmoteIndex lives for the lifetime of this sidecar run; a fresh one is
     // built on every respawn. Shared by the control-plane reader (which
@@ -320,29 +328,61 @@ async fn run_once<R: Runtime>(
 
     emit_status(app, "running", attempt, None);
 
-    while let Some(event) = rx.recv().await {
-        match event {
-            CommandEvent::Stdout(bytes) => {
-                handle_sidecar_stdout(&bytes, app, &emote_index);
+    // Heartbeat deadline tracking. The sidecar emits a heartbeat every
+    // 1 s (see `src-sidecar/internal/sidecar/sidecar.go::heartbeatPeriod`);
+    // if `cfg.heartbeat_timeout` elapses without one, the child is
+    // considered wedged and we force-kill it so the outer supervise loop
+    // respawns a fresh process. Initial deadline starts from bootstrap so
+    // a sidecar that never emits a first heartbeat still gets killed.
+    let mut last_heartbeat = Instant::now();
+    loop {
+        let deadline = last_heartbeat + cfg.heartbeat_timeout;
+        tokio::select! {
+            maybe_event = rx.recv() => {
+                let Some(event) = maybe_event else { break };
+                match event {
+                    CommandEvent::Stdout(bytes) => {
+                        if handle_sidecar_stdout(&bytes, app, &emote_index) {
+                            last_heartbeat = Instant::now();
+                        }
+                    }
+                    CommandEvent::Stderr(bytes) => {
+                        tracing::debug!(line = %String::from_utf8_lossy(&bytes), "sidecar stderr");
+                    }
+                    CommandEvent::Error(msg) => {
+                        // Transient stream error; the child may still be alive.
+                        // Log and keep reading until we see Terminated (or the
+                        // stream closes on its own).
+                        tracing::error!(error = %msg, attempt, "sidecar command stream error");
+                    }
+                    CommandEvent::Terminated(payload) => {
+                        tracing::warn!(code = ?payload.code, attempt, "sidecar terminated");
+                        break;
+                    }
+                    // `CommandEvent` is `#[non_exhaustive]` upstream. Any future
+                    // variant should at least surface at trace level instead of
+                    // silently disappearing.
+                    _ => {
+                        tracing::trace!(attempt, "unhandled sidecar command event variant");
+                    }
+                }
             }
-            CommandEvent::Stderr(bytes) => {
-                tracing::debug!(line = %String::from_utf8_lossy(&bytes), "sidecar stderr");
-            }
-            CommandEvent::Error(msg) => {
-                // Transient stream error; the child may still be alive.
-                // Log and keep reading until we see Terminated (or the
-                // stream closes on its own).
-                tracing::error!(error = %msg, attempt, "sidecar command stream error");
-            }
-            CommandEvent::Terminated(payload) => {
-                tracing::warn!(code = ?payload.code, attempt, "sidecar terminated");
+            _ = tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)) => {
+                let gap_ms = last_heartbeat.elapsed().as_millis() as u64;
+                tracing::error!(
+                    attempt,
+                    gap_ms,
+                    timeout_ms = cfg.heartbeat_timeout.as_millis() as u64,
+                    "heartbeat timeout; killing sidecar to force respawn"
+                );
+                emit_status(app, "unhealthy", attempt, None);
+                if let Err(e) = child.kill() {
+                    tracing::error!(error = %e, "kill after heartbeat timeout failed");
+                }
+                // Fall through to drain the stream until Terminated arrives
+                // so the drain loop gets a clean shutdown and we don't leak
+                // the task.
                 break;
-            }
-            // `CommandEvent` is `#[non_exhaustive]` upstream. Any future
-            // variant should at least surface at trace level instead of
-            // silently disappearing.
-            _ => {
-                tracing::trace!(attempt, "unhandled sidecar command event variant");
             }
         }
     }
@@ -417,18 +457,23 @@ fn drain_and_emit<R: Runtime>(
 /// sidecar buffers multiple JSON objects per write, each object still
 /// parses independently. Empty pieces (trailing newline, blank lines) are
 /// skipped.
+///
+/// Returns `true` if at least one heartbeat was observed in this batch,
+/// which lets the supervisor reset the heartbeat-timeout deadline without
+/// re-parsing each line.
 #[cfg(windows)]
 fn handle_sidecar_stdout<R: Runtime>(
     bytes: &[u8],
     app: &AppHandle<R>,
     emote_index: &Arc<EmoteIndex>,
-) {
+) -> bool {
+    let mut saw_heartbeat = false;
     for line in bytes.split(|b| *b == b'\n') {
         if line.is_empty() {
             continue;
         }
         match parse_sidecar_event(line) {
-            SidecarEvent::Heartbeat => {}
+            SidecarEvent::Heartbeat => saw_heartbeat = true,
             SidecarEvent::EmoteBundle(bundle) => apply_emote_bundle(bundle, app, emote_index),
             SidecarEvent::Other(t) => {
                 tracing::debug!(msg_type = %t, "unhandled sidecar control message");
@@ -438,6 +483,7 @@ fn handle_sidecar_stdout<R: Runtime>(
             }
         }
     }
+    saw_heartbeat
 }
 
 /// Swaps a fresh [`EmoteBundle`] into the supervisor's [`EmoteIndex`] and
@@ -489,6 +535,9 @@ mod tests {
         assert_eq!(cfg.initial_backoff, Duration::from_millis(250));
         assert_eq!(cfg.max_backoff, Duration::from_secs(30));
         assert_eq!(cfg.healthy_threshold, Duration::from_secs(60));
+        // `docs/stability.md` §Sidecar Health: 3 missed heartbeats at
+        // 1 s interval triggers respawn.
+        assert_eq!(cfg.heartbeat_timeout, Duration::from_secs(3));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/sidecar_supervisor.rs
+++ b/apps/desktop/src-tauri/src/sidecar_supervisor.rs
@@ -473,6 +473,19 @@ fn handle_sidecar_stdout<R: Runtime>(
     app: &AppHandle<R>,
     emote_index: &Arc<EmoteIndex>,
 ) -> bool {
+    scan_sidecar_stdout(bytes, |bundle| apply_emote_bundle(bundle, app, emote_index))
+}
+
+/// Pure scan-and-dispatch core of [`handle_sidecar_stdout`]. Splits the
+/// batch on newlines, parses each non-empty piece via
+/// [`parse_sidecar_event`], returns `true` if any line was a heartbeat,
+/// and invokes `on_bundle` for each parsed [`EmoteBundle`]. Factored out
+/// from `handle_sidecar_stdout` so it can be unit-tested without a Tauri
+/// runtime (the AppHandle-dependent work happens inside the closure).
+fn scan_sidecar_stdout<F>(bytes: &[u8], mut on_bundle: F) -> bool
+where
+    F: FnMut(Box<crate::emote_index::EmoteBundle>),
+{
     let mut saw_heartbeat = false;
     for line in bytes.split(|b| *b == b'\n') {
         if line.is_empty() {
@@ -480,7 +493,7 @@ fn handle_sidecar_stdout<R: Runtime>(
         }
         match parse_sidecar_event(line) {
             SidecarEvent::Heartbeat => saw_heartbeat = true,
-            SidecarEvent::EmoteBundle(bundle) => apply_emote_bundle(bundle, app, emote_index),
+            SidecarEvent::EmoteBundle(bundle) => on_bundle(bundle),
             SidecarEvent::Other(t) => {
                 tracing::debug!(msg_type = %t, "unhandled sidecar control message");
             }
@@ -593,5 +606,64 @@ mod tests {
         let v: serde_json::Value = serde_json::to_value(&status).unwrap();
         assert_eq!(v["state"], "backoff");
         assert_eq!(v["backoff_ms"], 4000);
+    }
+
+    const VALID_EMOTE_BUNDLE_LINE: &[u8] = br#"{"type":"emote_bundle","payload":{"twitch_global_emotes":{"provider":"twitch","scope":"global","emotes":[{"id":"1","code":"Kappa","provider":"twitch","url_1x":"https://t/1"}]},"twitch_channel_emotes":{"provider":"twitch","scope":"channel","emotes":[]},"twitch_global_badges":{"scope":"global","badges":[]},"twitch_channel_badges":{"scope":"channel","badges":[]},"seventv_global":{"provider":"7tv","scope":"global","emotes":[]},"seventv_channel":{"provider":"7tv","scope":"channel","emotes":[]},"bttv_global":{"provider":"bttv","scope":"global","emotes":[]},"bttv_channel":{"provider":"bttv","scope":"channel","emotes":[]},"ffz_global":{"provider":"ffz","scope":"global","emotes":[]},"ffz_channel":{"provider":"ffz","scope":"channel","emotes":[]}}}"#;
+
+    #[test]
+    fn scan_sidecar_stdout_returns_false_on_empty_input() {
+        assert!(!scan_sidecar_stdout(b"", |_| panic!("no bundle")));
+        assert!(!scan_sidecar_stdout(b"\n\n\n", |_| panic!("no bundle")));
+    }
+
+    #[test]
+    fn scan_sidecar_stdout_detects_single_heartbeat() {
+        let line = br#"{"type":"heartbeat","payload":{"ts_ms":1,"counter":1}}"#;
+        assert!(scan_sidecar_stdout(line, |_| panic!("no bundle")));
+    }
+
+    #[test]
+    fn scan_sidecar_stdout_detects_heartbeat_in_multi_line_batch() {
+        let mut batch = Vec::new();
+        batch.extend_from_slice(b"garbage line\n");
+        batch.extend_from_slice(br#"{"type":"future_thing","payload":{}}"#);
+        batch.push(b'\n');
+        batch.extend_from_slice(br#"{"type":"heartbeat","payload":{"ts_ms":1,"counter":1}}"#);
+        batch.push(b'\n');
+        assert!(scan_sidecar_stdout(&batch, |_| panic!("no bundle")));
+    }
+
+    #[test]
+    fn scan_sidecar_stdout_reports_false_when_only_non_heartbeat_events() {
+        let mut batch = Vec::new();
+        batch.extend_from_slice(b"not json\n");
+        batch.extend_from_slice(br#"{"type":"future_thing","payload":{}}"#);
+        assert!(!scan_sidecar_stdout(&batch, |_| panic!("no bundle")));
+    }
+
+    #[test]
+    fn scan_sidecar_stdout_dispatches_emote_bundle_and_tracks_heartbeat() {
+        let mut batch = Vec::new();
+        batch.extend_from_slice(VALID_EMOTE_BUNDLE_LINE);
+        batch.push(b'\n');
+        batch.extend_from_slice(br#"{"type":"heartbeat","payload":{"ts_ms":2,"counter":2}}"#);
+
+        let mut bundles = 0_usize;
+        let saw_heartbeat = scan_sidecar_stdout(&batch, |bundle| {
+            assert_eq!(bundle.total_emotes(), 1);
+            bundles += 1;
+        });
+
+        assert!(saw_heartbeat);
+        assert_eq!(bundles, 1);
+    }
+
+    #[test]
+    fn scan_sidecar_stdout_skips_empty_segments_between_newlines() {
+        let mut batch = Vec::new();
+        batch.extend_from_slice(b"\n\n");
+        batch.extend_from_slice(br#"{"type":"heartbeat","payload":{"ts_ms":3,"counter":3}}"#);
+        batch.extend_from_slice(b"\n\n");
+        assert!(scan_sidecar_stdout(&batch, |_| panic!("no bundle")));
     }
 }

--- a/apps/desktop/src-tauri/src/sidecar_supervisor.rs
+++ b/apps/desktop/src-tauri/src/sidecar_supervisor.rs
@@ -309,8 +309,10 @@ async fn run_once<R: Runtime>(
     // the rest of the function so its stdin stays open for the duration
     // of the session (dropping it mid-session would close stdin and
     // strand the control protocol). It also lets us force-kill on a
-    // heartbeat timeout without waiting for Tauri's Drop path.
-    let child = child.release();
+    // heartbeat timeout without waiting for Tauri's Drop path. Wrapped
+    // in Option so the heartbeat-timeout branch can take ownership for
+    // the `kill(self)` call.
+    let mut child = Some(child.release());
 
     // EmoteIndex lives for the lifetime of this sidecar run; a fresh one is
     // built on every respawn. Shared by the control-plane reader (which
@@ -335,6 +337,7 @@ async fn run_once<R: Runtime>(
     // respawns a fresh process. Initial deadline starts from bootstrap so
     // a sidecar that never emits a first heartbeat still gets killed.
     let mut last_heartbeat = Instant::now();
+    let mut killed = false;
     loop {
         let deadline = last_heartbeat + cfg.heartbeat_timeout;
         tokio::select! {
@@ -367,7 +370,7 @@ async fn run_once<R: Runtime>(
                     }
                 }
             }
-            _ = tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)) => {
+            _ = tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)), if !killed => {
                 let gap_ms = last_heartbeat.elapsed().as_millis() as u64;
                 tracing::error!(
                     attempt,
@@ -376,13 +379,16 @@ async fn run_once<R: Runtime>(
                     "heartbeat timeout; killing sidecar to force respawn"
                 );
                 emit_status(app, "unhealthy", attempt, None);
-                if let Err(e) = child.kill() {
-                    tracing::error!(error = %e, "kill after heartbeat timeout failed");
+                if let Some(c) = child.take() {
+                    if let Err(e) = c.kill() {
+                        tracing::error!(error = %e, "kill after heartbeat timeout failed");
+                    }
                 }
-                // Fall through to drain the stream until Terminated arrives
-                // so the drain loop gets a clean shutdown and we don't leak
-                // the task.
-                break;
+                // Disable the timeout branch and keep draining events so the
+                // outer supervise loop doesn't race a respawn against the
+                // dying child. We exit when we see Terminated or the stream
+                // closes on its own.
+                killed = true;
             }
         }
     }

--- a/apps/desktop/src-tauri/src/sidecar_supervisor.rs
+++ b/apps/desktop/src-tauri/src/sidecar_supervisor.rs
@@ -330,22 +330,73 @@ async fn run_once<R: Runtime>(
 
     emit_status(app, "running", attempt, None);
 
-    // Heartbeat deadline tracking. The sidecar emits a heartbeat every
-    // 1 s (see `src-sidecar/internal/sidecar/sidecar.go::heartbeatPeriod`);
-    // if `cfg.heartbeat_timeout` elapses without one, the child is
-    // considered wedged and we force-kill it so the outer supervise loop
-    // respawns a fresh process. Initial deadline starts from bootstrap so
-    // a sidecar that never emits a first heartbeat still gets killed.
+    run_event_loop(
+        &mut rx,
+        cfg.heartbeat_timeout,
+        attempt,
+        |bytes| handle_sidecar_stdout(bytes, app, &emote_index),
+        || {
+            if let Some(c) = child.take() {
+                if let Err(e) = c.kill() {
+                    tracing::error!(error = %e, "kill after heartbeat timeout failed");
+                }
+            }
+        },
+        || emit_status(app, "unhealthy", attempt, None),
+    )
+    .await;
+
+    // Release-store the shutdown flag; the drain loop does an Acquire-load
+    // at the top of every iteration and exits after one final drain pass
+    // so no pending messages are dropped on the floor.
+    shutdown.store(true, Ordering::Release);
+    if let Err(e) = drain_handle.await {
+        tracing::error!(error = %e, "drain task join failed");
+    }
+
+    emit_status(app, "terminated", attempt, None);
+    Ok(())
+}
+
+/// Drives the CommandEvent stream until the sidecar terminates or its
+/// heartbeat stream goes silent for longer than `heartbeat_timeout`.
+///
+/// Extracted from [`run_once`] so the heartbeat/respawn logic can be
+/// tested without a real Tauri runtime. Callers inject:
+/// * `on_stdout`: parses each stdout batch and returns `true` if any
+///   line was a heartbeat (resets the timeout deadline).
+/// * `on_timeout_kill`: force-kills the child process. Called at most
+///   once, the first time the heartbeat deadline elapses.
+/// * `on_unhealthy`: emits the "unhealthy" sidecar status so the
+///   frontend can render a respawn indicator.
+///
+/// After the first timeout fires the timeout branch is disabled and the
+/// loop keeps draining events so the outer supervise loop doesn't race a
+/// respawn against the dying child: we exit only on `Terminated` or when
+/// the event stream closes on its own.
+#[cfg(windows)]
+async fn run_event_loop<F, K, U>(
+    rx: &mut tauri::async_runtime::Receiver<CommandEvent>,
+    heartbeat_timeout: Duration,
+    attempt: u32,
+    mut on_stdout: F,
+    mut on_timeout_kill: K,
+    mut on_unhealthy: U,
+) where
+    F: FnMut(&[u8]) -> bool,
+    K: FnMut(),
+    U: FnMut(),
+{
     let mut last_heartbeat = Instant::now();
     let mut killed = false;
     loop {
-        let deadline = last_heartbeat + cfg.heartbeat_timeout;
+        let deadline = last_heartbeat + heartbeat_timeout;
         tokio::select! {
             maybe_event = rx.recv() => {
                 let Some(event) = maybe_event else { break };
                 match event {
                     CommandEvent::Stdout(bytes) => {
-                        if handle_sidecar_stdout(&bytes, app, &emote_index) {
+                        if on_stdout(&bytes) {
                             last_heartbeat = Instant::now();
                         }
                     }
@@ -375,34 +426,15 @@ async fn run_once<R: Runtime>(
                 tracing::error!(
                     attempt,
                     gap_ms,
-                    timeout_ms = cfg.heartbeat_timeout.as_millis() as u64,
+                    timeout_ms = heartbeat_timeout.as_millis() as u64,
                     "heartbeat timeout; killing sidecar to force respawn"
                 );
-                emit_status(app, "unhealthy", attempt, None);
-                if let Some(c) = child.take() {
-                    if let Err(e) = c.kill() {
-                        tracing::error!(error = %e, "kill after heartbeat timeout failed");
-                    }
-                }
-                // Disable the timeout branch and keep draining events so the
-                // outer supervise loop doesn't race a respawn against the
-                // dying child. We exit when we see Terminated or the stream
-                // closes on its own.
+                on_unhealthy();
+                on_timeout_kill();
                 killed = true;
             }
         }
     }
-
-    // Release-store the shutdown flag; the drain loop does an Acquire-load
-    // at the top of every iteration and exits after one final drain pass
-    // so no pending messages are dropped on the floor.
-    shutdown.store(true, Ordering::Release);
-    if let Err(e) = drain_handle.await {
-        tracing::error!(error = %e, "drain task join failed");
-    }
-
-    emit_status(app, "terminated", attempt, None);
-    Ok(())
 }
 
 #[cfg(windows)]
@@ -665,5 +697,244 @@ mod tests {
         batch.extend_from_slice(br#"{"type":"heartbeat","payload":{"ts_ms":3,"counter":3}}"#);
         batch.extend_from_slice(b"\n\n");
         assert!(scan_sidecar_stdout(&batch, |_| panic!("no bundle")));
+    }
+
+    // -- run_event_loop tests --------------------------------------------
+    //
+    // These drive the real event loop with an mpsc channel of
+    // `CommandEvent`s under `tokio::time::pause()`, letting us assert the
+    // heartbeat-respawn behaviour deterministically without a Tauri
+    // runtime or a real child process.
+
+    use std::cell::Cell;
+    use std::rc::Rc;
+    use tauri_plugin_shell::process::TerminatedPayload;
+    use tokio::sync::mpsc;
+
+    const HB_LINE: &[u8] = br#"{"type":"heartbeat","payload":{"ts_ms":1,"counter":1}}"#;
+
+    #[derive(Default)]
+    struct LoopProbe {
+        stdout_calls: Rc<Cell<u32>>,
+        kill_calls: Rc<Cell<u32>>,
+        unhealthy_calls: Rc<Cell<u32>>,
+    }
+
+    impl LoopProbe {
+        fn stdout(&self) -> u32 {
+            self.stdout_calls.get()
+        }
+        fn kills(&self) -> u32 {
+            self.kill_calls.get()
+        }
+        fn unhealthy(&self) -> u32 {
+            self.unhealthy_calls.get()
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn run_event_loop_exits_on_terminated_event() {
+        let (tx, mut rx) = mpsc::channel::<CommandEvent>(4);
+        let probe = LoopProbe::default();
+        let stdout_calls = probe.stdout_calls.clone();
+        let kill_calls = probe.kill_calls.clone();
+        let unhealthy_calls = probe.unhealthy_calls.clone();
+
+        tx.send(CommandEvent::Terminated(TerminatedPayload {
+            code: Some(0),
+            signal: None,
+        }))
+        .await
+        .unwrap();
+
+        run_event_loop(
+            &mut rx,
+            Duration::from_secs(60),
+            1,
+            |_| {
+                stdout_calls.set(stdout_calls.get() + 1);
+                false
+            },
+            || kill_calls.set(kill_calls.get() + 1),
+            || unhealthy_calls.set(unhealthy_calls.get() + 1),
+        )
+        .await;
+
+        assert_eq!(probe.stdout(), 0);
+        assert_eq!(probe.kills(), 0);
+        assert_eq!(probe.unhealthy(), 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn run_event_loop_exits_when_stream_closes() {
+        let (tx, mut rx) = mpsc::channel::<CommandEvent>(4);
+        drop(tx); // close the channel immediately
+        let probe = LoopProbe::default();
+        let kill_calls = probe.kill_calls.clone();
+        let unhealthy_calls = probe.unhealthy_calls.clone();
+
+        run_event_loop(
+            &mut rx,
+            Duration::from_secs(60),
+            1,
+            |_| false,
+            || kill_calls.set(kill_calls.get() + 1),
+            || unhealthy_calls.set(unhealthy_calls.get() + 1),
+        )
+        .await;
+
+        assert_eq!(probe.kills(), 0);
+        assert_eq!(probe.unhealthy(), 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn run_event_loop_kills_on_heartbeat_timeout() {
+        let (tx, mut rx) = mpsc::channel::<CommandEvent>(4);
+        let probe = LoopProbe::default();
+        let kill_calls = probe.kill_calls.clone();
+        let unhealthy_calls = probe.unhealthy_calls.clone();
+
+        // Drive the loop and feed a Terminated after the kill fires so it
+        // exits cleanly. spawn_local isn't available on a single-threaded
+        // runtime without LocalSet, so send the event synchronously after
+        // `tokio::time::advance`.
+        let timeout = Duration::from_secs(3);
+        let loop_fut = run_event_loop(
+            &mut rx,
+            timeout,
+            1,
+            |_| false,
+            || kill_calls.set(kill_calls.get() + 1),
+            || unhealthy_calls.set(unhealthy_calls.get() + 1),
+        );
+
+        tokio::pin!(loop_fut);
+
+        // Advance past the heartbeat deadline; the select! should pick the
+        // timeout branch.
+        tokio::select! {
+            _ = &mut loop_fut => panic!("loop exited before timeout"),
+            _ = tokio::time::sleep(timeout + Duration::from_millis(100)) => {}
+        }
+
+        // Now close the stream so the loop exits.
+        drop(tx);
+        loop_fut.await;
+
+        assert_eq!(probe.kills(), 1);
+        assert_eq!(probe.unhealthy(), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn run_event_loop_heartbeat_resets_deadline() {
+        let (tx, mut rx) = mpsc::channel::<CommandEvent>(16);
+        let probe = LoopProbe::default();
+        let stdout_calls = probe.stdout_calls.clone();
+        let kill_calls = probe.kill_calls.clone();
+
+        let timeout = Duration::from_secs(3);
+
+        // Pre-load two heartbeat batches, each followed by a ~2s pause.
+        // After the second heartbeat we send Terminated so the loop exits
+        // without the timeout branch ever firing.
+        tx.send(CommandEvent::Stdout(HB_LINE.to_vec()))
+            .await
+            .unwrap();
+        tx.send(CommandEvent::Stdout(HB_LINE.to_vec()))
+            .await
+            .unwrap();
+        tx.send(CommandEvent::Terminated(TerminatedPayload {
+            code: Some(0),
+            signal: None,
+        }))
+        .await
+        .unwrap();
+
+        run_event_loop(
+            &mut rx,
+            timeout,
+            1,
+            |bytes| {
+                stdout_calls.set(stdout_calls.get() + 1);
+                // Forward to the pure scanner so heartbeat detection is real.
+                scan_sidecar_stdout(bytes, |_| {})
+            },
+            || kill_calls.set(kill_calls.get() + 1),
+            || {},
+        )
+        .await;
+
+        assert_eq!(probe.stdout(), 2);
+        assert_eq!(probe.kills(), 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn run_event_loop_logs_stderr_and_error_without_affecting_state() {
+        let (tx, mut rx) = mpsc::channel::<CommandEvent>(8);
+        let probe = LoopProbe::default();
+        let kill_calls = probe.kill_calls.clone();
+
+        tx.send(CommandEvent::Stderr(b"some warning\n".to_vec()))
+            .await
+            .unwrap();
+        tx.send(CommandEvent::Error("stream hiccup".into()))
+            .await
+            .unwrap();
+        tx.send(CommandEvent::Terminated(TerminatedPayload {
+            code: Some(1),
+            signal: None,
+        }))
+        .await
+        .unwrap();
+
+        run_event_loop(
+            &mut rx,
+            Duration::from_secs(60),
+            7,
+            |_| false,
+            || kill_calls.set(kill_calls.get() + 1),
+            || {},
+        )
+        .await;
+
+        assert_eq!(probe.kills(), 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn run_event_loop_kills_at_most_once_across_multiple_deadlines() {
+        let (tx, mut rx) = mpsc::channel::<CommandEvent>(4);
+        let probe = LoopProbe::default();
+        let kill_calls = probe.kill_calls.clone();
+        let unhealthy_calls = probe.unhealthy_calls.clone();
+
+        let timeout = Duration::from_millis(500);
+        let loop_fut = run_event_loop(
+            &mut rx,
+            timeout,
+            1,
+            |_| false,
+            || kill_calls.set(kill_calls.get() + 1),
+            || unhealthy_calls.set(unhealthy_calls.get() + 1),
+        );
+        tokio::pin!(loop_fut);
+
+        // Let the timeout branch fire once.
+        tokio::select! {
+            _ = &mut loop_fut => panic!("loop exited before timeout"),
+            _ = tokio::time::sleep(timeout * 2) => {}
+        }
+
+        // Advance another few timeouts with the stream still open; the
+        // timeout branch is gated on `!killed` so it must not fire again.
+        tokio::select! {
+            _ = &mut loop_fut => panic!("loop exited unexpectedly"),
+            _ = tokio::time::sleep(timeout * 5) => {}
+        }
+
+        drop(tx);
+        loop_fut.await;
+
+        assert_eq!(probe.kills(), 1);
+        assert_eq!(probe.unhealthy(), 1);
     }
 }


### PR DESCRIPTION
Closes the `docs/stability.md` §Sidecar Health gap: heartbeats flowed but nothing monitored them.

Adds a deadline-based heartbeat watcher to the supervisor's event loop. If `cfg.heartbeat_timeout` (default 3 s, per spec: 3 missed heartbeats at 1 s interval) elapses without a heartbeat, the supervisor emits `sidecar_status={state:'unhealthy'}`, force-kills the child, and falls out of `run_once` so the outer supervise loop respawns a fresh process with the usual exponential backoff.

- `SupervisorConfig` gains `heartbeat_timeout: Duration` (default 3 s); tests can override for faster test timings when we get an integration harness.
- `handle_sidecar_stdout` now returns `bool` indicating whether at least one heartbeat was observed in the batch, so the supervisor resets the deadline without re-parsing.
- `run_once` takes `&SupervisorConfig` so production timings and any future test timings flow through the same path.

Verified: `cargo test`, `cargo clippy --all-targets -- -D warnings` clean.