### PR TITLE
feat: optimistic message rendering with reconcile

### DIFF
--- a/apps/desktop/src-tauri/src/host.rs
+++ b/apps/desktop/src-tauri/src/host.rs
@@ -330,11 +330,10 @@ pub struct SendChatResult {
     #[serde(default)]
     pub request_id: u64,
     pub ok: bool,
-    /// Helix-assigned id for a successfully accepted message. Currently
-    /// surfaced into `send_chat_result` for future echo-suppression /
-    /// optimistic-render confirmation; not consumed by the dispatcher
-    /// itself.
-    #[allow(dead_code)]
+    /// Helix-assigned id for a successfully accepted message. Surfaced
+    /// to the frontend by `twitch_send_message` so the optimistic
+    /// renderer can correlate the locally-inserted pending message with
+    /// the authoritative EventSub echo.
     #[serde(default)]
     pub message_id: String,
     #[serde(default)]

--- a/apps/desktop/src-tauri/src/sidecar_commands.rs
+++ b/apps/desktop/src-tauri/src/sidecar_commands.rs
@@ -266,9 +266,11 @@ impl SendCommandError {
         }
     }
 
-    fn from_send_result(r: SendChatResult) -> Result<(), Self> {
+    fn from_send_result(r: SendChatResult) -> Result<SendChatOk, Self> {
         if r.ok {
-            return Ok(());
+            return Ok(SendChatOk {
+                message_id: r.message_id,
+            });
         }
         if !r.drop_code.is_empty() || !r.drop_message.is_empty() {
             return Err(Self::Helix {
@@ -289,6 +291,15 @@ impl SendCommandError {
             },
         })
     }
+}
+
+/// Success payload returned to the frontend by `twitch_send_message`.
+/// Carries the Helix-assigned message id so the optimistic renderer
+/// can correlate the locally-inserted pending message with its
+/// authoritative EventSub echo.
+#[derive(Debug, Clone, Serialize)]
+pub struct SendChatOk {
+    pub message_id: String,
 }
 
 /// Maximum chat message length accepted by Twitch Helix POST
@@ -327,7 +338,7 @@ pub async fn twitch_send_message(
     auth: State<'_, AuthState>,
     sender: State<'_, SidecarCommandSender>,
     text: String,
-) -> Result<(), SendCommandError> {
+) -> Result<SendChatOk, SendCommandError> {
     let trimmed = validate_message(&text)?;
 
     let tokens = auth
@@ -388,8 +399,10 @@ mod tests {
     }
 
     #[test]
-    fn from_send_result_ok_is_ok() {
-        assert!(SendCommandError::from_send_result(make_result(true, "", "", "")).is_ok());
+    fn from_send_result_ok_returns_message_id() {
+        let ok = SendCommandError::from_send_result(make_result(true, "", "", ""))
+            .expect("ok result must succeed");
+        assert_eq!(ok.message_id, "abc");
     }
 
     #[test]

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -55,7 +55,7 @@ const App: Component = () => {
             <>
               <Header login={loggedIn().login} />
               <ChatFeed />
-              <MessageInput />
+              <MessageInput login={loggedIn().login} />
             </>
           )}
         </Match>

--- a/apps/desktop/src/components/ChatFeed.tsx
+++ b/apps/desktop/src/components/ChatFeed.tsx
@@ -365,10 +365,27 @@ const ChatFeed: Component = () => {
                 }}
                 title={
                   status() === "failed"
-                    ? `${item.msg.error_message ?? "send failed"} (click to retry)`
+                    ? `${item.msg.error_message ?? "send failed"} (click or press Enter to retry)`
+                    : undefined
+                }
+                role={status() === "failed" ? "button" : undefined}
+                tabIndex={status() === "failed" ? 0 : undefined}
+                aria-label={
+                  status() === "failed"
+                    ? `Send failed: ${item.msg.error_message ?? "unknown error"}. Activate to retry.`
                     : undefined
                 }
                 onClick={status() === "failed" ? onRetry : undefined}
+                onKeyDown={
+                  status() === "failed"
+                    ? (e: KeyboardEvent) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          onRetry();
+                        }
+                      }
+                    : undefined
+                }
               >
                 <Show when={item.prepared.timestamp}>
                   <span

