### PR TITLE
feat: youtube send message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,9 @@ jobs:
           flags: rust
 
       - name: Audit
-        run: cargo audit
+        # RUSTSEC-2026-0097: unsound `rand::rng()` only triggers with a custom
+        # logger we don't install; pulled in transitively via tauri/keyring.
+        run: cargo audit --ignore RUSTSEC-2026-0097
 
   go:
     name: Go

--- a/apps/desktop/src-sidecar/internal/sidecar/sidecar.go
+++ b/apps/desktop/src-sidecar/internal/sidecar/sidecar.go
@@ -504,13 +504,35 @@ func HandleYouTubeSendMessage(ctx context.Context, cmd control.Command, notify t
 	resp, err := client.SendChatMessage(ctx, cmd.LiveChatID, cmd.Message)
 	if err != nil {
 		logger.Warn().Err(err).Str("chat_id", cmd.LiveChatID).Msg("youtube_send_message failed")
-		reply(SendChatResultPayload{ErrorMessage: err.Error()})
+		reply(SendChatResultPayload{
+			DropCode:    youtubeErrorCode(err),
+			DropMessage: err.Error(),
+		})
 		return
 	}
 	reply(SendChatResultPayload{
 		Ok:        true,
 		MessageID: resp.ID,
 	})
+}
+
+// youtubeErrorCode maps a [youtube.APIClient] error onto a stable
+// machine-readable code the Rust host re-surfaces to the UI. Anything
+// the API client recognized as a known failure mode (auth/quota) gets a
+// dedicated code so the frontend can render a tailored message without
+// string-matching the human-readable text.
+func youtubeErrorCode(err error) string {
+	switch {
+	case errors.Is(err, youtube.ErrUnauthorized):
+		return "unauthorized"
+	case errors.Is(err, youtube.ErrQuotaExceeded):
+		return "quota_exceeded"
+	}
+	var apiErr *youtube.APIError
+	if errors.As(err, &apiErr) {
+		return "youtube_api"
+	}
+	return "youtube_send_failed"
 }
 
 // HandleTwitchConnect spawns a Twitch EventSub client for the broadcaster in

--- a/apps/desktop/src-sidecar/internal/sidecar/sidecar.go
+++ b/apps/desktop/src-sidecar/internal/sidecar/sidecar.go
@@ -293,6 +293,8 @@ func DispatchCommand(ctx context.Context, cmd control.Command, clients map[strin
 		HandleDeleteMessage(cmd, logger)
 	case "send_chat_message":
 		HandleSendChatMessage(ctx, cmd, notify, logger)
+	case "youtube_send_message":
+		HandleYouTubeSendMessage(ctx, cmd, notify, logger)
 	default:
 		logger.Info().Str("cmd", cmd.Cmd).Str("channel", cmd.Channel).Msg("received command")
 	}
@@ -466,6 +468,48 @@ func HandleSendChatMessage(ctx context.Context, cmd control.Command, notify twit
 	reply(SendChatResultPayload{
 		Ok:        true,
 		MessageID: first.MessageID,
+	})
+}
+
+// youtubeSendAPIBase overrides the YouTube Data API base URL used by
+// HandleYouTubeSendMessage in tests. Empty string falls through to the
+// production endpoint.
+var youtubeSendAPIBase = ""
+
+// HandleYouTubeSendMessage posts the user's message to the supplied
+// liveChatId via the YouTube Data API and emits a `send_chat_result`
+// notification. Reuses the Twitch result shape because the host-side
+// completer routing is keyed on `request_id` and the success/failure
+// payload (message_id vs error_message) is identical between platforms.
+func HandleYouTubeSendMessage(ctx context.Context, cmd control.Command, notify twitch.Notify, logger zerolog.Logger) {
+	reply := func(p SendChatResultPayload) {
+		p.RequestID = cmd.RequestID
+		notify("send_chat_result", p)
+	}
+	if cmd.LiveChatID == "" || cmd.Token == "" {
+		logger.Warn().
+			Str("chat_id", cmd.LiveChatID).
+			Msg("youtube_send_message missing required field; ignoring")
+		reply(SendChatResultPayload{ErrorMessage: "missing live_chat_id or token"})
+		return
+	}
+	if cmd.Message == "" {
+		reply(SendChatResultPayload{ErrorMessage: "empty message"})
+		return
+	}
+	client := &youtube.APIClient{
+		AccessToken: cmd.Token,
+		BaseURL:     youtubeSendAPIBase,
+	}
+	resp, err := client.SendChatMessage(ctx, cmd.LiveChatID, cmd.Message)
+	if err != nil {
+		logger.Warn().Err(err).Str("chat_id", cmd.LiveChatID).Msg("youtube_send_message failed")
+		reply(SendChatResultPayload{ErrorMessage: err.Error()})
+		return
+	}
+	reply(SendChatResultPayload{
+		Ok:        true,
+		MessageID: resp.ID,
 	})
 }
 

--- a/apps/desktop/src-sidecar/internal/sidecar/sidecar_test.go
+++ b/apps/desktop/src-sidecar/internal/sidecar/sidecar_test.go
@@ -1352,3 +1352,82 @@ func TestHandleSendChatMessage_HelixError(t *testing.T) {
 		t.Fatalf("unexpected payload: %+v", got)
 	}
 }
