### PR TITLE
fix: emotes, chat perf, and send UX

### DIFF
--- a/apps/desktop/src-sidecar/internal/emotes/fetcher.go
+++ b/apps/desktop/src-sidecar/internal/emotes/fetcher.go
@@ -221,5 +221,30 @@ func (f *Fetcher) Fetch(ctx context.Context, broadcasterID string) Bundle {
 	wg.Wait()
 	b.YouTubeBadges = youtubeBadges
 	b.KickBadges = kickBadges
+
+	// Go serializes nil slices as JSON `null`; the Rust host expects `[]`.
+	// Ensure every slice is non-nil so the emote_bundle contract holds.
+	ensureEmoteSlice(&b.TwitchGlobalEmotes)
+	ensureEmoteSlice(&b.TwitchChannelEmotes)
+	ensureEmoteSlice(&b.SevenTVGlobal)
+	ensureEmoteSlice(&b.SevenTVChannel)
+	ensureEmoteSlice(&b.BTTVGlobal)
+	ensureEmoteSlice(&b.BTTVChannel)
+	ensureEmoteSlice(&b.FFZGlobal)
+	ensureEmoteSlice(&b.FFZChannel)
+	ensureBadgeSlice(&b.TwitchGlobalBadges)
+	ensureBadgeSlice(&b.TwitchChannelBadges)
 	return b
+}
+
+func ensureEmoteSlice(s *EmoteSet) {
+	if s.Emotes == nil {
+		s.Emotes = []Emote{}
+	}
+}
+
+func ensureBadgeSlice(s *BadgeSet) {
+	if s.Badges == nil {
+		s.Badges = []Badge{}
+	}
 }

--- a/apps/desktop/src-sidecar/internal/emotes/fetcher_test.go
+++ b/apps/desktop/src-sidecar/internal/emotes/fetcher_test.go
@@ -2,6 +2,7 @@ package emotes
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -117,6 +118,36 @@ func TestFetcher_NilProvidersSkipped(t *testing.T) {
 	if len(b.KickBadges.Badges) != 4 {
 		t.Errorf("kick badges = %d, want 4 even with nil providers", len(b.KickBadges.Badges))
 	}
+}
+
+// Verify that empty emote/badge slices serialize as JSON `[]` not `null`.
+// The Rust host's serde deserializer cannot parse `null` as Vec, so nil
+// slices in the Go bundle would break the entire emote pipeline.
+func TestFetcher_NilSlicesSerializeAsEmptyArray(t *testing.T) {
+	f := &Fetcher{} // all providers nil → zero-valued EmoteSets
+	b := f.Fetch(context.Background(), "42")
+
+	raw, err := json.Marshal(b)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(raw)
+
+	// Ensure no `"emotes":null` or `"badges":null` appear.
+	for _, needle := range []string{`"emotes":null`, `"badges":null`} {
+		if idx := findSubstring(s, needle); idx >= 0 {
+			t.Errorf("found %q at offset %d in marshalled bundle", needle, idx)
+		}
+	}
+}
+
+func findSubstring(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
 }
 
 func TestFetcher_RecordsProviderErrors(t *testing.T) {

--- a/apps/desktop/src-tauri/src/emote_index.rs
+++ b/apps/desktop/src-tauri/src/emote_index.rs
@@ -14,8 +14,20 @@ use std::sync::Arc;
 use aho_corasick::{AhoCorasick, AhoCorasickBuilder, MatchKind};
 use arc_swap::ArcSwap;
 use rustc_hash::FxHashMap;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use tracing::warn;
+
+/// Deserializes `null` as `T::default()`. Go serializes nil slices as JSON
+/// `null` rather than `[]`; `#[serde(default)]` only handles *missing*
+/// fields, so `"emotes": null` would otherwise fail with "expected a
+/// sequence". Combined with `#[serde(default)]` this covers both cases.
+fn null_to_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Default + Deserialize<'de>,
+{
+    Ok(Option::<T>::deserialize(deserializer)?.unwrap_or_default())
+}
 
 /// Emote provider. Mirrors `sidecar/internal/emotes.Provider`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -64,7 +76,7 @@ pub struct EmoteMeta {
 /// them; serde's default behaviour already does so silently.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct EmoteSet {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "null_to_default")]
     pub emotes: Vec<EmoteMeta>,
 }
 