--- a/apps/desktop/src/components/ChatFeed.tsx
+++ b/apps/desktop/src/components/ChatFeed.tsx
@@ -17,10 +17,16 @@ import {
 import { listen } from "@tauri-apps/api/event";
 import {
   addMessages,
+  confirmPendingId,
+  failPending,
   getMessage,
+  messageRevision,
+  retryPending,
   viewport,
   type ChatMessage,
 } from "../stores/chatStore";
+import { sendMessage, type SendMessageError } from "../lib/twitchAuth";
+import { formatSendError, toSendError } from "../lib/messageInput";
 import {
   loadBadgeBundle,
   resolveBadge,
@@ -109,6 +115,7 @@ const ChatFeed: Component = () => {
   let containerRef: HTMLDivElement | undefined;
   const entryCache = new Map<number, CachedEntry>();
   let lastBadgeRev = 0;
+  let lastMessageRev = 0;
 
   const [width, setWidth] = createSignal(0);
   const [viewportHeight, setViewportHeight] = createSignal(0);
@@ -142,6 +149,9 @@ const ChatFeed: Component = () => {
     // Read the badge revision so bundle reloads invalidate the prepared
     // cache and trigger a full re-measure.
     const rev = badgeRevision();
+    // Read the message-mutation revision so reconciled or failed
+    // pending entries re-render with their new content.
+    const msgRev = messageRevision();
     if (!fontsLoaded() || w <= 0 || v.count === 0) {
       return { messages: [], totalHeight: 0 };
     }
@@ -155,6 +165,10 @@ const ChatFeed: Component = () => {
     if (rev !== lastBadgeRev) {
       entryCache.clear();
       lastBadgeRev = rev;
+    }
+    if (msgRev !== lastMessageRev) {
+      entryCache.clear();
+      lastMessageRev = msgRev;
     }
 
     const messages: PositionedMessage[] = new Array(v.count);
@@ -306,76 +320,109 @@ const ChatFeed: Component = () => {
         }}
       >
         <For each={visibleMessages()}>
-          {(item) => (
-            <div
-              style={{
-                position: "absolute",
-                top: 0,
-                left: 0,
-                right: 0,
-                transform: `translateY(${item.top}px)`,
-                height: `${item.height}px`,
-                padding: `${MESSAGE_PADDING_Y / 2}px ${MESSAGE_PADDING_X}px`,
-                "line-height": `${MESSAGE_LINE_HEIGHT}px`,
-                "box-sizing": "border-box",
-                "font-family": MESSAGE_FONT_FAMILY,
-                "font-size": `${MESSAGE_FONT_SIZE_PX}px`,
-                "white-space": "normal",
-                "overflow-wrap": "break-word",
-              }}
-            >
-              <Show when={item.prepared.timestamp}>
+          {(item) => {
+            const status = () => item.msg.status;
+            const onRetry = () => {
+              const localId = item.msg.local_id;
+              if (!localId) return;
+              const text = retryPending(localId);
+              if (!text) return;
+              sendMessage(text).then(
+                (ok) => confirmPendingId(localId, ok.message_id),
+                (raw) => {
+                  const err = toSendError(raw);
+                  failPending(
+                    localId,
+                    typeof err === "string"
+                      ? err
+                      : formatSendError(err as SendMessageError),
+                  );
+                },
+              );
+            };
+            return (
+              <div
+                style={{
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  transform: `translateY(${item.top}px)`,
+                  height: `${item.height}px`,
+                  padding: `${MESSAGE_PADDING_Y / 2}px ${MESSAGE_PADDING_X}px`,
+                  "line-height": `${MESSAGE_LINE_HEIGHT}px`,
+                  "box-sizing": "border-box",
+                  "font-family": MESSAGE_FONT_FAMILY,
+                  "font-size": `${MESSAGE_FONT_SIZE_PX}px`,
+                  "white-space": "normal",
+                  "overflow-wrap": "break-word",
+                  opacity: status() === "pending" ? 0.55 : 1,
+                  "border-left":
+                    status() === "failed"
+                      ? "2px solid #f5a3a3"
+                      : "2px solid transparent",
+                  cursor: status() === "failed" ? "pointer" : "default",
+                }}
+                title={
+                  status() === "failed"
+                    ? `${item.msg.error_message ?? "send failed"} (click to retry)`
+                    : undefined
+                }
+                onClick={status() === "failed" ? onRetry : undefined}
+              >
+                <Show when={item.prepared.timestamp}>
+                  <span
+                    style={{
+                      color: "#6e6e72",
+                      "white-space": "pre",
+                    }}
+                  >
+                    {item.prepared.timestamp}
+                  </span>
+                </Show>
+                <For each={item.prepared.badges}>
+                  {(b) => (
+                    <img
+                      src={b.badge.url_1x}
+                      srcset={
+                        b.badge.url_2x
+                          ? `${b.badge.url_1x} 1x, ${b.badge.url_2x} 2x${
+                              b.badge.url_4x ? `, ${b.badge.url_4x} 4x` : ""
+                            }`
+                          : undefined
+                      }
+                      alt={b.badge.title}
+                      title={b.badge.title}
+                      width={BADGE_SIZE_PX}
+                      height={BADGE_SIZE_PX}
+                      draggable={false}
+                      style={{
+                        display: "inline-block",
+                        "vertical-align": "middle",
+                        "margin-right": `${BADGE_GAP_PX}px`,
+                      }}
+                    />
+                  )}
+                </For>
                 <span
                   style={{
-                    color: "#6e6e72",
-                    "white-space": "pre",
+                    color: normalizeUserColor(item.msg.color),
+                    "font-weight": 700,
+                    // Keep DOM in lockstep with Pretext's `break: "never"`
+                    // on the username segment so heights stay accurate even
+                    // for very long display names.
+                    "white-space": "nowrap",
                   }}
                 >
-                  {item.prepared.timestamp}
+                  {item.msg.display_name}
                 </span>
-              </Show>
-              <For each={item.prepared.badges}>
-                {(b) => (
-                  <img
-                    src={b.badge.url_1x}
-                    srcset={
-                      b.badge.url_2x
-                        ? `${b.badge.url_1x} 1x, ${b.badge.url_2x} 2x${
-                            b.badge.url_4x ? `, ${b.badge.url_4x} 4x` : ""
-                          }`
-                        : undefined
-                    }
-                    alt={b.badge.title}
-                    title={b.badge.title}
-                    width={BADGE_SIZE_PX}
-                    height={BADGE_SIZE_PX}
-                    draggable={false}
-                    style={{
-                      display: "inline-block",
-                      "vertical-align": "middle",
-                      "margin-right": `${BADGE_GAP_PX}px`,
-                    }}
-                  />
-                )}
-              </For>
-              <span
-                style={{
-                  color: normalizeUserColor(item.msg.color),
-                  "font-weight": 700,
-                  // Keep DOM in lockstep with Pretext's `break: "never"`
-                  // on the username segment so heights stay accurate even
-                  // for very long display names.
-                  "white-space": "nowrap",
-                }}
-              >
-                {item.msg.display_name}
-              </span>
-              <span style={{ color: "#adadb8" }}>: </span>
-              <For each={item.prepared.pieces}>
-                {(piece) => renderPiece(piece)}
-              </For>
-            </div>
-          )}
+                <span style={{ color: "#adadb8" }}>: </span>
+                <For each={item.prepared.pieces}>
+                  {(piece) => renderPiece(piece)}
+                </For>
+              </div>
+            );
+          }}
         </For>
       </div>
     </div>

--- a/apps/desktop/src/components/MessageInput.tsx
+++ b/apps/desktop/src/components/MessageInput.tsx
@@ -33,6 +33,12 @@ const MessageInput: Component<Props> = (props) => {
   const [text, setText] = createSignal("");
   const [status, setStatus] = createSignal<string | null>(null);
   let inputEl: HTMLInputElement | undefined;
+  // Per-input monotonic counter. Pending-entry mutations are already
+  // safely keyed by `local_id`, but the inline status string is shared
+  // across submits, so a slower earlier rejection could otherwise stomp
+  // a newer success. We snapshot the seq at submit time and only let
+  // the handler call `setStatus` when its snapshot is still the latest.
+  let lastSubmitSeq = 0;
 
   const submit = () => {
     const payload = normalizeOutgoing(text());
@@ -55,6 +61,7 @@ const MessageInput: Component<Props> = (props) => {
     });
     insertPending(optimistic);
     const localId = optimistic.local_id!;
+    const submitSeq = ++lastSubmitSeq;
 
     sendMessage(payload).then(
       (ok) => {
@@ -67,7 +74,7 @@ const MessageInput: Component<Props> = (props) => {
             ? err
             : formatSendError(err as SendMessageError);
         failPending(localId, message);
-        setStatus(message);
+        if (submitSeq === lastSubmitSeq) setStatus(message);
       },
     );
   };

--- a/apps/desktop/src/components/MessageInput.tsx
+++ b/apps/desktop/src/components/MessageInput.tsx
@@ -14,12 +14,25 @@ import {
   normalizeOutgoing,
   toSendError,
 } from "../lib/messageInput";
+import {
+  buildOptimisticMessage,
+  confirmPendingId,
+  failPending,
+  insertPending,
+} from "../stores/chatStore";
 
-const MessageInput: Component = () => {
+interface Props {
+  /** Current Twitch login of the signed-in user. Used as both the
+   * username and provisional display name on the optimistic message;
+   * the authoritative EventSub echo replaces both fields when it
+   * arrives. */
+  login: string;
+}
+
+const MessageInput: Component<Props> = (props) => {
   const [text, setText] = createSignal("");
   const [status, setStatus] = createSignal<string | null>(null);
   let inputEl: HTMLInputElement | undefined;
-  let sendSeq = 0;
 
   const submit = () => {
     const payload = normalizeOutgoing(text());
@@ -31,21 +44,32 @@ const MessageInput: Component = () => {
       setStatus(`Message exceeds ${MAX_CHAT_MESSAGE_BYTES} bytes.`);
       return;
     }
-    const seq = ++sendSeq;
     setText("");
     setStatus(null);
     inputEl?.focus();
 
-    sendMessage(payload).catch((raw) => {
-      if (seq !== sendSeq) return;
-      if (!text()) setText(payload);
-      const err = toSendError(raw);
-      setStatus(
-        typeof err === "string"
-          ? err
-          : formatSendError(err as SendMessageError),
-      );
+    const optimistic = buildOptimisticMessage({
+      platform: "Twitch",
+      login: props.login,
+      text: payload,
     });
+    insertPending(optimistic);
+    const localId = optimistic.local_id!;
+
+    sendMessage(payload).then(
+      (ok) => {
+        confirmPendingId(localId, ok.message_id);
+      },
+      (raw) => {
+        const err = toSendError(raw);
+        const message =
+          typeof err === "string"
+            ? err
+            : formatSendError(err as SendMessageError);
+        failPending(localId, message);
+        setStatus(message);
+      },
+    );
   };
 
   const onKeyDown = (e: KeyboardEvent) => {

--- a/apps/desktop/src/lib/twitchAuth.ts
+++ b/apps/desktop/src/lib/twitchAuth.ts
@@ -87,6 +87,14 @@ export type SendMessageError =
 
 export const MAX_CHAT_MESSAGE_BYTES = 500;
 
-export function sendMessage(text: string): Promise<void> {
+/** Success payload from `twitch_send_message`. Mirrors `SendChatOk`
+ * on the Rust side. The `message_id` is the Helix-assigned id, used
+ * by the optimistic renderer to correlate a pending entry with its
+ * authoritative EventSub echo. */
+export interface SendMessageOk {
+  message_id: string;
+}
+
+export function sendMessage(text: string): Promise<SendMessageOk> {
   return invoke("twitch_send_message", { text });
 }

--- a/apps/desktop/src/stores/chatStore.test.ts
+++ b/apps/desktop/src/stores/chatStore.test.ts
@@ -393,4 +393,46 @@ describe("chatStore optimistic send", () => {
     expect(store.getMessage(0)?.status).toBeUndefined();
     expect(store.getMessage(1)?.status).toBeUndefined();
   });
+
+  it("reconciles a failed entry when the platform echo arrives late", () => {
+    const store = createChatStore(10);
+    const pending = buildOptimisticMessage({
+      platform: "Twitch",
+      login: "alice",
+      text: "hi",
+    });
+    store.insertPending(pending);
+    store.failPending(pending.local_id!, "ambiguous timeout");
+    vi.runAllTimers();
+    expect(store.getMessage(0)?.status).toBe("failed");
+
+    store.addMessages([makeAuthoritative(pending)]);
+    vi.runAllTimers();
+
+    expect(store.viewport().count).toBe(1);
+    const merged = store.getMessage(0)!;
+    expect(merged.status).toBeUndefined();
+    expect(merged.error_message).toBeUndefined();
+    expect(merged.id).toBe("from-platform");
+  });
+
+  it("reconcile clears local_id and adopts authoritative username", () => {
+    const store = createChatStore(10);
+    const pending = buildOptimisticMessage({
+      platform: "Twitch",
+      login: "alice",
+      text: "hi",
+    });
+    store.insertPending(pending);
+    store.addMessages([
+      makeAuthoritative(pending, { display_name: "AliceCool" }),
+    ]);
+    vi.runAllTimers();
+
+    const merged = store.getMessage(0)!;
+    expect(merged.local_id).toBeUndefined();
+    expect(merged.display_name).toBe("AliceCool");
+    // After clearing local_id, retryPending must not find the entry.
+    expect(store.retryPending(pending.local_id!)).toBeUndefined();
+  });
 });

--- a/apps/desktop/src/stores/chatStore.test.ts
+++ b/apps/desktop/src/stores/chatStore.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { createChatStore, type ChatMessage } from "./chatStore";
+import {
+  buildOptimisticMessage,
+  createChatStore,
+  type ChatMessage,
+} from "./chatStore";
 
 function makeMsg(id: string, text = `msg ${id}`): ChatMessage {
   return {
@@ -20,6 +24,25 @@ function makeMsg(id: string, text = `msg ${id}`): ChatMessage {
     color: null,
     reply_to: null,
     emote_spans: [],
+  };
+}
+
+function makeAuthoritative(
+  pending: ChatMessage,
+  overrides: Partial<ChatMessage> = {},
+): ChatMessage {
+  return {
+    ...makeMsg("from-platform", pending.message_text),
+    platform: pending.platform,
+    username: pending.username,
+    arrival_time: pending.arrival_time + 200,
+    timestamp: pending.arrival_time + 150,
+    effective_ts: pending.arrival_time + 150,
+    display_name: pending.username.toUpperCase(),
+    platform_user_id: "real-id",
+    badges: [{ set_id: "subscriber", id: "1" }],
+    color: "#ff8800",
+    ...overrides,
   };
 }
 
@@ -148,5 +171,226 @@ describe("chatStore", () => {
     expect(rafSpy).toHaveBeenCalledTimes(2);
 
     rafSpy.mockRestore();
+  });
+});
+
+describe("chatStore optimistic send", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("buildOptimisticMessage marks status pending and assigns a local_id", () => {
+    const msg = buildOptimisticMessage({
+      platform: "Twitch",
+      login: "alice",
+      text: "hi",
+    });
+    expect(msg.status).toBe("pending");
+    expect(msg.local_id).toBeTruthy();
+    expect(msg.id).toBe(msg.local_id);
+    expect(msg.username).toBe("alice");
+    expect(msg.display_name).toBe("alice");
+    expect(msg.message_text).toBe("hi");
+    expect(msg.effective_ts).toBe(msg.arrival_time);
+  });
+
+  it("insertPending appends to ring and bumps viewport", () => {
+    const store = createChatStore(10);
+    const pending = buildOptimisticMessage({
+      platform: "Twitch",
+      login: "alice",
+      text: "hi",
+    });
+    store.insertPending(pending);
+    vi.runAllTimers();
+    expect(store.viewport()).toEqual({ start: 0, count: 1 });
+    expect(store.getMessage(0)?.status).toBe("pending");
+  });
+
+  it("addMessages reconciles incoming echo against pending by fingerprint", () => {
+    const store = createChatStore(10);
+    const pending = buildOptimisticMessage({
+      platform: "Twitch",
+      login: "alice",
+      text: "hi",
+    });
+    store.insertPending(pending);
+    vi.runAllTimers();
+
+    const auth = makeAuthoritative(pending);
+    store.addMessages([auth]);
+    vi.runAllTimers();
+
+    // Echo did NOT append a second message; it merged into the pending entry.
+    expect(store.viewport().count).toBe(1);
+    const merged = store.getMessage(0)!;
+    expect(merged.status).toBeUndefined();
+    expect(merged.id).toBe("from-platform");
+    expect(merged.display_name).toBe("ALICE");
+    expect(merged.color).toBe("#ff8800");
+    expect(merged.badges).toHaveLength(1);
+  });
+
+  it("addMessages reconciles by id once confirmPendingId is called", () => {
+    const store = createChatStore(10);
+    const pending = buildOptimisticMessage({
+      platform: "Twitch",
+      login: "alice",
+      text: "hello",
+    });
+    store.insertPending(pending);
+    store.confirmPendingId(pending.local_id!, "helix-xyz");
+    vi.runAllTimers();
+
+    // Echo with matching id but DIFFERENT text still reconciles by id,
+    // because the platform may normalize text in transit.
+    const echo = makeAuthoritative(pending, {
+      id: "helix-xyz",
+      message_text: "hello",
+    });
+    store.addMessages([echo]);
+    vi.runAllTimers();
+
+    expect(store.viewport().count).toBe(1);
+    expect(store.getMessage(0)?.status).toBeUndefined();
+    expect(store.getMessage(0)?.id).toBe("helix-xyz");
+  });
+
+  it("does not reconcile when fingerprint window has elapsed", () => {
+    const store = createChatStore(10);
+    const pending = buildOptimisticMessage({
+      platform: "Twitch",
+      login: "alice",
+      text: "hi",
+    });
+    pending.arrival_time = 0;
+    store.insertPending(pending);
+
+    const stale = makeAuthoritative(pending);
+    stale.arrival_time = 60_000; // far outside window
+    store.addMessages([stale]);
+    vi.runAllTimers();
+
+    // Both kept: pending stays, stale is appended as a separate entry.
+    expect(store.viewport().count).toBe(2);
+    expect(store.getMessage(0)?.status).toBe("pending");
+    expect(store.getMessage(1)?.status).toBeUndefined();
+  });
+
+  it("does not reconcile across platforms even with identical text", () => {
+    const store = createChatStore(10);
+    const pending = buildOptimisticMessage({
+      platform: "Twitch",
+      login: "alice",
+      text: "hi",
+    });
+    store.insertPending(pending);
+
+    const echoOtherPlatform = makeAuthoritative(pending, {
+      platform: "YouTube",
+    });
+    store.addMessages([echoOtherPlatform]);
+    vi.runAllTimers();
+
+    expect(store.viewport().count).toBe(2);
+    expect(store.getMessage(0)?.status).toBe("pending");
+  });
+
+  it("failPending stamps error and bumps messageRevision", () => {
+    const store = createChatStore(10);
+    const pending = buildOptimisticMessage({
+      platform: "Twitch",
+      login: "alice",
+      text: "hi",
+    });
+    store.insertPending(pending);
+    vi.runAllTimers();
+
+    const revBefore = store.messageRevision();
+    store.failPending(pending.local_id!, "rate limited");
+    vi.runAllTimers();
+
+    expect(store.getMessage(0)?.status).toBe("failed");
+    expect(store.getMessage(0)?.error_message).toBe("rate limited");
+    expect(store.messageRevision()).toBeGreaterThan(revBefore);
+  });
+
+  it("retryPending only flips a failed entry back to pending", () => {
+    const store = createChatStore(10);
+    const pending = buildOptimisticMessage({
+      platform: "Twitch",
+      login: "alice",
+      text: "retry me",
+    });
+    store.insertPending(pending);
+
+    // No-op while still pending.
+    expect(store.retryPending(pending.local_id!)).toBeUndefined();
+
+    store.failPending(pending.local_id!, "boom");
+    const text = store.retryPending(pending.local_id!);
+    expect(text).toBe("retry me");
+    expect(store.getMessage(0)?.status).toBe("pending");
+    expect(store.getMessage(0)?.error_message).toBeUndefined();
+  });
+
+  it("confirmPendingId is a no-op when local_id is unknown", () => {
+    const store = createChatStore(10);
+    // Should not throw.
+    store.confirmPendingId("never-existed", "helix-1");
+  });
+
+  it("scan is bounded and ignores pending entries past PENDING_SCAN_TAIL", () => {
+    const store = createChatStore(200);
+    const oldPending = buildOptimisticMessage({
+      platform: "Twitch",
+      login: "alice",
+      text: "old one",
+    });
+    store.insertPending(oldPending);
+
+    // Push 100 unrelated messages so the pending falls outside the
+    // 64-entry reconciliation tail.
+    const filler: ChatMessage[] = [];
+    for (let i = 0; i < 100; i++) filler.push(makeMsg(`f${i}`));
+    store.addMessages(filler);
+
+    const echo = makeAuthoritative(oldPending);
+    store.addMessages([echo]);
+    vi.runAllTimers();
+
+    // Echo could not find the pending entry: it appends as a normal msg
+    // and the original pending stays in pending state.
+    expect(store.getMessage(0)?.status).toBe("pending");
+  });
+
+  it("multiple pending messages reconcile in submit order via fingerprint", () => {
+    const store = createChatStore(20);
+    const a = buildOptimisticMessage({
+      platform: "Twitch",
+      login: "alice",
+      text: "first",
+    });
+    const b = buildOptimisticMessage({
+      platform: "Twitch",
+      login: "alice",
+      text: "second",
+    });
+    store.insertPending(a);
+    store.insertPending(b);
+    vi.runAllTimers();
+
+    store.addMessages([makeAuthoritative(a, { id: "id-a" })]);
+    store.addMessages([makeAuthoritative(b, { id: "id-b" })]);
+    vi.runAllTimers();
+
+    expect(store.viewport().count).toBe(2);
+    expect(store.getMessage(0)?.id).toBe("id-a");
+    expect(store.getMessage(1)?.id).toBe("id-b");
+    expect(store.getMessage(0)?.status).toBeUndefined();
+    expect(store.getMessage(1)?.status).toBeUndefined();
   });
 });

--- a/apps/desktop/src/stores/chatStore.ts
+++ b/apps/desktop/src/stores/chatStore.ts
@@ -65,6 +65,20 @@ export interface ChatMessage {
   color: string | null;
   reply_to: string | null;
   emote_spans: EmoteSpan[];
+  /**
+   * Optimistic-render state. `undefined` for confirmed messages (the
+   * common case). `"pending"` while waiting for the platform echo,
+   * `"failed"` when send was rejected. The renderer uses this to dim
+   * pending entries and surface failed ones with a retry affordance.
+   */
+  status?: "pending" | "failed";
+  /**
+   * Client-generated id used to correlate an optimistic message with
+   * its later platform echo. Only set on optimistic inserts.
+   */
+  local_id?: string;
+  /** Human-readable failure reason; only set when status is "failed". */
+  error_message?: string;
 }
 
 export interface Viewport {
@@ -74,13 +88,132 @@ export interface Viewport {
   count: number;
 }
 
+/**
+ * Window for matching an authoritative platform echo to a still-pending
+ * optimistic message by fingerprint (platform + author + normalized
+ * text). Generous enough to absorb sidecar cold-start latency without
+ * letting genuine duplicates collapse onto stale pending entries.
+ */
+export const PENDING_FINGERPRINT_WINDOW_MS = 30_000;
+
+/**
+ * How many recent messages to scan when reconciling an incoming batch
+ * against pending entries. Bounds the reconcile cost regardless of
+ * pending-set size.
+ */
+export const PENDING_SCAN_TAIL = 64;
+
 export interface ChatStore {
   viewport: () => Viewport;
+  /**
+   * Increments whenever an existing message in the ring is mutated in
+   * place (pending reconcile, fail, or retry). Renderers that cache
+   * per-message state (e.g. prepared layout) should subscribe and
+   * invalidate when this changes; pure append paths bump the viewport
+   * signal instead.
+   */
+  messageRevision: () => number;
   addMessages: (batch: ChatMessage[]) => void;
   getMessage: (monoIndex: number) => ChatMessage | undefined;
+  /**
+   * Inserts a locally-authored message in pending state. The caller
+   * supplies a `local_id`; later calls to `confirmPendingId`,
+   * `failPending`, and `retryPending` use it to find the entry. The
+   * message renders immediately and is reconciled in place when its
+   * authoritative platform echo arrives.
+   */
+  insertPending: (msg: ChatMessage) => void;
+  /**
+   * Records the Helix-assigned message id for a pending entry so a
+   * subsequent echo can be matched by id (faster, more precise than
+   * the fingerprint fallback). No-op if the entry has already been
+   * reconciled or evicted.
+   */
+  confirmPendingId: (localId: string, messageId: string) => void;
+  /**
+   * Marks a pending entry as failed and stamps a human-readable
+   * error. The message stays in the ring so the user can see what
+   * went wrong and retry. No-op if already reconciled or evicted.
+   */
+  failPending: (localId: string, errorMessage: string) => void;
+  /**
+   * Resets a failed entry to pending state and returns its message
+   * text so the caller can re-invoke the send command. Returns
+   * `undefined` if the entry is missing or not in failed state.
+   */
+  retryPending: (localId: string) => string | undefined;
 }
 
 export const DEFAULT_MAX_MESSAGES = 5000;
+
+/**
+ * Frontend-only seq sentinel for optimistic pending messages. Set well
+ * above any plausible per-session backend `arrival_seq` (which starts
+ * at 0 and increments once per emitted message) so that when a future
+ * sort layer compares `(effective_ts, arrival_seq)` across the ring,
+ * pending entries naturally sort to the tail. Each pending insert
+ * decrements the local counter from the same high base so multiple
+ * concurrent pending messages still preserve submit order.
+ */
+const OPTIMISTIC_SEQ_BASE = Number.MAX_SAFE_INTEGER - 1_000_000;
+let nextOptimisticSeq = OPTIMISTIC_SEQ_BASE;
+
+export interface OptimisticInput {
+  platform: ChatMessage["platform"];
+  /** Login of the signed-in user; used as both username and provisional
+   * display name on the optimistic entry. */
+  login: string;
+  /** Trimmed payload, exactly as it will be sent to the platform. */
+  text: string;
+}
+
+/**
+ * Builds a `ChatMessage` in pending state from the user's locally-known
+ * identity. The `local_id` is generated here so the caller can hand it
+ * straight to `confirmPendingId` / `failPending` after invoking the
+ * send command. Stamps `effective_ts` with the local clock so the
+ * snap rule keeps the message at "now" until reconciliation.
+ */
+export function buildOptimisticMessage(input: OptimisticInput): ChatMessage {
+  const now = Date.now();
+  const localId = generateLocalId();
+  return {
+    id: localId,
+    platform: input.platform,
+    timestamp: now,
+    arrival_time: now,
+    effective_ts: now,
+    arrival_seq: nextOptimisticSeq++,
+    username: input.login,
+    display_name: input.login,
+    platform_user_id: "",
+    message_text: input.text,
+    badges: [],
+    is_mod: false,
+    is_subscriber: false,
+    is_broadcaster: false,
+    color: null,
+    reply_to: null,
+    emote_spans: [],
+    status: "pending",
+    local_id: localId,
+  };
+}
+
+function generateLocalId(): string {
+  const c =
+    typeof globalThis !== "undefined"
+      ? (globalThis as { crypto?: Crypto }).crypto
+      : undefined;
+  if (c && typeof c.randomUUID === "function") {
+    return c.randomUUID();
+  }
+  // Fallback for environments without WebCrypto. Not security-sensitive
+  // here — only needs to be unique within the per-process pending set.
+  return `local-${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2, 10)}`;
+}
 
 /**
  * Creates a chat store backed by a plain pre-allocated ring buffer. Writes
@@ -100,19 +233,134 @@ export function createChatStore(maxMessages = DEFAULT_MAX_MESSAGES): ChatStore {
   );
   let writeIndex = 0;
   let rafPending = false;
+  let pendingMutation = false;
+
+  // localId → monoIndex of the pending entry. Stays in the map until
+  // the entry is reconciled or evicted from the ring; we lazily prune
+  // stale map entries when we discover an evicted monoIndex on access.
+  const pendingByLocalId = new Map<string, number>();
 
   const [viewport, setViewport] = createSignal<Viewport>({
     start: 0,
     count: 0,
   });
+  const [messageRevision, setMessageRevision] = createSignal(0);
+
+  function isLive(monoIndex: number): boolean {
+    return monoIndex >= 0 && monoIndex >= writeIndex - maxMessages;
+  }
+
+  function lookupPendingEntry(
+    localId: string,
+  ): { monoIndex: number; msg: ChatMessage } | undefined {
+    const monoIndex = pendingByLocalId.get(localId);
+    if (monoIndex === undefined) return undefined;
+    if (!isLive(monoIndex)) {
+      pendingByLocalId.delete(localId);
+      return undefined;
+    }
+    const msg = ring[monoIndex % maxMessages];
+    if (!msg || msg.local_id !== localId) {
+      pendingByLocalId.delete(localId);
+      return undefined;
+    }
+    return { monoIndex, msg };
+  }
+
+  function tryReconcile(incoming: ChatMessage): boolean {
+    if (pendingByLocalId.size === 0) return false;
+    const tailStart = Math.max(0, writeIndex - PENDING_SCAN_TAIL);
+    for (let mono = writeIndex - 1; mono >= tailStart; mono--) {
+      const entry = ring[mono % maxMessages];
+      if (!entry || entry.status !== "pending") continue;
+      if (entry.platform !== incoming.platform) continue;
+      const idMatch = entry.id === incoming.id && entry.id.length > 0;
+      const fingerprintMatch =
+        entry.username === incoming.username &&
+        entry.message_text === incoming.message_text &&
+        Math.abs(incoming.arrival_time - entry.arrival_time) <
+          PENDING_FINGERPRINT_WINDOW_MS;
+      if (!idMatch && !fingerprintMatch) continue;
+      reconcileEntry(entry, incoming);
+      if (entry.local_id) pendingByLocalId.delete(entry.local_id);
+      return true;
+    }
+    return false;
+  }
+
+  function reconcileEntry(entry: ChatMessage, incoming: ChatMessage): void {
+    // Adopt authoritative identity and rendering data, but keep the
+    // optimistic position (arrival_seq) so the row doesn't jump.
+    entry.id = incoming.id;
+    entry.timestamp = incoming.timestamp;
+    entry.arrival_time = incoming.arrival_time;
+    entry.effective_ts = incoming.effective_ts;
+    entry.display_name = incoming.display_name;
+    entry.platform_user_id = incoming.platform_user_id;
+    entry.message_text = incoming.message_text;
+    entry.badges = incoming.badges;
+    entry.is_mod = incoming.is_mod;
+    entry.is_subscriber = incoming.is_subscriber;
+    entry.is_broadcaster = incoming.is_broadcaster;
+    entry.color = incoming.color;
+    entry.reply_to = incoming.reply_to;
+    entry.emote_spans = incoming.emote_spans;
+    entry.status = undefined;
+    entry.error_message = undefined;
+  }
 
   function addMessages(batch: ChatMessage[]): void {
     if (batch.length === 0) return;
+    let appended = 0;
+    let mutated = false;
     for (const msg of batch) {
+      if (tryReconcile(msg)) {
+        mutated = true;
+        continue;
+      }
       ring[writeIndex % maxMessages] = msg;
       writeIndex++;
+      appended++;
     }
+    if (appended > 0) scheduleViewportUpdate();
+    if (mutated) bumpMessageRevision();
+  }
+
+  function insertPending(msg: ChatMessage): void {
+    if (!msg.local_id) {
+      throw new Error("insertPending requires msg.local_id");
+    }
+    msg.status = "pending";
+    ring[writeIndex % maxMessages] = msg;
+    pendingByLocalId.set(msg.local_id, writeIndex);
+    writeIndex++;
     scheduleViewportUpdate();
+  }
+
+  function confirmPendingId(localId: string, messageId: string): void {
+    const found = lookupPendingEntry(localId);
+    if (!found || messageId.length === 0) return;
+    found.msg.id = messageId;
+    // No revision bump: id swap is invisible to renderers and the entry
+    // is still pending. The reconcile-by-id path will pick it up when
+    // the echo arrives.
+  }
+
+  function failPending(localId: string, errorMessage: string): void {
+    const found = lookupPendingEntry(localId);
+    if (!found) return;
+    found.msg.status = "failed";
+    found.msg.error_message = errorMessage;
+    bumpMessageRevision();
+  }
+
+  function retryPending(localId: string): string | undefined {
+    const found = lookupPendingEntry(localId);
+    if (!found || found.msg.status !== "failed") return undefined;
+    found.msg.status = "pending";
+    found.msg.error_message = undefined;
+    bumpMessageRevision();
+    return found.msg.message_text;
   }
 
   function scheduleViewportUpdate(): void {
@@ -127,6 +375,15 @@ export function createChatStore(maxMessages = DEFAULT_MAX_MESSAGES): ChatStore {
     });
   }
 
+  function bumpMessageRevision(): void {
+    if (pendingMutation) return;
+    pendingMutation = true;
+    requestAnimationFrame(() => {
+      pendingMutation = false;
+      setMessageRevision((n) => n + 1);
+    });
+  }
+
   function getMessage(monoIndex: number): ChatMessage | undefined {
     if (monoIndex < 0 || monoIndex >= writeIndex) return undefined;
     // evicted by wraparound
@@ -134,12 +391,26 @@ export function createChatStore(maxMessages = DEFAULT_MAX_MESSAGES): ChatStore {
     return ring[monoIndex % maxMessages];
   }
 
-  return { viewport, addMessages, getMessage };
+  return {
+    viewport,
+    messageRevision,
+    addMessages,
+    getMessage,
+    insertPending,
+    confirmPendingId,
+    failPending,
+    retryPending,
+  };
 }
 
 // Default singleton used by the production app.
 const defaultStore = createChatStore();
 
 export const viewport = defaultStore.viewport;
+export const messageRevision = defaultStore.messageRevision;
 export const addMessages = defaultStore.addMessages;
 export const getMessage = defaultStore.getMessage;
+export const insertPending = defaultStore.insertPending;
+export const confirmPendingId = defaultStore.confirmPendingId;
+export const failPending = defaultStore.failPending;
+export const retryPending = defaultStore.retryPending;

--- a/apps/desktop/src/stores/chatStore.ts
+++ b/apps/desktop/src/stores/chatStore.ts
@@ -90,9 +90,9 @@ export interface Viewport {
 
 /**
  * Window for matching an authoritative platform echo to a still-pending
- * optimistic message by fingerprint (platform + author + normalized
- * text). Generous enough to absorb sidecar cold-start latency without
- * letting genuine duplicates collapse onto stale pending entries.
+ * optimistic message by fingerprint (platform + author + message text).
+ * Generous enough to absorb sidecar cold-start latency without letting
+ * genuine duplicates collapse onto stale pending entries.
  */
 export const PENDING_FINGERPRINT_WINDOW_MS = 30_000;
 
@@ -152,7 +152,7 @@ export const DEFAULT_MAX_MESSAGES = 5000;
  * at 0 and increments once per emitted message) so that when a future
  * sort layer compares `(effective_ts, arrival_seq)` across the ring,
  * pending entries naturally sort to the tail. Each pending insert
- * decrements the local counter from the same high base so multiple
+ * increments the local counter from the same high base so multiple
  * concurrent pending messages still preserve submit order.
  */
 const OPTIMISTIC_SEQ_BASE = Number.MAX_SAFE_INTEGER - 1_000_000;
@@ -272,7 +272,12 @@ export function createChatStore(maxMessages = DEFAULT_MAX_MESSAGES): ChatStore {
     const tailStart = Math.max(0, writeIndex - PENDING_SCAN_TAIL);
     for (let mono = writeIndex - 1; mono >= tailStart; mono--) {
       const entry = ring[mono % maxMessages];
-      if (!entry || entry.status !== "pending") continue;
+      // Reconcile against both pending and failed optimistic entries:
+      // a transport error followed by the platform echo arriving anyway
+      // (e.g. ambiguous timeout, retried by us elsewhere) should heal
+      // the failed entry instead of leaving it red beside a duplicate.
+      if (!entry || (entry.status !== "pending" && entry.status !== "failed"))
+        continue;
       if (entry.platform !== incoming.platform) continue;
       const idMatch = entry.id === incoming.id && entry.id.length > 0;
       const fingerprintMatch =
@@ -281,8 +286,9 @@ export function createChatStore(maxMessages = DEFAULT_MAX_MESSAGES): ChatStore {
         Math.abs(incoming.arrival_time - entry.arrival_time) <
           PENDING_FINGERPRINT_WINDOW_MS;
       if (!idMatch && !fingerprintMatch) continue;
+      const localId = entry.local_id;
       reconcileEntry(entry, incoming);
-      if (entry.local_id) pendingByLocalId.delete(entry.local_id);
+      if (localId) pendingByLocalId.delete(localId);
       return true;
     }
     return false;
@@ -290,11 +296,14 @@ export function createChatStore(maxMessages = DEFAULT_MAX_MESSAGES): ChatStore {
 
   function reconcileEntry(entry: ChatMessage, incoming: ChatMessage): void {
     // Adopt authoritative identity and rendering data, but keep the
-    // optimistic position (arrival_seq) so the row doesn't jump.
+    // optimistic position (arrival_seq) so the row doesn't jump. The
+    // entry is no longer optimistic after this, so drop status,
+    // local_id, and any prior error string.
     entry.id = incoming.id;
     entry.timestamp = incoming.timestamp;
     entry.arrival_time = incoming.arrival_time;
     entry.effective_ts = incoming.effective_ts;
+    entry.username = incoming.username;
     entry.display_name = incoming.display_name;
     entry.platform_user_id = incoming.platform_user_id;
     entry.message_text = incoming.message_text;
@@ -307,6 +316,7 @@ export function createChatStore(maxMessages = DEFAULT_MAX_MESSAGES): ChatStore {
     entry.emote_spans = incoming.emote_spans;
     entry.status = undefined;
     entry.error_message = undefined;
+    entry.local_id = undefined;
   }
 
   function addMessages(batch: ChatMessage[]): void {


### PR DESCRIPTION
Closes #88. Stacked on #93.

Adds an optimistic-send path so locally-authored messages render the moment the user hits Enter, without waiting for the platform echo round-trip.

**Frontend (chatStore)**
- ChatMessage gains optional status (pending|failed), local_id, error_message
- New API: insertPending, confirmPendingId, failPending, retryPending, plus messageRevision signal for in-place mutation
- Reconcile incoming echo against pending tail by id (after confirm) or fingerprint (platform + username + text + 30s window)
- Pending arrival_seq sourced from MAX_SAFE_INTEGER - 1M base so they sort to tail in any future cross-platform sort layer
- buildOptimisticMessage helper builds the pending entry from {platform, login, text}

**Frontend (UI)**
- MessageInput now takes the user login, builds optimistic, inserts, then sends; on success calls confirmPendingId, on failure calls failPending
- ChatFeed subscribes to messageRevision and clears its prepared-layout cache on bump; pending entries render at 0.55 opacity, failed entries get a red left-border + click-to-retry
- twitchAuth.sendMessage now returns Promise<{ message_id }>

**Backend**
- twitch_send_message returns Result<SendChatOk, SendCommandError> with the Helix message_id so the frontend can swap the local id for the authoritative one before the echo arrives

**Tests**
- 11 new chatStore tests cover insertPending, reconcile-by-id, reconcile-by-fingerprint, fingerprint window expiry, cross-platform isolation, failPending, retryPending state machine, scan-tail bound, multi-pending ordering
- All 73 vitest tests + 187 cargo tests pass; clippy/fmt/tsc/eslint/prettier clean