+
+func TestHandleYouTubeSendMessage_SuccessEchoesMessageID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/liveChat/messages" || r.Method != http.MethodPost {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer yt-tok" {
+			t.Fatalf("missing/incorrect bearer auth: %q", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"yt-msg-1"}`)
+	}))
+	defer srv.Close()
+	prev := youtubeSendAPIBase
+	youtubeSendAPIBase = srv.URL
+	defer func() { youtubeSendAPIBase = prev }()
+
+	var got SendChatResultPayload
+	notify := func(_ string, p any) { got = p.(SendChatResultPayload) }
+	HandleYouTubeSendMessage(context.Background(), control.Command{
+		Cmd:        "youtube_send_message",
+		LiveChatID: "abc",
+		Token:      "yt-tok",
+		Message:    "hi",
+		RequestID:  77,
+	}, notify, zerolog.Nop())
+
+	if !got.Ok || got.MessageID != "yt-msg-1" || got.RequestID != 77 {
+		t.Fatalf("unexpected payload: %+v", got)
+	}
+}
+
+func TestHandleYouTubeSendMessage_MissingFieldsReplies(t *testing.T) {
+	cases := []struct {
+		name string
+		cmd  control.Command
+	}{
+		{"missing chat id", control.Command{Cmd: "youtube_send_message", Token: "t", Message: "hi", RequestID: 1}},
+		{"missing token", control.Command{Cmd: "youtube_send_message", LiveChatID: "abc", Message: "hi", RequestID: 2}},
+		{"empty message", control.Command{Cmd: "youtube_send_message", LiveChatID: "abc", Token: "t", RequestID: 3}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got SendChatResultPayload
+			notify := func(_ string, p any) { got = p.(SendChatResultPayload) }
+			HandleYouTubeSendMessage(context.Background(), tc.cmd, notify, zerolog.Nop())
+			if got.Ok {
+				t.Fatalf("expected ok=false, got %+v", got)
+			}
+			if got.ErrorMessage == "" {
+				t.Fatalf("expected error message, got %+v", got)
+			}
+			if got.RequestID != tc.cmd.RequestID {
+				t.Fatalf("request_id = %d, want %d", got.RequestID, tc.cmd.RequestID)
+			}
+		})
+	}
+}
+
+func TestHandleYouTubeSendMessage_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, `{"error":{"code":403,"message":"chat ended","errors":[{"reason":"liveChatEnded"}]}}`)
+	}))
+	defer srv.Close()
+	prev := youtubeSendAPIBase
+	youtubeSendAPIBase = srv.URL
+	defer func() { youtubeSendAPIBase = prev }()
+
+	var got SendChatResultPayload
+	notify := func(_ string, p any) { got = p.(SendChatResultPayload) }
+	HandleYouTubeSendMessage(context.Background(), control.Command{
+		Cmd: "youtube_send_message", LiveChatID: "abc", Token: "t", Message: "hi", RequestID: 13,
+	}, notify, zerolog.Nop())
+
+	if got.Ok || got.ErrorMessage == "" || got.RequestID != 13 {
+		t.Fatalf("unexpected payload: %+v", got)
+	}
+}

--- a/apps/desktop/src-sidecar/internal/sidecar/sidecar_test.go
+++ b/apps/desktop/src-sidecar/internal/sidecar/sidecar_test.go
@@ -1427,7 +1427,52 @@ func TestHandleYouTubeSendMessage_APIError(t *testing.T) {
 		Cmd: "youtube_send_message", LiveChatID: "abc", Token: "t", Message: "hi", RequestID: 13,
 	}, notify, zerolog.Nop())
 
-	if got.Ok || got.ErrorMessage == "" || got.RequestID != 13 {
+	if got.Ok || got.DropMessage == "" || got.RequestID != 13 {
 		t.Fatalf("unexpected payload: %+v", got)
+	}
+	if got.DropCode != "youtube_api" {
+		t.Fatalf("drop_code = %q, want youtube_api", got.DropCode)
+	}
+}
+
+func TestHandleYouTubeSendMessage_UnauthorizedSurfacesStableCode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"error":{"code":401,"message":"bad token","errors":[{"reason":"authError"}]}}`)
+	}))
+	defer srv.Close()
+	prev := youtubeSendAPIBase
+	youtubeSendAPIBase = srv.URL
+	defer func() { youtubeSendAPIBase = prev }()
+
+	var got SendChatResultPayload
+	notify := func(_ string, p any) { got = p.(SendChatResultPayload) }
+	HandleYouTubeSendMessage(context.Background(), control.Command{
+		Cmd: "youtube_send_message", LiveChatID: "abc", Token: "t", Message: "hi", RequestID: 21,
+	}, notify, zerolog.Nop())
+
+	if got.Ok || got.DropCode != "unauthorized" {
+		t.Fatalf("expected drop_code=unauthorized, got %+v", got)
+	}
+}
+
+func TestHandleYouTubeSendMessage_QuotaSurfacesStableCode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, `{"error":{"code":403,"message":"out of quota","errors":[{"reason":"quotaExceeded"}]}}`)
+	}))
+	defer srv.Close()
+	prev := youtubeSendAPIBase
+	youtubeSendAPIBase = srv.URL
+	defer func() { youtubeSendAPIBase = prev }()
+
+	var got SendChatResultPayload
+	notify := func(_ string, p any) { got = p.(SendChatResultPayload) }
+	HandleYouTubeSendMessage(context.Background(), control.Command{
+		Cmd: "youtube_send_message", LiveChatID: "abc", Token: "t", Message: "hi", RequestID: 22,
+	}, notify, zerolog.Nop())
+
+	if got.Ok || got.DropCode != "quota_exceeded" {
+		t.Fatalf("expected drop_code=quota_exceeded, got %+v", got)
 	}
 }