@@ -90,7 +102,7 @@ pub struct Badge {
 /// for why the metadata fields are omitted.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct BadgeSet {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "null_to_default")]
     pub badges: Vec<Badge>,
 }
 
@@ -639,5 +651,39 @@ mod tests {
             "https://cdn/mod/1x"
         );
         assert_eq!(reserialized["errors"][0]["error"], "boom");
+    }
+
+    #[test]
+    fn bundle_deserializes_null_emote_slices() {
+        // Go serializes nil slices as JSON `null`. The Rust side must treat
+        // `null` as an empty vec so the whole bundle doesn't fail to parse.
+        let raw = r#"{
+            "twitch_global_emotes": {"provider":"twitch","scope":"global","emotes":[
+                {"id":"1","code":"Kappa","provider":"twitch","url_1x":"https://t/1"}
+            ]},
+            "twitch_channel_emotes": {"provider":"twitch","scope":"channel","emotes":null},
+            "twitch_global_badges": {"scope":"global","badges":[]},
+            "twitch_channel_badges": {"scope":"channel","badges":null},
+            "seventv_global": {"provider":"7tv","scope":"global","emotes":[
+                {"id":"2","code":"LULW","provider":"7tv","url_1x":"https://s/2"}
+            ]},
+            "seventv_channel": {"provider":"7tv","scope":"channel","emotes":null},
+            "bttv_global": {"provider":"bttv","scope":"global","emotes":null},
+            "bttv_channel": {"provider":"bttv","scope":"channel","emotes":null},
+            "ffz_global": {"provider":"ffz","scope":"global","emotes":null},
+            "ffz_channel": {"provider":"ffz","scope":"channel","emotes":null}
+        }"#;
+        let b: EmoteBundle = serde_json::from_str(raw).unwrap();
+        assert_eq!(b.total_emotes(), 2);
+        assert!(b.bttv_channel.emotes.is_empty());
+        assert!(b.twitch_channel_badges.badges.is_empty());
+
+        // Verify the index can load from the bundle and scan works.
+        let idx = EmoteIndex::new();
+        idx.load_bundle(b);
+        let mut out = Vec::new();
+        idx.scan_into("hello LULW world", &mut out);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].emote.code.as_ref(), "LULW");
     }
 }

--- a/apps/desktop/src-tauri/src/host.rs
+++ b/apps/desktop/src-tauri/src/host.rs
@@ -516,6 +516,53 @@ mod tests {
         assert_eq!(span.emote.code.as_ref(), "Kappa");
     }
 