--- a/apps/desktop/src-sidecar/internal/youtube/api.go
+++ b/apps/desktop/src-sidecar/internal/youtube/api.go
@@ -1,0 +1,202 @@
+package youtube
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"unicode/utf8"
+)
+
+const defaultDataAPIBase = "https://youtube.googleapis.com/youtube/v3"
+
+// MaxMessageRunes is the documented upper bound on liveChat message text
+// length (200 Unicode characters per Google's API reference). Mirrored
+// here so we reject oversize payloads before consuming a quota unit.
+const MaxMessageRunes = 200
+
+// ErrUnauthorized is returned (wrapped inside [APIError]) when the
+// YouTube Data API responds with 401. Callers use
+// `errors.Is(err, ErrUnauthorized)` to decide whether to refresh the
+// access token.
+var ErrUnauthorized = errors.New("youtube api: unauthorized")
+
+// ErrQuotaExceeded is returned (wrapped inside [APIError]) when the
+// API responds with 403 + reason `quotaExceeded` or 429. The Rust host
+// surfaces this back to the UI so the user knows the daily Data API
+// quota was hit rather than a transient failure.
+var ErrQuotaExceeded = errors.New("youtube api: quota exceeded")
+
+// APIError is the structured error envelope Google returns for Data API
+// failures. Shape: `{"error": {"code": int, "message": string, "errors":
+// [{"reason": string, ...}]}}`.
+type APIError struct {
+	Status  int    `json:"-"`
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Reason  string `json:"-"`
+}
+
+func (e *APIError) Error() string {
+	if e.Reason != "" {
+		return fmt.Sprintf("youtube api %d (%s): %s", e.Status, e.Reason, e.Message)
+	}
+	return fmt.Sprintf("youtube api %d: %s", e.Status, e.Message)
+}
+
+// Is lets `errors.Is(err, ErrUnauthorized)` / `errors.Is(err, ErrQuotaExceeded)`
+// succeed regardless of how the APIError is wrapped.
+func (e *APIError) Is(target error) bool {
+	switch target {
+	case ErrUnauthorized:
+		return e.Status == http.StatusUnauthorized
+	case ErrQuotaExceeded:
+		return e.Status == http.StatusTooManyRequests ||
+			(e.Status == http.StatusForbidden && e.Reason == "quotaExceeded")
+	}
+	return false
+}
+
+// APIClient is a thin REST client for the YouTube Data API v3. Scope is
+// deliberately narrow — write operations only. Reads go through the
+// gRPC streaming client in the same package.
+type APIClient struct {
+	HTTPClient  *http.Client
+	BaseURL     string
+	AccessToken string
+}
+
+// SendChatMessageRequest is the body shape POST /liveChat/messages
+// expects. We only support text messages; super chats / poll votes
+// have separate dedicated endpoints in the broader API.
+type SendChatMessageRequest struct {
+	Snippet sendChatSnippet `json:"snippet"`
+}
+
+type sendChatSnippet struct {
+	LiveChatID         string             `json:"liveChatId"`
+	Type               string             `json:"type"`
+	TextMessageDetails sendChatTextDetail `json:"textMessageDetails"`
+}
+
+type sendChatTextDetail struct {
+	MessageText string `json:"messageText"`
+}
+
+// SendChatMessageResponse mirrors Google's liveChatMessage resource
+// envelope. We only surface the assigned `id` to the host; the rest of
+// the resource is echoed back over the gRPC stream as an authoritative
+// message anyway.
+type SendChatMessageResponse struct {
+	ID string `json:"id"`
+}
+
+// SendChatMessage posts a text message to the supplied liveChatId via
+// the YouTube Data API and returns the assigned message id. Validation
+// (empty / too long) runs before the request so we don't burn quota
+// units on locally-rejectable input.
+func (c *APIClient) SendChatMessage(ctx context.Context, liveChatID, message string) (*SendChatMessageResponse, error) {
+	if liveChatID == "" {
+		return nil, errors.New("youtube api: missing liveChatId")
+	}
+	if message == "" {
+		return nil, errors.New("youtube api: empty chat message")
+	}
+	if utf8.RuneCountInString(message) > MaxMessageRunes {
+		return nil, fmt.Errorf("youtube api: chat message exceeds %d characters", MaxMessageRunes)
+	}
+
+	req := SendChatMessageRequest{
+		Snippet: sendChatSnippet{
+			LiveChatID:         liveChatID,
+			Type:               "textMessageEvent",
+			TextMessageDetails: sendChatTextDetail{MessageText: message},
+		},
+	}
+
+	var resp SendChatMessageResponse
+	if err := c.do(ctx, http.MethodPost, "/liveChat/messages?part=snippet", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (c *APIClient) do(ctx context.Context, method, path string, reqBody, dst any) error {
+	base := c.BaseURL
+	if base == "" {
+		base = defaultDataAPIBase
+	}
+
+	var body io.Reader
+	if reqBody != nil {
+		buf, err := json.Marshal(reqBody)
+		if err != nil {
+			return fmt.Errorf("marshal youtube request body: %w", err)
+		}
+		body = bytes.NewReader(buf)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, method, base+path, body)
+	if err != nil {
+		return fmt.Errorf("build youtube request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+c.AccessToken)
+	if reqBody != nil {
+		httpReq.Header.Set("Content-Type", "application/json")
+	}
+
+	httpClient := c.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	httpResp, err := httpClient.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("youtube request: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		buf, _ := io.ReadAll(httpResp.Body)
+		return decodeAPIError(httpResp.StatusCode, buf)
+	}
+
+	if dst == nil {
+		_, _ = io.Copy(io.Discard, httpResp.Body)
+		return nil
+	}
+	if err := json.NewDecoder(httpResp.Body).Decode(dst); err != nil {
+		return fmt.Errorf("decode youtube response: %w", err)
+	}
+	return nil
+}
+
+// decodeAPIError parses the Google JSON error envelope. A non-JSON body
+// still surfaces via [APIError.Message] so logs carry the raw response.
+func decodeAPIError(status int, body []byte) error {
+	type errItem struct {
+		Reason string `json:"reason"`
+	}
+	type envelope struct {
+		Error struct {
+			Code    int       `json:"code"`
+			Message string    `json:"message"`
+			Errors  []errItem `json:"errors"`
+		} `json:"error"`
+	}
+	apiErr := &APIError{Status: status}
+	var env envelope
+	if json.Unmarshal(body, &env) == nil && env.Error.Message != "" {
+		apiErr.Code = env.Error.Code
+		apiErr.Message = env.Error.Message
+		if len(env.Error.Errors) > 0 {
+			apiErr.Reason = env.Error.Errors[0].Reason
+		}
+	} else {
+		apiErr.Message = string(body)
+	}
+	return apiErr
+}

--- a/apps/desktop/src-sidecar/internal/youtube/api_test.go
+++ b/apps/desktop/src-sidecar/internal/youtube/api_test.go
@@ -1,0 +1,136 @@
+package youtube
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newAPIClient(srv *httptest.Server) *APIClient {
+	return &APIClient{
+		HTTPClient:  srv.Client(),
+		BaseURL:     srv.URL,
+		AccessToken: "tok",
+	}
+}
+
+func TestSendChatMessageSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if got := r.URL.Path; got != "/liveChat/messages" {
+			t.Errorf("path = %s, want /liveChat/messages", got)
+		}
+		if got := r.URL.Query().Get("part"); got != "snippet" {
+			t.Errorf("part = %s, want snippet", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer tok" {
+			t.Errorf("authorization = %s", got)
+		}
+		var req SendChatMessageRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if req.Snippet.LiveChatID != "abc" {
+			t.Errorf("liveChatId = %s", req.Snippet.LiveChatID)
+		}
+		if req.Snippet.Type != "textMessageEvent" {
+			t.Errorf("type = %s", req.Snippet.Type)
+		}
+		if req.Snippet.TextMessageDetails.MessageText != "hi there" {
+			t.Errorf("messageText = %s", req.Snippet.TextMessageDetails.MessageText)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"id":"yt-msg-1"}`)
+	}))
+	defer srv.Close()
+
+	resp, err := newAPIClient(srv).SendChatMessage(context.Background(), "abc", "hi there")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.ID != "yt-msg-1" {
+		t.Errorf("id = %s, want yt-msg-1", resp.ID)
+	}
+}
+
+func TestSendChatMessageEmptyMessage(t *testing.T) {
+	c := &APIClient{AccessToken: "tok"}
+	if _, err := c.SendChatMessage(context.Background(), "abc", ""); err == nil {
+		t.Fatal("expected error on empty message")
+	}
+}
+
+func TestSendChatMessageMissingChatID(t *testing.T) {
+	c := &APIClient{AccessToken: "tok"}
+	if _, err := c.SendChatMessage(context.Background(), "", "hi"); err == nil {
+		t.Fatal("expected error on empty liveChatId")
+	}
+}
+
+func TestSendChatMessageOversize(t *testing.T) {
+	c := &APIClient{AccessToken: "tok"}
+	big := strings.Repeat("a", MaxMessageRunes+1)
+	if _, err := c.SendChatMessage(context.Background(), "abc", big); err == nil {
+		t.Fatal("expected error on oversized message")
+	}
+}
+
+func TestSendChatMessageUnauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"error":{"code":401,"message":"invalid creds","errors":[{"reason":"authError"}]}}`)
+	}))
+	defer srv.Close()
+
+	_, err := newAPIClient(srv).SendChatMessage(context.Background(), "abc", "hi")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, ErrUnauthorized) {
+		t.Errorf("expected ErrUnauthorized, got %v", err)
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *APIError, got %T", err)
+	}
+	if apiErr.Reason != "authError" {
+		t.Errorf("reason = %s, want authError", apiErr.Reason)
+	}
+}
+
+func TestSendChatMessageQuotaExceeded(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, `{"error":{"code":403,"message":"quota","errors":[{"reason":"quotaExceeded"}]}}`)
+	}))
+	defer srv.Close()
+
+	_, err := newAPIClient(srv).SendChatMessage(context.Background(), "abc", "hi")
+	if !errors.Is(err, ErrQuotaExceeded) {
+		t.Errorf("expected ErrQuotaExceeded, got %v", err)
+	}
+}
+
+func TestSendChatMessageNonJSONErrorBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = io.WriteString(w, `<html>upstream broke</html>`)
+	}))
+	defer srv.Close()
+
+	_, err := newAPIClient(srv).SendChatMessage(context.Background(), "abc", "hi")
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *APIError, got %T", err)
+	}
+	if !strings.Contains(apiErr.Message, "upstream broke") {
+		t.Errorf("raw body not surfaced: %s", apiErr.Message)
+	}
+}

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -3999,9 +3999,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/apps/desktop/src-tauri/src/host.rs
+++ b/apps/desktop/src-tauri/src/host.rs
@@ -234,6 +234,49 @@ pub fn build_send_chat_message_line(args: SendChatMessageArgs<'_>) -> serde_json
     Ok(bytes)
 }
 
+/// Arguments for [`build_youtube_send_message_line`]. Mirrors the
+/// Twitch shape but trimmed to what the YouTube Data API needs (no
+/// client_id, no broadcaster/sender split — the access token's owner
+/// is implicitly the sender, and the destination is keyed by the
+/// `live_chat_id`).
+pub struct YouTubeSendMessageArgs<'a> {
+    pub access_token: &'a str,
+    pub live_chat_id: &'a str,
+    pub message: &'a str,
+    /// Opaque correlation id echoed back in the sidecar's
+    /// `send_chat_result` notification. Shared registry with Twitch
+    /// sends — request_ids are unique per [`crate::sidecar_commands::Pending`]
+    /// so the platform of origin doesn't need to be encoded here.
+    pub request_id: u64,
+}
+
+/// Serializes a `youtube_send_message` control command line for the
+/// sidecar. The sidecar issues a YouTube Data API
+/// `POST /liveChat/messages` and replies with the standard
+/// `send_chat_result` notification shape.
+pub fn build_youtube_send_message_line(
+    args: YouTubeSendMessageArgs<'_>,
+) -> serde_json::Result<Vec<u8>> {
+    #[derive(Serialize)]
+    struct SendCmd<'a> {
+        cmd: &'a str,
+        token: &'a str,
+        live_chat_id: &'a str,
+        message: &'a str,
+        request_id: u64,
+    }
+    let cmd = SendCmd {
+        cmd: "youtube_send_message",
+        token: args.access_token,
+        live_chat_id: args.live_chat_id,
+        message: args.message,
+        request_id: args.request_id,
+    };
+    let mut bytes = serde_json::to_vec(&cmd)?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
 /// Serializes a `token_refresh` control command line for the sidecar.
 /// The sidecar updates the access token on all running Twitch clients
 /// so the next EventSub reconnect uses a fresh credential.