+    /// Verify the JSON that Tauri sends to the frontend includes emote_spans
+    /// with the expected shape, so the TypeScript `ChatMessage` type matches.
+    #[test]
+    fn emote_spans_survive_json_serialization() {
+        use crate::emote_index::{EmoteMeta, Provider};
+
+        let viewer = tag_twitch(br##"{
+            "metadata": {"message_id":"m","message_type":"notification","message_timestamp":"2023-11-06T18:11:47.492Z"},
+            "payload": {
+                "subscription": {"type":"channel.chat.message"},
+                "event": {
+                    "chatter_user_id":"1","chatter_user_login":"u","chatter_user_name":"U",
+                    "message_id":"mid","message":{"text":"hello Kappa world"}
+                }
+            }
+        }"##);
+
+        let idx = EmoteIndex::new();
+        idx.load([EmoteMeta {
+            id: "25".into(),
+            code: "Kappa".into(),
+            provider: Provider::Twitch,
+            url_1x: "https://cdn/Kappa/1x".into(),
+            url_2x: "https://cdn/Kappa/2x".into(),
+            url_4x: "https://cdn/Kappa/4x".into(),
+            width: 28,
+            height: 28,
+            animated: false,
+            zero_width: false,
+        }]);
+
+        let mut batch = Vec::new();
+        parse_batch(std::slice::from_ref(&viewer), &mut batch, &idx);
+        assert_eq!(batch.len(), 1);
+
+        let json = serde_json::to_value(&batch[0]).unwrap();
+        let spans = json["emote_spans"].as_array().unwrap();
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0]["start"], 6);
+        assert_eq!(spans[0]["end"], 11);
+        assert_eq!(spans[0]["emote"]["code"], "Kappa");
+        assert_eq!(spans[0]["emote"]["url_1x"], "https://cdn/Kappa/1x");
+        assert_eq!(spans[0]["emote"]["provider"], "twitch");
+        assert_eq!(spans[0]["emote"]["width"], 28);
+        assert_eq!(spans[0]["emote"]["height"], 28);
+    }
+
     #[test]
     fn parse_batch_routes_youtube_messages() {
         let yt_msg = tag_youtube(br##"{"id":"yt-1","snippet":{"type":"TEXT_MESSAGE_EVENT","published_at":"2024-01-01T00:00:00Z","display_message":"hello from yt","text_message_details":{"message_text":"hello from yt"}},"author_details":{"channel_id":"UC123","display_name":"YTUser","is_chat_owner":false,"is_chat_moderator":false,"is_chat_sponsor":false}}"##);

--- a/apps/desktop/src/components/ChatFeed.tsx
+++ b/apps/desktop/src/components/ChatFeed.tsx
@@ -99,9 +99,15 @@ interface PositionedMessage {
   height: number;
 }
 
+interface CachedEntry {
+  prepared: PreparedMessage;
+  height: number;
+  measuredWidth: number;
+}
+
 const ChatFeed: Component = () => {
   let containerRef: HTMLDivElement | undefined;
-  const preparedCache = new Map<number, PreparedMessage>();
+  const entryCache = new Map<number, CachedEntry>();
   let lastBadgeRev = 0;
 
   const [width, setWidth] = createSignal(0);
@@ -143,11 +149,11 @@ const ChatFeed: Component = () => {
     const liveStart = v.start;
     const liveEnd = v.start + v.count;
 
-    for (const key of preparedCache.keys()) {
-      if (key < liveStart) preparedCache.delete(key);
+    for (const key of entryCache.keys()) {
+      if (key < liveStart) entryCache.delete(key);
     }
     if (rev !== lastBadgeRev) {
-      preparedCache.clear();
+      entryCache.clear();
       lastBadgeRev = rev;
     }
 
@@ -157,14 +163,24 @@ const ChatFeed: Component = () => {
     for (let mono = liveStart; mono < liveEnd; mono++) {
       const msg = getMessage(mono);
       if (!msg) continue;
-      let prepared = preparedCache.get(mono);
-      if (prepared === undefined) {
-        prepared = prepareMessage(msg, resolveBadge);
-        preparedCache.set(mono, prepared);
+      let entry = entryCache.get(mono);
+      if (entry === undefined || entry.measuredWidth !== w) {
+        const prepared =
+          entry !== undefined
+            ? entry.prepared
+            : prepareMessage(msg, resolveBadge);
+        const height = measureMessageHeight(prepared.prepared, w);
+        entry = { prepared, height, measuredWidth: w };
+        entryCache.set(mono, entry);
       }
-      const height = measureMessageHeight(prepared.prepared, w);
-      messages[writeIdx++] = { monoIndex: mono, msg, prepared, top: y, height };
-      y += height;
+      messages[writeIdx++] = {
+        monoIndex: mono,
+        msg,
+        prepared: entry.prepared,
+        top: y,
+        height: entry.height,
+      };
+      y += entry.height;
     }
     messages.length = writeIdx;
     return { messages, totalHeight: y };

--- a/apps/desktop/src/components/MessageInput.tsx
+++ b/apps/desktop/src/components/MessageInput.tsx
@@ -19,6 +19,7 @@ const MessageInput: Component = () => {
   const [text, setText] = createSignal("");
   const [status, setStatus] = createSignal<string | null>(null);
   let inputEl: HTMLInputElement | undefined;
+  let sendSeq = 0;
 
   const submit = () => {
     const payload = normalizeOutgoing(text());
@@ -30,11 +31,14 @@ const MessageInput: Component = () => {
       setStatus(`Message exceeds ${MAX_CHAT_MESSAGE_BYTES} bytes.`);
       return;
     }
+    const seq = ++sendSeq;
     setText("");
     setStatus(null);
     inputEl?.focus();
 
     sendMessage(payload).catch((raw) => {
+      if (seq !== sendSeq) return;
+      if (!text()) setText(payload);
       const err = toSendError(raw);
       setStatus(
         typeof err === "string"

--- a/apps/desktop/src/components/MessageInput.tsx
+++ b/apps/desktop/src/components/MessageInput.tsx
@@ -18,11 +18,9 @@ import {
 const MessageInput: Component = () => {
   const [text, setText] = createSignal("");
   const [status, setStatus] = createSignal<string | null>(null);
-  const [pending, setPending] = createSignal(false);
   let inputEl: HTMLInputElement | undefined;
 
-  const submit = async () => {
-    if (pending()) return;
+  const submit = () => {
     const payload = normalizeOutgoing(text());
     if (!payload) {
       setStatus("Message is empty.");
@@ -32,22 +30,18 @@ const MessageInput: Component = () => {
       setStatus(`Message exceeds ${MAX_CHAT_MESSAGE_BYTES} bytes.`);
       return;
     }
-    setPending(true);
+    setText("");
     setStatus(null);
-    try {
-      await sendMessage(payload);
-      setText("");
-      inputEl?.focus();
-    } catch (raw) {
+    inputEl?.focus();
+
+    sendMessage(payload).catch((raw) => {
       const err = toSendError(raw);
       setStatus(
         typeof err === "string"
           ? err
           : formatSendError(err as SendMessageError),
       );
-    } finally {
-      setPending(false);
-    }
+    });
   };
 
   const onKeyDown = (e: KeyboardEvent) => {
@@ -80,7 +74,6 @@ const MessageInput: Component = () => {
           aria-label="Send a chat message"
           value={text()}
           placeholder="Send a message"
-          disabled={pending()}
           onInput={(e) => setText(e.currentTarget.value)}
           onKeyDown={onKeyDown}
           style={{
@@ -98,7 +91,7 @@ const MessageInput: Component = () => {
         />
         <button
           type="button"
-          disabled={pending() || normalizeOutgoing(text()) === null}
+          disabled={normalizeOutgoing(text()) === null}
           onClick={() => void submit()}
           style={{
             "background-color": "#9147ff",
@@ -108,11 +101,10 @@ const MessageInput: Component = () => {
             padding: "6px 14px",
             "font-weight": 600,
             "font-size": "13px",
-            cursor: pending() ? "default" : "pointer",
-            opacity: pending() ? 0.6 : 1,
+            cursor: "pointer",
           }}
         >
-          {pending() ? "Sending" : "Chat"}
+          Chat
         </button>
       </div>
       <Show when={status()}>


### PR DESCRIPTION
- Fix emote index deserialization: Go nil slices serialize as JSON `null`, which broke serde on the Rust side. Added `null_to_default` deserializer for Vec fields on EmoteMeta, plus `ensureEmoteSlice`/`ensureBadgeSlice` on the Go side to guarantee empty arrays.
- Cache message height measurements: the layout memo was calling `measureRichInlineStats` (canvas text measurement) for every message in the ring buffer on every frame. Heights are now cached and only remeasured on width change.
- Non-blocking message send: input clears instantly and focus stays on the text field instead of blocking for the full Helix round-trip.