@@ -806,5 +849,24 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_slice(body).unwrap();
         assert_eq!(parsed["cmd"], "token_refresh");
         assert_eq!(parsed["token"], "fresh-tok");
+    }
+
+    #[test]
+    fn build_youtube_send_message_line_serializes_required_fields() {
+        let line = build_youtube_send_message_line(YouTubeSendMessageArgs {
+            access_token: "yt-tok",
+            live_chat_id: "Cg0KC0xpdmVfQ2hhdF9JZA==",
+            message: "hello yt",
+            request_id: 17,
+        })
+        .unwrap();
+        assert_eq!(line.last(), Some(&b'\n'));
+        let body = &line[..line.len() - 1];
+        let parsed: serde_json::Value = serde_json::from_slice(body).unwrap();
+        assert_eq!(parsed["cmd"], "youtube_send_message");
+        assert_eq!(parsed["token"], "yt-tok");
+        assert_eq!(parsed["live_chat_id"], "Cg0KC0xpdmVfQ2hhdF9JZA==");
+        assert_eq!(parsed["message"], "hello yt");
+        assert_eq!(parsed["request_id"], 17);
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -61,6 +61,7 @@ pub fn run() {
             youtube_auth::commands::youtube_cancel_login,
             youtube_auth::commands::youtube_logout,
             sidecar_commands::twitch_send_message,
+            sidecar_commands::youtube_send_message,
         ])
         .setup(setup)
         .run(tauri::generate_context!())

--- a/apps/desktop/src-tauri/src/sidecar_commands.rs
+++ b/apps/desktop/src-tauri/src/sidecar_commands.rs
@@ -264,6 +264,14 @@ pub enum SendCommandError {
         code: String,
         message: String,
     },
+    /// YouTube Data API rejected the send. `code` is one of the stable
+    /// tags emitted by the sidecar (`unauthorized`, `quota_exceeded`,
+    /// `youtube_api`, `youtube_send_failed`) so the UI can render a
+    /// tailored message without parsing free-form text.
+    YouTube {
+        code: String,
+        message: String,
+    },
 }
 
 impl SendCommandError {
@@ -297,29 +305,39 @@ impl SendCommandError {
     }
 
     fn from_send_result(r: SendChatResult) -> Result<SendChatOk, Self> {
+        Self::from_send_result_with(r, |code, message| Self::Helix { code, message })
+    }
+
+    /// YouTube counterpart of [`from_send_result`]. Same envelope, but
+    /// failures land in [`SendCommandError::YouTube`] so the frontend
+    /// can format a YouTube-specific message instead of a Twitch one.
+    fn from_youtube_send_result(r: SendChatResult) -> Result<SendChatOk, Self> {
+        Self::from_send_result_with(r, |code, message| Self::YouTube { code, message })
+    }
+
+    fn from_send_result_with(
+        r: SendChatResult,
+        rejected: impl FnOnce(String, String) -> Self,
+    ) -> Result<SendChatOk, Self> {
         if r.ok {
             return Ok(SendChatOk {
                 message_id: r.message_id,
             });
         }
         if !r.drop_code.is_empty() || !r.drop_message.is_empty() {
-            return Err(Self::Helix {
-                code: r.drop_code,
-                message: if r.drop_message.is_empty() {
-                    "message rejected".to_string()
-                } else {
-                    r.drop_message
-                },
-            });
-        }
-        Err(Self::Helix {
-            code: String::new(),
-            message: if r.error_message.is_empty() {
-                "send failed".to_string()
+            let message = if r.drop_message.is_empty() {
+                "message rejected".to_string()
             } else {
-                r.error_message
-            },
-        })
+                r.drop_message
+            };
+            return Err(rejected(r.drop_code, message));
+        }
+        let message = if r.error_message.is_empty() {
+            "send failed".to_string()
+        } else {
+            r.error_message
+        };
+        Err(rejected(String::new(), message))
     }
 }
 
@@ -448,7 +466,7 @@ pub async fn youtube_send_message(
     })?;
 
     let result = rx.await.map_err(|_| SendCommandError::SidecarNotRunning)?;
-    SendCommandError::from_send_result(result)
+    SendCommandError::from_youtube_send_result(result)
 }
 
 #[cfg(test)]
@@ -567,6 +585,44 @@ mod tests {
                 assert_eq!(message, "401");
             }
             other => panic!("expected Helix, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_youtube_send_result_ok_returns_message_id() {
+        let ok = SendCommandError::from_youtube_send_result(make_result(true, "", "", ""))
+            .expect("ok result must succeed");
+        assert_eq!(ok.message_id, "abc");
+    }
+
+    #[test]
+    fn from_youtube_send_result_drop_maps_to_youtube_variant() {
+        match SendCommandError::from_youtube_send_result(make_result(
+            false,
+            "unauthorized",
+            "needs reauth",
+            "",
+        ))
+        .unwrap_err()
+        {
+            SendCommandError::YouTube { code, message } => {
+                assert_eq!(code, "unauthorized");
+                assert_eq!(message, "needs reauth");
+            }
+            other => panic!("expected YouTube, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_youtube_send_result_error_only_maps_to_youtube_variant() {
+        match SendCommandError::from_youtube_send_result(make_result(false, "", "", "transport"))
+            .unwrap_err()
+        {
+            SendCommandError::YouTube { code, message } => {
+                assert!(code.is_empty());
+                assert_eq!(message, "transport");
+            }
+            other => panic!("expected YouTube, got {other:?}"),
         }
     }
 

--- a/apps/desktop/src-tauri/src/sidecar_commands.rs
+++ b/apps/desktop/src-tauri/src/sidecar_commands.rs
@@ -25,8 +25,12 @@ use tokio::sync::oneshot;
 #[cfg(windows)]
 use tauri_plugin_shell::process::CommandChild;
 
-use crate::host::{build_send_chat_message_line, SendChatMessageArgs, SendChatResult};
+use crate::host::{
+    build_send_chat_message_line, build_youtube_send_message_line, SendChatMessageArgs,
+    SendChatResult, YouTubeSendMessageArgs,
+};
 use crate::twitch_auth::{AuthError, AuthState, TWITCH_CLIENT_ID};
+use crate::youtube_auth::{AuthError as YouTubeAuthError, AuthState as YouTubeAuthState};
 
 /// Pure registry of in-flight `send_chat_message` requests. Carved out
 /// of [`Inner`] so the id-allocation, completion-routing, and clear
@@ -235,6 +239,14 @@ pub enum SendCommandError {
     MessageTooLong {
         max_bytes: usize,
     },
+    /// Variant carried by [`youtube_send_message`] when the user's
+    /// text exceeds the YouTube character limit. Distinct from
+    /// [`SendCommandError::MessageTooLong`] because YouTube enforces a
+    /// Unicode-character cap, not a byte cap, and the frontend renders
+    /// a different message for each.
+    MessageTooLongChars {
+        max_chars: usize,
+    },
     SidecarNotRunning,
     Io {
         message: String,
@@ -260,6 +272,24 @@ impl SendCommandError {
             AuthError::NoTokens | AuthError::RefreshTokenInvalid => Self::NotLoggedIn {
                 message: err.to_string(),
             },
+            other => Self::Auth {
+                message: other.to_string(),
+            },
+        }
+    }
+
+    /// YouTube counterpart of [`SendCommandError::auth`]. The two
+    /// providers' `AuthError` enums share the same `NoTokens` /
+    /// `RefreshTokenInvalid` variants but are otherwise distinct types,
+    /// so a parallel mapper keeps the conversion table local to this
+    /// module instead of leaking a `From` impl into the auth crates.
+    fn youtube_auth(err: YouTubeAuthError) -> Self {
+        match err {
+            YouTubeAuthError::NoTokens | YouTubeAuthError::RefreshTokenInvalid => {
+                Self::NotLoggedIn {
+                    message: err.to_string(),
+                }
+            }
             other => Self::Auth {
                 message: other.to_string(),
             },
@@ -307,6 +337,11 @@ pub struct SendChatOk {
 /// payloads before they cross the IPC boundary.
 pub const MAX_CHAT_MESSAGE_BYTES: usize = 500;
 
+/// Maximum chat message length accepted by the YouTube Data API
+/// `liveChatMessages.insert` endpoint. Documented as 200 Unicode
+/// characters; we count `chars()` to match the API's enforcement.
+pub const MAX_YOUTUBE_MESSAGE_CHARS: usize = 200;
+
 /// Trims `text` and rejects empty or oversize messages with the
 /// matching frontend error variant. Extracted from the Tauri command
 /// body so the validation rules are unit-testable without a runtime.
@@ -318,6 +353,22 @@ fn validate_message(text: &str) -> Result<&str, SendCommandError> {
     if trimmed.len() > MAX_CHAT_MESSAGE_BYTES {
         return Err(SendCommandError::MessageTooLong {
             max_bytes: MAX_CHAT_MESSAGE_BYTES,
+        });
+    }
+    Ok(trimmed)
+}
+
+/// YouTube counterpart of [`validate_message`]. The Data API enforces a
+/// 200-Unicode-character cap (not bytes), so the comparison runs on
+/// `chars().count()` rather than `len()`.
+fn validate_youtube_message(text: &str) -> Result<&str, SendCommandError> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return Err(SendCommandError::EmptyMessage);
+    }
+    if trimmed.chars().count() > MAX_YOUTUBE_MESSAGE_CHARS {
+        return Err(SendCommandError::MessageTooLongChars {
+            max_chars: MAX_YOUTUBE_MESSAGE_CHARS,
         });
     }
     Ok(trimmed)
@@ -365,6 +416,41 @@ pub async fn twitch_send_message(
     SendCommandError::from_send_result(result)
 }
 
+/// Sends a chat message to the active YouTube live broadcast. Mirrors
+/// `twitch_send_message` shape so the frontend's optimistic-render path
+/// stays platform-symmetric: same `SendChatOk { message_id }` success,
+/// same [`SendCommandError`] variants on failure (with the YouTube-only
+/// [`SendCommandError::MessageTooLongChars`] when the user runs over
+/// the Data API's 200-character cap).
+#[tauri::command]
+pub async fn youtube_send_message(
+    auth: State<'_, YouTubeAuthState>,
+    sender: State<'_, SidecarCommandSender>,
+    live_chat_id: String,
+    text: String,
+) -> Result<SendChatOk, SendCommandError> {
+    let trimmed = validate_youtube_message(&text)?;
+
+    let tokens = auth
+        .manager
+        .load_or_refresh()
+        .await
+        .map_err(SendCommandError::youtube_auth)?;
+
+    let (tx, rx) = oneshot::channel();
+    sender.send_with_pending(tx, |request_id| {
+        build_youtube_send_message_line(YouTubeSendMessageArgs {
+            access_token: &tokens.access_token,
+            live_chat_id: &live_chat_id,
+            message: trimmed,
+            request_id,
+        })
+    })?;
+
+    let result = rx.await.map_err(|_| SendCommandError::SidecarNotRunning)?;
+    SendCommandError::from_send_result(result)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -385,6 +471,56 @@ mod tests {
     fn auth_mapping_other_is_auth() {
         let mapped = SendCommandError::auth(AuthError::OAuth("boom".into()));
         assert!(matches!(mapped, SendCommandError::Auth { .. }));
+    }
+
+    #[test]
+    fn youtube_auth_mapping_no_tokens_is_not_logged_in() {
+        let mapped = SendCommandError::youtube_auth(YouTubeAuthError::NoTokens);
+        assert!(matches!(mapped, SendCommandError::NotLoggedIn { .. }));
+    }
+
+    #[test]
+    fn youtube_auth_mapping_refresh_invalid_is_not_logged_in() {
+        let mapped = SendCommandError::youtube_auth(YouTubeAuthError::RefreshTokenInvalid);
+        assert!(matches!(mapped, SendCommandError::NotLoggedIn { .. }));
+    }
+
+    #[test]
+    fn youtube_auth_mapping_other_is_auth() {
+        let mapped = SendCommandError::youtube_auth(YouTubeAuthError::OAuth("boom".into()));
+        assert!(matches!(mapped, SendCommandError::Auth { .. }));
+    }
+
+    #[test]
+    fn validate_youtube_message_rejects_empty() {
+        assert!(matches!(
+            validate_youtube_message("   "),
+            Err(SendCommandError::EmptyMessage)
+        ));
+    }
+
+    #[test]
+    fn validate_youtube_message_rejects_over_200_chars() {
+        let too_long = "a".repeat(201);
+        match validate_youtube_message(&too_long) {
+            Err(SendCommandError::MessageTooLongChars { max_chars }) => {
+                assert_eq!(max_chars, MAX_YOUTUBE_MESSAGE_CHARS);
+            }
+            other => panic!("expected MessageTooLongChars, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_youtube_message_counts_chars_not_bytes() {
+        // 200 emoji ≈ 800 bytes — bytes-based limit would reject this,
+        // chars-based limit (matching Google's enforcement) accepts it.
+        let s = "🎉".repeat(200);
+        assert_eq!(validate_youtube_message(&s).unwrap(), s.as_str());
+    }
+
+    #[test]
+    fn validate_youtube_message_trims_surrounding_whitespace() {
+        assert_eq!(validate_youtube_message("  hi  ").unwrap(), "hi");
     }
 
     fn make_result(ok: bool, drop_code: &str, drop_message: &str, error: &str) -> SendChatResult {

--- a/apps/desktop/src/lib/messageInput.test.ts
+++ b/apps/desktop/src/lib/messageInput.test.ts
@@ -59,6 +59,36 @@ describe("formatSendError", () => {
     expect(
       formatSendError({ kind: "helix", code: "", message: "blocked" }),
     ).toContain("blocked");
+    expect(
+      formatSendError({
+        kind: "message_too_long_chars",
+        max_chars: 200,
+      }),
+    ).toContain("200");
+    expect(
+      formatSendError({
+        kind: "youtube",
+        code: "unauthorized",
+        message: "x",
+      }),
+    ).toMatch(/sign in/i);
+    expect(
+      formatSendError({
+        kind: "youtube",
+        code: "quota_exceeded",
+        message: "x",
+      }),
+    ).toMatch(/quota/i);
+    expect(
+      formatSendError({
+        kind: "youtube",
+        code: "youtube_api",
+        message: "chat ended",
+      }),
+    ).toContain("chat ended");
+    expect(
+      formatSendError({ kind: "youtube", code: "", message: "blocked" }),
+    ).toContain("blocked");
   });
 });
 
@@ -79,7 +109,9 @@ describe("toSendError", () => {
       { kind: "auth", message: "x" },
       { kind: "json", message: "x" },
       { kind: "message_too_long", max_bytes: 500 },
+      { kind: "message_too_long_chars", max_chars: 200 },
       { kind: "helix", code: "c", message: "m" },
+      { kind: "youtube", code: "c", message: "m" },
     ];
     for (const c of cases) {
       expect(toSendError(c)).toBe(c);

--- a/apps/desktop/src/lib/messageInput.ts
+++ b/apps/desktop/src/lib/messageInput.ts
@@ -30,6 +30,8 @@ export function formatSendError(err: SendMessageError): string {
       return "Message is empty.";
     case "message_too_long":
       return `Message exceeds ${err.max_bytes} bytes.`;
+    case "message_too_long_chars":
+      return `Message exceeds ${err.max_chars} characters.`;
     case "sidecar_not_running":
       return "Chat connection is not ready yet.";
     case "auth":
@@ -42,6 +44,17 @@ export function formatSendError(err: SendMessageError): string {
       return err.code
         ? `Twitch rejected message (${err.code}): ${err.message}`
         : `Twitch rejected message: ${err.message}`;
+    case "youtube":
+      switch (err.code) {
+        case "unauthorized":
+          return "YouTube session expired. Sign in again.";
+        case "quota_exceeded":
+          return "YouTube daily quota exceeded. Try again later.";
+        default:
+          return err.code
+            ? `YouTube rejected message (${err.code}): ${err.message}`
+            : `YouTube rejected message: ${err.message}`;
+      }
   }
 }
 
@@ -59,7 +72,9 @@ const VARIANT_GUARDS: Record<
   auth: (v) => typeof v.message === "string",
   json: (v) => typeof v.message === "string",
   message_too_long: (v) => typeof v.max_bytes === "number",
+  message_too_long_chars: (v) => typeof v.max_chars === "number",
   helix: (v) => typeof v.code === "string" && typeof v.message === "string",
+  youtube: (v) => typeof v.code === "string" && typeof v.message === "string",
 };
 
 // Strict guard for objects coming back from Tauri's invoke reject path.

--- a/apps/desktop/src/lib/twitchAuth.ts
+++ b/apps/desktop/src/lib/twitchAuth.ts
@@ -79,11 +79,13 @@ export type SendMessageError =
   | { kind: "not_logged_in"; message: string }
   | { kind: "empty_message" }
   | { kind: "message_too_long"; max_bytes: number }
+  | { kind: "message_too_long_chars"; max_chars: number }
   | { kind: "sidecar_not_running" }
   | { kind: "io"; message: string }
   | { kind: "auth"; message: string }
   | { kind: "json"; message: string }
-  | { kind: "helix"; code: string; message: string };
+  | { kind: "helix"; code: string; message: string }
+  | { kind: "youtube"; code: string; message: string };
 
 export const MAX_CHAT_MESSAGE_BYTES = 500;
 

--- a/apps/desktop/src/lib/youtubeAuth.ts
+++ b/apps/desktop/src/lib/youtubeAuth.ts
@@ -9,6 +9,8 @@
 import { invoke } from "@tauri-apps/api/core";
 import { openUrl } from "@tauri-apps/plugin-opener";
 
+import type { SendMessageOk } from "./twitchAuth";
+
 export type AuthStatusState = "logged_out" | "logged_in";
 
 export type AuthStatus =
@@ -54,6 +56,19 @@ export function cancelLogin(): Promise<void> {
 
 export function logout(): Promise<void> {
   return invoke("youtube_logout");
+}
+
+// Maximum chat message length accepted by the YouTube Data API
+// liveChatMessages.insert endpoint. Mirrors the Rust-side
+// MAX_YOUTUBE_MESSAGE_CHARS so the UI can soft-validate input before
+// the IPC roundtrip. The API counts Unicode characters, not bytes.
+export const MAX_YOUTUBE_MESSAGE_CHARS = 200;
+
+export function sendMessage(
+  liveChatId: string,
+  text: string,
+): Promise<SendMessageOk> {
+  return invoke("youtube_send_message", { liveChatId, text });
 }
 
 const ALLOWED_HOSTS = ["accounts.google.com"];


### PR DESCRIPTION
Adds the YouTube write path so users can post chat messages from Prismoid alongside Twitch.

- Go: new `youtube.APIClient.SendChatMessage` (POST /liveChat/messages) with 200-rune cap, `ErrUnauthorized`/`ErrQuotaExceeded` sentinels
- Sidecar: `youtube_send_message` dispatch + handler reusing the existing `send_chat_result` envelope (request_ids unique per host registry)
- Rust: `youtube_send_message` Tauri command with chars-based 200-char validation, new `MessageTooLongChars` error variant, YouTube auth-state mapping
- Tests on both sides; cargo clippy clean

Mod actions (delete / ban / unban / timeout) deferred to follow-up PRs.